### PR TITLE
Wave A: improve dashboard, approval workflow, and execution profiles

### DIFF
--- a/tests/test_wave_a_approval_v2.py
+++ b/tests/test_wave_a_approval_v2.py
@@ -1,0 +1,79 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.core.agent import VelocityClawAgent
+
+
+class ApprovalWorkflowV2Tests(unittest.IsolatedAsyncioTestCase):
+    async def test_run_enters_awaiting_approval_and_history_is_recorded(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        settings = Settings(workspace_root=workspace, memory_db_path=db_path, execution_profile="safe")
+        Path(workspace, "sample.py").write_text("value = 'old'\n")
+        agent = VelocityClawAgent(settings)
+
+        async def fake_plan(task, context=None):
+            return {
+                "task": task,
+                "steps": [
+                    {"id": 1, "title": "patch sample", "tool": "patch.apply", "args": {"patch": {"op": "replace_block", "path": "sample.py", "target": "old", "replacement": "new"}}, "expected_output": "patched"}
+                ],
+            }
+
+        agent.planner.create_plan = fake_plan
+        result = await agent.run_task("patch")
+        self.assertEqual(result["status"], "awaiting_approval")
+        history = agent.get_approval_history(result["run_id"])
+        self.assertTrue(history)
+        self.assertEqual(history[0]["decision"], "requested")
+
+    async def test_approve_step_resumes_saved_plan(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        settings = Settings(workspace_root=workspace, memory_db_path=db_path, execution_profile="safe")
+        Path(workspace, "sample.py").write_text("value = 'old'\n")
+        agent = VelocityClawAgent(settings)
+
+        async def fake_plan(task, context=None):
+            return {
+                "task": task,
+                "steps": [
+                    {"id": 1, "title": "patch sample", "tool": "patch.apply", "args": {"patch": {"op": "replace_block", "path": "sample.py", "target": "old", "replacement": "new"}}, "expected_output": "patched"},
+                    {"id": 2, "title": "read patched file", "tool": "fs.read", "args": {"path": "sample.py"}, "expected_output": "content"}
+                ],
+            }
+
+        agent.planner.create_plan = fake_plan
+        result = await agent.run_task("patch")
+        approve = agent.approve_step(result["run_id"], 1, actor="tester", reason="approved")
+        self.assertIn("resume", approve)
+        self.assertEqual(approve["resume"]["status"], "completed")
+        self.assertIn("new", Path(workspace, "sample.py").read_text())
+
+    async def test_reject_step_records_history(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        settings = Settings(workspace_root=workspace, memory_db_path=db_path, execution_profile="safe")
+        Path(workspace, "sample.py").write_text("value = 'old'\n")
+        agent = VelocityClawAgent(settings)
+
+        async def fake_plan(task, context=None):
+            return {
+                "task": task,
+                "steps": [
+                    {"id": 1, "title": "patch sample", "tool": "patch.apply", "args": {"patch": {"op": "replace_block", "path": "sample.py", "target": "old", "replacement": "new"}}, "expected_output": "patched"}
+                ],
+            }
+
+        agent.planner.create_plan = fake_plan
+        result = await agent.run_task("patch")
+        reject = agent.reject_step(result["run_id"], 1, actor="tester", reason="later")
+        self.assertEqual(reject["decision"], "rejected")
+        history = agent.get_approval_history(result["run_id"])
+        self.assertEqual(history[-1]["decision"], "rejected")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wave_a_dashboard_v2.py
+++ b/tests/test_wave_a_dashboard_v2.py
@@ -1,0 +1,20 @@
+import unittest
+
+from velocity_claw.api.server import create_app
+
+
+class DashboardV2Tests(unittest.TestCase):
+    def test_app_exposes_profile_manager(self):
+        app = create_app()
+        self.assertTrue(hasattr(app.state, "profiles"))
+
+    def test_active_profile_matrix_contains_capabilities(self):
+        app = create_app()
+        matrix = app.state.profiles.get_capability_matrix()
+        self.assertIn("capabilities", matrix)
+        self.assertIn("approval_workflow", matrix["capabilities"])
+        self.assertIn("patch_engine", matrix["capabilities"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wave_a_profiles_v2.py
+++ b/tests/test_wave_a_profiles_v2.py
@@ -1,0 +1,38 @@
+import unittest
+
+from velocity_claw.api.server import create_app
+from velocity_claw.config.settings import Settings
+from velocity_claw.security.access import ExecutionProfileManager
+
+
+class ExecutionProfilesV2Tests(unittest.TestCase):
+    def test_capability_matrix_has_expected_profiles(self):
+        settings = Settings(execution_profile="safe")
+        manager = ExecutionProfileManager(settings)
+        profiles = manager.list_profiles()
+        self.assertIn("safe", profiles)
+        self.assertIn("dev", profiles)
+        self.assertIn("owner", profiles)
+
+    def test_active_profile_matrix(self):
+        settings = Settings(execution_profile="dev")
+        manager = ExecutionProfileManager(settings)
+        matrix = manager.get_capability_matrix()
+        self.assertEqual(matrix["profile"], "dev")
+        self.assertTrue(matrix["capabilities"]["patch_engine"])
+        self.assertTrue(matrix["capabilities"]["shell"])
+
+    def test_explain_tool_access(self):
+        settings = Settings(execution_profile="safe")
+        manager = ExecutionProfileManager(settings)
+        info = manager.explain_tool_access("patch.apply")
+        self.assertEqual(info["profile"], "safe")
+        self.assertFalse(info["allowed"])
+
+    def test_api_has_profile_manager(self):
+        app = create_app()
+        self.assertTrue(hasattr(app.state, "profiles"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/velocity_claw/api/server.py
+++ b/velocity_claw/api/server.py
@@ -66,6 +66,11 @@ class ModeRequest(BaseModel):
     context: Optional[Dict[str, Any]] = None
 
 
+class ApprovalDecisionRequest(BaseModel):
+    actor: str = "owner"
+    reason: Optional[str] = None
+
+
 def create_app() -> FastAPI:
     settings = load_settings()
     app = FastAPI(title="Velocity Claw API")
@@ -163,17 +168,21 @@ def create_app() -> FastAPI:
             raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Run not found"})
         return data
 
+    @app.get("/runs/{run_id}/approval-history")
+    def approval_history(run_id: str):
+        return {"run_id": run_id, "history": app.state.agent.get_approval_history(run_id)}
+
     @app.get("/approvals")
     def approvals():
         return {"pending": app.state.agent.list_pending_approvals()}
 
     @app.post("/approvals/{run_id}/{step_id}/approve")
-    def approve(run_id: str, step_id: int):
-        return app.state.agent.approve_step(run_id, step_id)
+    def approve(run_id: str, step_id: int, request: ApprovalDecisionRequest):
+        return app.state.agent.approve_step(run_id, step_id, actor=request.actor, reason=request.reason)
 
     @app.post("/approvals/{run_id}/{step_id}/reject")
-    def reject(run_id: str, step_id: int):
-        return app.state.agent.reject_step(run_id, step_id)
+    def reject(run_id: str, step_id: int, request: ApprovalDecisionRequest):
+        return app.state.agent.reject_step(run_id, step_id, actor=request.actor, reason=request.reason)
 
     @app.get("/dashboard", response_class=HTMLResponse)
     def dashboard():
@@ -187,7 +196,8 @@ def create_app() -> FastAPI:
         body.append("</ul>")
         body.append("<h2>Pending approvals</h2><ul>")
         for item in approvals:
-            body.append(f"<li>{item['run_id']} / step {item['step_id']} — {item['title']} ({item['tool']})</li>")
+            reason = (item.get("result") or {}).get("reason") if isinstance(item.get("result"), dict) else None
+            body.append(f"<li>{item['run_id']} / step {item['step_id']} — {item['title']} ({item['tool']}) — reason: {reason or 'n/a'}</li>")
         body.append("</ul>")
         body.append("</body></html>")
         return "".join(body)

--- a/velocity_claw/api/server.py
+++ b/velocity_claw/api/server.py
@@ -203,17 +203,45 @@ def create_app() -> FastAPI:
     def dashboard():
         recent = app.state.agent.memory.list_recent_runs(limit=10)
         approvals = app.state.agent.list_pending_approvals()
-        body = ["<html><body><h1>Velocity Claw Dashboard</h1>"]
-        body.append(f"<p>Execution profile: <b>{app.state.settings.execution_profile}</b></p>")
-        body.append("<h2>Recent runs</h2><ul>")
+        profile = app.state.profiles.get_capability_matrix()
+
+        def badge(status: str) -> str:
+            return f"<span style='padding:2px 8px;border-radius:999px;border:1px solid #999'>{status}</span>"
+
+        body = [
+            "<html><body style='font-family:Arial,sans-serif;max-width:1100px;margin:24px auto;padding:0 16px'>",
+            "<h1>Velocity Claw Dashboard</h1>",
+            f"<p>Execution profile: <b>{app.state.settings.execution_profile}</b></p>",
+            "<h2>Active profile matrix</h2>",
+            f"<p>{profile['description']}</p>",
+            "<ul>",
+        ]
+        for key, value in profile["capabilities"].items():
+            body.append(f"<li>{key}: <b>{value}</b></li>")
+        body.append("</ul>")
+
+        body.append("<h2>Recent runs</h2>")
+        body.append("<table border='1' cellpadding='6' cellspacing='0' style='border-collapse:collapse;width:100%'>")
+        body.append("<tr><th>Run ID</th><th>Task</th><th>Status</th><th>Created</th></tr>")
         for run in recent:
-            body.append(f"<li>{run['run_id']} — {run['task']} — <b>{run['status']}</b></li>")
-        body.append("</ul>")
-        body.append("<h2>Pending approvals</h2><ul>")
-        for item in approvals:
-            reason = (item.get("result") or {}).get("reason") if isinstance(item.get("result"), dict) else None
-            body.append(f"<li>{item['run_id']} / step {item['step_id']} — {item['title']} ({item['tool']}) — reason: {reason or 'n/a'}</li>")
-        body.append("</ul>")
+            body.append(
+                f"<tr><td><code>{run['run_id']}</code></td><td>{run['task']}</td><td>{badge(run['status'])}</td><td>{run['created_at']}</td></tr>"
+            )
+        body.append("</table>")
+
+        body.append("<h2>Pending approvals</h2>")
+        if approvals:
+            body.append("<table border='1' cellpadding='6' cellspacing='0' style='border-collapse:collapse;width:100%'>")
+            body.append("<tr><th>Run ID</th><th>Step</th><th>Tool</th><th>Reason</th></tr>")
+            for item in approvals:
+                reason = (item.get("result") or {}).get("reason") if isinstance(item.get("result"), dict) else None
+                body.append(
+                    f"<tr><td><code>{item['run_id']}</code></td><td>{item['title']}</td><td>{item['tool']}</td><td>{reason or 'n/a'}</td></tr>"
+                )
+            body.append("</table>")
+        else:
+            body.append("<p>No pending approvals.</p>")
+
         body.append("</body></html>")
         return "".join(body)
 

--- a/velocity_claw/api/server.py
+++ b/velocity_claw/api/server.py
@@ -9,6 +9,7 @@ from velocity_claw.core.queue import RunQueue
 from velocity_claw.core.metrics import MetricsRegistry
 from velocity_claw.logs.logger import get_logger
 from velocity_claw.security.policy import SecurityViolationError
+from velocity_claw.security.access import ExecutionProfileManager
 
 
 class TaskRequest(BaseModel):
@@ -79,6 +80,7 @@ def create_app() -> FastAPI:
     app.state.agent = VelocityClawAgent(settings=settings)
     app.state.queue = RunQueue()
     app.state.metrics = MetricsRegistry()
+    app.state.profiles = ExecutionProfileManager(settings)
 
     @app.get("/health")
     def health():
@@ -119,6 +121,19 @@ def create_app() -> FastAPI:
     @app.get("/modes")
     def modes():
         return {"modes": app.state.agent.get_status()["available_modes"]}
+
+    @app.get("/profiles")
+    def profiles():
+        return {"active": app.state.settings.execution_profile, "profiles": app.state.profiles.list_profiles()}
+
+    @app.get("/profiles/active")
+    def active_profile():
+        return app.state.profiles.get_capability_matrix()
+
+    @app.get("/profiles/explain/{tool_name}")
+    def explain_profile_tool(tool_name: str):
+        tool = tool_name.replace("__", ".")
+        return app.state.profiles.explain_tool_access(tool)
 
     @app.post("/queue/submit")
     async def queue_submit(request: TaskRequest):

--- a/velocity_claw/api/server.py
+++ b/velocity_claw/api/server.py
@@ -204,6 +204,8 @@ def create_app() -> FastAPI:
         recent = app.state.agent.memory.list_recent_runs(limit=10)
         approvals = app.state.agent.list_pending_approvals()
         profile = app.state.profiles.get_capability_matrix()
+        metrics_snapshot = app.state.metrics.snapshot()
+        last_failed = app.state.agent.resume_last_failed_run()
 
         def badge(status: str) -> str:
             return f"<span style='padding:2px 8px;border-radius:999px;border:1px solid #999'>{status}</span>"
@@ -212,10 +214,17 @@ def create_app() -> FastAPI:
             "<html><body style='font-family:Arial,sans-serif;max-width:1100px;margin:24px auto;padding:0 16px'>",
             "<h1>Velocity Claw Dashboard</h1>",
             f"<p>Execution profile: <b>{app.state.settings.execution_profile}</b></p>",
-            "<h2>Active profile matrix</h2>",
-            f"<p>{profile['description']}</p>",
+            "<p>Quick links: <a href='/status'>/status</a> | <a href='/metrics'>/metrics</a> | <a href='/runs'>/runs</a> | <a href='/approvals'>/approvals</a> | <a href='/profiles'>/profiles</a></p>",
+            "<h2>Metrics</h2>",
             "<ul>",
         ]
+        for key, value in metrics_snapshot.items():
+            body.append(f"<li>{key}: <b>{value}</b></li>")
+        body.append("</ul>")
+
+        body.append("<h2>Active profile matrix</h2>")
+        body.append(f"<p>{profile['description']}</p>")
+        body.append("<ul>")
         for key, value in profile["capabilities"].items():
             body.append(f"<li>{key}: <b>{value}</b></li>")
         body.append("</ul>")
@@ -228,6 +237,12 @@ def create_app() -> FastAPI:
                 f"<tr><td><code>{run['run_id']}</code></td><td>{run['task']}</td><td>{badge(run['status'])}</td><td>{run['created_at']}</td></tr>"
             )
         body.append("</table>")
+
+        body.append("<h2>Last failed run</h2>")
+        if last_failed:
+            body.append(f"<p><code>{last_failed['run_id']}</code> — {last_failed['task']} — {badge(last_failed['status'])}</p>")
+        else:
+            body.append("<p>No failed runs recorded.</p>")
 
         body.append("<h2>Pending approvals</h2>")
         if approvals:

--- a/velocity_claw/core/agent.py
+++ b/velocity_claw/core/agent.py
@@ -1,3 +1,5 @@
+import asyncio
+import json
 from datetime import datetime
 from typing import Dict, Optional
 from velocity_claw.config.settings import Settings
@@ -44,6 +46,7 @@ class VelocityClawAgent:
         try:
             self.logger.info("Run %s: Planning", run_id)
             plan = await self.planner.create_plan(task, context)
+            self.memory.save_artifact(run_id, "run_plan", json.dumps(plan, ensure_ascii=False), artifact_type="plan")
             results = []
             for step in plan["steps"]:
                 step_id = step["id"]
@@ -68,7 +71,15 @@ class VelocityClawAgent:
                     self.memory.save_step(run_id, step_result)
                     self.memory.save_artifact(run_id, f"approval_step_{step_id}", str(approval), step_id=step_id, artifact_type="approval")
                     self.memory.save_approval_decision(run_id, step_id, "requested", actor=None, reason=approval.get("reason"), payload=approval)
-                    break
+                    self.memory.update_run_status(run_id, "awaiting_approval")
+                    return {
+                        "run_id": run_id,
+                        "task": task,
+                        "status": "awaiting_approval",
+                        "summary": f"Run paused at step {step_id} awaiting approval.",
+                        "steps": results,
+                        "signature": "velocity claw",
+                    }
 
                 if not self.profile_manager.is_tool_allowed(step.get("tool", ""), profile_name):
                     completed_at = datetime.now().isoformat()
@@ -170,11 +181,12 @@ class VelocityClawAgent:
             "actor": actor,
             "reason": reason,
             "decided_at": datetime.now().isoformat(),
-            "resume_status": "manual_resume_required",
         }
         self.memory.update_step_status(run_id, step_id, "approved", result=payload)
         self.memory.save_approval_decision(run_id, step_id, "approved", actor=actor, reason=reason, payload=payload)
         self.memory.save_artifact(run_id, f"approval_decision_step_{step_id}", str(payload), step_id=step_id, artifact_type="approval")
+        resume = self.resume_after_approval(run_id, step_id)
+        payload["resume"] = resume
         return payload
 
     def reject_step(self, run_id: str, step_id: int, actor: str = "owner", reason: str | None = None) -> dict:
@@ -187,7 +199,37 @@ class VelocityClawAgent:
         self.memory.update_step_status(run_id, step_id, "rejected", result=payload, error="Rejected by reviewer")
         self.memory.save_approval_decision(run_id, step_id, "rejected", actor=actor, reason=reason, payload=payload)
         self.memory.save_artifact(run_id, f"approval_decision_step_{step_id}", str(payload), step_id=step_id, artifact_type="approval")
+        self.memory.update_run_status(run_id, "rejected")
         return payload
+
+    def resume_after_approval(self, run_id: str, step_id: int) -> dict:
+        run = self.memory.load_run(run_id)
+        if not run:
+            return {"status": "failed", "error": "run_not_found"}
+        artifacts = run.get("artifacts", [])
+        plan_artifact = next((a for a in artifacts if a.get("name") == "run_plan"), None)
+        if not plan_artifact:
+            self.memory.update_run_status(run_id, "approved_waiting_manual_resume")
+            return {"status": "manual_resume_required", "reason": "run_plan_missing"}
+        try:
+            plan = json.loads(plan_artifact["content"])
+        except Exception:
+            self.memory.update_run_status(run_id, "approved_waiting_manual_resume")
+            return {"status": "manual_resume_required", "reason": "run_plan_invalid"}
+        pending_steps = [s for s in plan.get("steps", []) if s.get("id", 0) >= step_id]
+        executed = []
+        for step in pending_steps:
+            result = asyncio.run(self.executor.execute_step(step, {}))
+            result["started_at"] = result.get("started_at") or datetime.now().isoformat()
+            result["completed_at"] = datetime.now().isoformat()
+            self.memory.save_step(run_id, result)
+            self._persist_artifacts(run_id, result)
+            executed.append(result)
+            if result.get("status") == "failed":
+                self.memory.update_run_status(run_id, "failed")
+                return {"status": "failed", "executed": executed}
+        self.memory.update_run_status(run_id, "completed")
+        return {"status": "completed", "executed": executed}
 
     def get_status(self) -> Dict:
         return {

--- a/velocity_claw/core/agent.py
+++ b/velocity_claw/core/agent.py
@@ -67,6 +67,7 @@ class VelocityClawAgent:
                     results.append(step_result)
                     self.memory.save_step(run_id, step_result)
                     self.memory.save_artifact(run_id, f"approval_step_{step_id}", str(approval), step_id=step_id, artifact_type="approval")
+                    self.memory.save_approval_decision(run_id, step_id, "requested", actor=None, reason=approval.get("reason"), payload=approval)
                     break
 
                 if not self.profile_manager.is_tool_allowed(step.get("tool", ""), profile_name):
@@ -160,14 +161,32 @@ class VelocityClawAgent:
     def list_pending_approvals(self):
         return self.memory.list_pending_approvals()
 
-    def approve_step(self, run_id: str, step_id: int, actor: str = "owner") -> dict:
-        payload = {"decision": "approved", "actor": actor, "decided_at": datetime.now().isoformat()}
+    def get_approval_history(self, run_id: str):
+        return self.memory.load_approval_history(run_id)
+
+    def approve_step(self, run_id: str, step_id: int, actor: str = "owner", reason: str | None = None) -> dict:
+        payload = {
+            "decision": "approved",
+            "actor": actor,
+            "reason": reason,
+            "decided_at": datetime.now().isoformat(),
+            "resume_status": "manual_resume_required",
+        }
         self.memory.update_step_status(run_id, step_id, "approved", result=payload)
+        self.memory.save_approval_decision(run_id, step_id, "approved", actor=actor, reason=reason, payload=payload)
+        self.memory.save_artifact(run_id, f"approval_decision_step_{step_id}", str(payload), step_id=step_id, artifact_type="approval")
         return payload
 
-    def reject_step(self, run_id: str, step_id: int, actor: str = "owner") -> dict:
-        payload = {"decision": "rejected", "actor": actor, "decided_at": datetime.now().isoformat()}
+    def reject_step(self, run_id: str, step_id: int, actor: str = "owner", reason: str | None = None) -> dict:
+        payload = {
+            "decision": "rejected",
+            "actor": actor,
+            "reason": reason,
+            "decided_at": datetime.now().isoformat(),
+        }
         self.memory.update_step_status(run_id, step_id, "rejected", result=payload, error="Rejected by reviewer")
+        self.memory.save_approval_decision(run_id, step_id, "rejected", actor=actor, reason=reason, payload=payload)
+        self.memory.save_artifact(run_id, f"approval_decision_step_{step_id}", str(payload), step_id=step_id, artifact_type="approval")
         return payload
 
     def get_status(self) -> Dict:

--- a/velocity_claw/memory/store.py
+++ b/velocity_claw/memory/store.py
@@ -80,6 +80,19 @@ class MemoryStore:
                     FOREIGN KEY (run_id) REFERENCES runs (run_id)
                 )
             """)
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS approval_history (
+                    id INTEGER PRIMARY KEY,
+                    run_id TEXT NOT NULL,
+                    step_id INTEGER NOT NULL,
+                    decision TEXT NOT NULL,
+                    actor TEXT,
+                    reason TEXT,
+                    payload TEXT,
+                    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (run_id) REFERENCES runs (run_id)
+                )
+            """)
 
     def create_run(self, task: str) -> str:
         if not self.enabled:
@@ -137,6 +150,7 @@ class MemoryStore:
                 "steps": self.load_steps(run_id),
                 "artifacts": self.load_artifacts(run_id),
                 "fix_attempts": self.load_fix_attempts(run_id),
+                "approval_history": self.load_approval_history(run_id),
             }
 
     def load_steps(self, run_id: str):
@@ -241,6 +255,36 @@ class MemoryStore:
             for r in rows
         ]
 
+    def save_approval_decision(self, run_id: str, step_id: int, decision: str, actor: str | None = None, reason: str | None = None, payload: Any = None) -> None:
+        if not self.enabled:
+            return
+        encoded = json.dumps(payload, ensure_ascii=False) if payload is not None else None
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "INSERT INTO approval_history (run_id, step_id, decision, actor, reason, payload) VALUES (?, ?, ?, ?, ?, ?)",
+                (run_id, step_id, decision, actor, reason, encoded),
+            )
+
+    def load_approval_history(self, run_id: str):
+        if not self.enabled:
+            return []
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute(
+                "SELECT step_id, decision, actor, reason, payload, created_at FROM approval_history WHERE run_id = ? ORDER BY id",
+                (run_id,),
+            ).fetchall()
+        return [
+            {
+                "step_id": r[0],
+                "decision": r[1],
+                "actor": r[2],
+                "reason": r[3],
+                "payload": json.loads(r[4]) if r[4] else None,
+                "created_at": r[5],
+            }
+            for r in rows
+        ]
+
     def get_last_failed_run(self) -> Optional[Dict]:
         if not self.enabled:
             return None
@@ -261,6 +305,7 @@ class MemoryStore:
             """)
             conn.execute("DELETE FROM steps WHERE run_id NOT IN (SELECT run_id FROM runs)")
             conn.execute("DELETE FROM artifacts WHERE run_id NOT IN (SELECT run_id FROM runs)")
+            conn.execute("DELETE FROM approval_history WHERE run_id NOT IN (SELECT run_id FROM runs)")
 
     def list_recent_runs(self, limit: int = 20):
         if not self.enabled:

--- a/velocity_claw/security/access.py
+++ b/velocity_claw/security/access.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Optional
 
 from velocity_claw.config.settings import Settings
@@ -26,20 +26,70 @@ class ExecutionProfile:
     git_write: bool
     network: bool
     approval_workflow: bool
+    description: str
 
 
 class ExecutionProfileManager:
     def __init__(self, settings: Settings):
         self.settings = settings
         self._profiles = {
-            "safe": ExecutionProfile("safe", filesystem_write=False, patch_engine=False, test_runner=True, shell=False, git_write=False, network=False, approval_workflow=True),
-            "dev": ExecutionProfile("dev", filesystem_write=True, patch_engine=True, test_runner=True, shell=True, git_write=False, network=False, approval_workflow=True),
-            "owner": ExecutionProfile("owner", filesystem_write=True, patch_engine=True, test_runner=True, shell=True, git_write=True, network=True, approval_workflow=True),
+            "safe": ExecutionProfile(
+                "safe",
+                filesystem_write=False,
+                patch_engine=False,
+                test_runner=True,
+                shell=False,
+                git_write=False,
+                network=False,
+                approval_workflow=True,
+                description="Restrictive profile for safe inspection and tightly controlled actions.",
+            ),
+            "dev": ExecutionProfile(
+                "dev",
+                filesystem_write=True,
+                patch_engine=True,
+                test_runner=True,
+                shell=True,
+                git_write=False,
+                network=False,
+                approval_workflow=True,
+                description="Development-focused profile with editing, testing, and limited shell workflows.",
+            ),
+            "owner": ExecutionProfile(
+                "owner",
+                filesystem_write=True,
+                patch_engine=True,
+                test_runner=True,
+                shell=True,
+                git_write=True,
+                network=True,
+                approval_workflow=True,
+                description="Expanded trusted profile with broader tool access and auditability.",
+            ),
         }
 
     def get_profile(self, name: Optional[str] = None) -> ExecutionProfile:
         key = name or self.settings.execution_profile
         return self._profiles.get(key, self._profiles["safe"])
+
+    def list_profiles(self) -> dict:
+        return {name: asdict(profile) for name, profile in self._profiles.items()}
+
+    def get_capability_matrix(self, profile_name: Optional[str] = None) -> dict:
+        profile = self.get_profile(profile_name)
+        return {
+            "profile": profile.name,
+            "description": profile.description,
+            "capabilities": {
+                "filesystem_write": profile.filesystem_write,
+                "patch_engine": profile.patch_engine,
+                "test_runner": profile.test_runner,
+                "shell": profile.shell,
+                "git_write": profile.git_write,
+                "network": profile.network,
+                "approval_workflow": profile.approval_workflow,
+            },
+        }
 
     def is_tool_allowed(self, tool: str, profile_name: Optional[str] = None) -> bool:
         profile = self.get_profile(profile_name)
@@ -56,6 +106,16 @@ class ExecutionProfileManager:
         if tool in {"http.get", "http.post"}:
             return profile.network
         return True
+
+    def explain_tool_access(self, tool: str, profile_name: Optional[str] = None) -> dict:
+        profile = self.get_profile(profile_name)
+        allowed = self.is_tool_allowed(tool, profile.name)
+        return {
+            "profile": profile.name,
+            "tool": tool,
+            "allowed": allowed,
+            "description": profile.description,
+        }
 
 
 class ApprovalManager:


### PR DESCRIPTION
## Summary
This PR starts Wave A after the advanced dev-agent MVP foundation merge.

## What is included
- approval workflow v2 foundations:
  - approval history persistence
  - richer approve/reject payloads
  - awaiting_approval run state
  - resume-after-approve foundation
- execution profiles v2 foundations:
  - clearer capability matrix
  - profile descriptions
  - API exposure for active profile and tool access explanation
- dashboard v2 foundations:
  - richer dashboard layout
  - active profile matrix section
  - recent runs table
  - pending approvals table
- new Wave A tests for approvals, profiles, and dashboard

## Related issues
- #18 Wave A: Dashboard v2
- #19 Wave A: Approval workflow v2
- #20 Wave A: Execution profiles v2

## Notes
This is still an iterative Wave A pass, not the final polished version of these systems. The goal of this PR is to turn the current foundations into more operational behavior and visibility.
