### PR TITLE
Wave B: improve auto-fix loop, test runner, and symbol navigation

### DIFF
--- a/tests/test_wave_b_auto_fix_v2.py
+++ b/tests/test_wave_b_auto_fix_v2.py
@@ -1,0 +1,60 @@
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.core.auto_fix import AutoFixLoop
+from velocity_claw.tools.code_nav import CodeNavigationTool
+from velocity_claw.tools.patch import PatchEngine
+from velocity_claw.tools.test_runner import TestRunnerTool
+
+
+class AutoFixLoopV2Tests(unittest.TestCase):
+    def setUp(self):
+        self.workspace = tempfile.mkdtemp()
+        self.settings = Settings(workspace_root=self.workspace)
+        Path(self.workspace, "sample.py").write_text("value = 'old'\n")
+        Path(self.workspace, "test_sample.py").write_text(textwrap.dedent(
+            """
+            from sample import value
+
+            def test_value():
+                assert value == 'new'
+            """
+        ))
+        self.loop = AutoFixLoop(PatchEngine(self.settings), TestRunnerTool(self.settings), CodeNavigationTool(self.settings))
+
+    def test_completed_run_has_repair_summary(self):
+        result = self.loop.run(
+            target_test="test_sample.py",
+            patch_plan=[{"op": "replace_block", "path": "sample.py", "target": "old", "replacement": "new"}],
+            max_attempts=1,
+        )
+        self.assertEqual(result["status"], "completed")
+        self.assertIn("repair_summary", result["attempts"][0])
+
+    def test_repeated_patch_signature_stops(self):
+        result = self.loop.run(
+            target_test="test_sample.py",
+            patch_plan=[
+                {"op": "replace_block", "path": "sample.py", "target": "old", "replacement": "new"},
+                {"op": "replace_block", "path": "sample.py", "target": "old", "replacement": "new"},
+            ],
+            max_attempts=2,
+            dry_run=True,
+        )
+        self.assertEqual(result["attempts"][-1]["stop_reason"], "repeated_patch_signature")
+
+    def test_failure_signature_present_on_failed_attempt(self):
+        result = self.loop.run(
+            target_test="test_sample.py",
+            patch_plan=[{"op": "append", "path": "sample.py", "content": "\nother = 1\n"}],
+            max_attempts=1,
+        )
+        self.assertEqual(result["status"], "failed")
+        self.assertTrue(result["attempts"][0]["failure_signature"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wave_b_symbol_nav_v2.py
+++ b/tests/test_wave_b_symbol_nav_v2.py
@@ -1,0 +1,52 @@
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.tools.code_nav import CodeNavigationTool
+
+
+class SymbolNavigationV2Tests(unittest.TestCase):
+    def setUp(self):
+        self.workspace = tempfile.mkdtemp()
+        self.settings = Settings(workspace_root=self.workspace)
+        self.nav = CodeNavigationTool(self.settings)
+        Path(self.workspace, "a.py").write_text(textwrap.dedent(
+            """
+            class Demo:
+                """demo class"""
+                pass
+
+            def hello():
+                """hello doc"""
+                value = 1
+                return value
+            """
+        ))
+        Path(self.workspace, "b.py").write_text(textwrap.dedent(
+            """
+            def hello():
+                return 2
+            """
+        ))
+
+    def test_find_symbol_has_metadata(self):
+        matches = self.nav.find_symbol("hello", "function")
+        self.assertTrue(matches)
+        self.assertIn("docstring", matches[0])
+        self.assertIn("match_score", matches[0])
+
+    def test_find_references(self):
+        refs = self.nav.find_references("value")
+        self.assertTrue(refs)
+        self.assertEqual(refs[0]["context"], "reference")
+
+    def test_explain_ambiguity(self):
+        info = self.nav.explain_ambiguity("hello", "function")
+        self.assertTrue(info["ambiguous"])
+        self.assertEqual(info["count"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wave_b_test_runner_v2.py
+++ b/tests/test_wave_b_test_runner_v2.py
@@ -1,0 +1,53 @@
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.tools.test_runner import TestRunnerTool
+
+
+class TestRunnerV2Tests(unittest.TestCase):
+    def setUp(self):
+        self.workspace = tempfile.mkdtemp()
+        self.settings = Settings(workspace_root=self.workspace)
+        self.runner = TestRunnerTool(self.settings)
+        Path(self.workspace, "test_sample.py").write_text(textwrap.dedent(
+            """
+            import pytest
+
+            @pytest.mark.fast
+            def test_ok():
+                assert 1 == 1
+
+            def test_bad():
+                assert 1 == 2
+            """
+        ))
+
+    def test_extract_summary_has_collected(self):
+        result = self.runner.run("pytest", target="test_sample.py", timeout=30)
+        self.assertIn("collected", result["summary"])
+        self.assertGreaterEqual(result["summary"]["collected"], 1)
+
+    def test_dry_run_keeps_new_fields(self):
+        result = self.runner.run("pytest", target="test_sample.py", dry_run=True, keyword="ok", marker="fast")
+        self.assertEqual(result["status"], "simulated")
+        self.assertEqual(result["keyword"], "ok")
+        self.assertEqual(result["marker"], "fast")
+
+    def test_keyword_and_marker_are_reflected_in_command(self):
+        result = self.runner.run("pytest", target="test_sample.py", dry_run=True, keyword="ok", marker="fast")
+        self.assertIn("-k", result["command"])
+        self.assertIn("ok", result["command"])
+        self.assertIn("-m", result["command"])
+        self.assertIn("fast", result["command"])
+
+    def test_parse_failures_has_nodeid(self):
+        result = self.runner.run("pytest", target="test_sample.py", timeout=30)
+        self.assertTrue(result["parsed_failures"])
+        self.assertIn("nodeid", result["parsed_failures"][0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/velocity_claw/core/auto_fix.py
+++ b/velocity_claw/core/auto_fix.py
@@ -16,6 +16,9 @@ class AutoFixAttempt:
     patches: List[dict] = field(default_factory=list)
     test_result: Optional[dict] = None
     status: str = "pending"
+    stop_reason: Optional[str] = None
+    failure_signature: Optional[str] = None
+    repair_summary: Optional[dict] = None
 
 
 class AutoFixLoop:
@@ -26,18 +29,34 @@ class AutoFixLoop:
 
     def run(self, *, target_test: str, patch_plan: List[dict], runner: str = "pytest", max_attempts: int = 2, dry_run: bool = False) -> dict:
         attempts: List[dict] = []
-        previous_signatures = set()
+        previous_patch_signatures = set()
+        previous_failure_signatures = set()
         for idx, patch in enumerate(patch_plan[:max_attempts], start=1):
             attempt = AutoFixAttempt(attempt=idx, reason="test failure", patches=[patch], status="running")
+            attempt.target_symbols = self._extract_target_symbols(patch)
             patch_result = self.patch_engine.apply(patch, dry_run=dry_run)
-            signature = patch_result.get("diff", "")
-            if signature in previous_signatures:
-                attempt.status = "stopped_repeated_failure"
+            patch_signature = patch_result.get("diff", "")
+            if patch_signature in previous_patch_signatures:
+                attempt.status = "stopped"
+                attempt.stop_reason = "repeated_patch_signature"
                 attempts.append(attempt.__dict__)
                 break
-            previous_signatures.add(signature)
+            previous_patch_signatures.add(patch_signature)
+
             test_result = self.test_runner.run(runner, target=target_test, dry_run=dry_run)
             attempt.test_result = test_result
+            failure_signature = self._build_failure_signature(test_result)
+            attempt.failure_signature = failure_signature
+            attempt.repair_summary = self._build_repair_summary(attempt.target_symbols, test_result)
+
+            if failure_signature and failure_signature in previous_failure_signatures:
+                attempt.status = "stopped"
+                attempt.stop_reason = "repeated_failure_signature"
+                attempts.append(attempt.__dict__)
+                break
+            if failure_signature:
+                previous_failure_signatures.add(failure_signature)
+
             attempt.status = "passed" if test_result["status"] in {"passed", "simulated"} else "failed"
             attempts.append(attempt.__dict__)
             if test_result["status"] in {"passed", "simulated"}:
@@ -53,3 +72,50 @@ class AutoFixLoop:
             "attempts": attempts,
             "status": "failed",
         }
+
+    def _extract_target_symbols(self, patch: dict) -> List[str]:
+        symbols = []
+        if patch.get("name"):
+            symbols.append(patch["name"])
+        for key in ("target", "replacement"):
+            value = patch.get(key)
+            if isinstance(value, str) and value.isidentifier():
+                symbols.append(value)
+        return symbols
+
+    def _build_failure_signature(self, test_result: dict) -> Optional[str]:
+        failures = test_result.get("parsed_failures") or []
+        if not failures:
+            return None
+        parts = []
+        for failure in failures:
+            parts.append(
+                "|".join(
+                    [
+                        failure.get("nodeid") or failure.get("failed_test_name") or "?",
+                        str(failure.get("file") or "?"),
+                        str(failure.get("line") or "?"),
+                        str(failure.get("assertion") or "?"),
+                    ]
+                )
+            )
+        return "::".join(parts)
+
+    def _build_repair_summary(self, target_symbols: List[str], test_result: dict) -> dict:
+        summary = {
+            "target_symbols": target_symbols,
+            "symbol_matches": {},
+            "failed_tests": [],
+        }
+        for symbol in target_symbols:
+            summary["symbol_matches"][symbol] = self.code_nav.explain_ambiguity(symbol)
+        for failure in test_result.get("parsed_failures") or []:
+            summary["failed_tests"].append(
+                {
+                    "nodeid": failure.get("nodeid") or failure.get("failed_test_name"),
+                    "file": failure.get("file"),
+                    "line": failure.get("line"),
+                    "assertion": failure.get("assertion"),
+                }
+            )
+        return summary

--- a/velocity_claw/tools/code_nav.py
+++ b/velocity_claw/tools/code_nav.py
@@ -24,26 +24,12 @@ class CodeNavigationTool:
             except Exception:
                 continue
             for node in ast.walk(tree):
-                entry = None
-                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
-                    entry = {
-                        "path": rel,
-                        "kind": "function",
-                        "name": node.name,
-                        "line_start": node.lineno,
-                        "line_end": node.end_lineno,
-                    }
-                elif isinstance(node, ast.ClassDef) and node.name == name:
-                    entry = {
-                        "path": rel,
-                        "kind": "class",
-                        "name": node.name,
-                        "line_start": node.lineno,
-                        "line_end": node.end_lineno,
-                    }
-                if entry and (kind is None or entry["kind"] == kind):
+                entry = self._build_entry(node, rel, source)
+                if not entry:
+                    continue
+                if entry["name"] == name and (kind is None or entry["kind"] == kind):
                     matches.append(entry)
-        return sorted(matches, key=lambda m: (m["path"], m["line_start"]))
+        return sorted(matches, key=lambda m: (-m["match_score"], m["path"], m["line_start"]))
 
     def read_symbol(self, path: str, name: str, kind: str) -> dict:
         source = self.fs.read(path)
@@ -51,21 +37,16 @@ class CodeNavigationTool:
         lines = source.splitlines(keepends=True)
         matches = []
         for node in ast.walk(tree):
-            if kind == "function" and isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
-                matches.append(node)
-            elif kind == "class" and isinstance(node, ast.ClassDef) and node.name == name:
-                matches.append(node)
+            entry = self._build_entry(node, path, source)
+            if entry and entry["kind"] == kind and entry["name"] == name:
+                matches.append((node, entry))
         if not matches:
             raise ValueError(f"{kind} '{name}' not found")
         if len(matches) > 1:
             raise ValueError(f"ambiguous {kind} '{name}'")
-        node = matches[0]
+        node, entry = matches[0]
         return {
-            "path": path,
-            "kind": kind,
-            "name": name,
-            "line_start": node.lineno,
-            "line_end": node.end_lineno,
+            **entry,
             "source": "".join(lines[node.lineno - 1: node.end_lineno]),
         }
 
@@ -92,3 +73,60 @@ class CodeNavigationTool:
                         "line": node.lineno,
                     })
         return sorted(imports, key=lambda x: x["line"])
+
+    def find_references(self, name: str) -> List[dict]:
+        refs: List[dict] = []
+        for path in self.workspace_root.rglob("*.py"):
+            rel = str(path.relative_to(self.workspace_root))
+            try:
+                source = self.fs.read(rel)
+                tree = ast.parse(source)
+            except Exception:
+                continue
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Name) and node.id == name:
+                    refs.append({
+                        "path": rel,
+                        "name": name,
+                        "line": node.lineno,
+                        "column": node.col_offset,
+                        "context": "reference",
+                    })
+        return sorted(refs, key=lambda r: (r["path"], r["line"], r["column"]))
+
+    def explain_ambiguity(self, name: str, kind: Optional[str] = None) -> dict:
+        matches = self.find_symbol(name, kind)
+        return {
+            "name": name,
+            "kind": kind,
+            "count": len(matches),
+            "matches": matches,
+            "ambiguous": len(matches) > 1,
+        }
+
+    def _build_entry(self, node: ast.AST, path: str, source: str) -> Optional[dict]:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return {
+                "path": path,
+                "kind": "function",
+                "name": node.name,
+                "line_start": node.lineno,
+                "line_end": node.end_lineno,
+                "is_async": isinstance(node, ast.AsyncFunctionDef),
+                "decorator_count": len(node.decorator_list),
+                "docstring": ast.get_docstring(node),
+                "match_score": 100,
+            }
+        if isinstance(node, ast.ClassDef):
+            return {
+                "path": path,
+                "kind": "class",
+                "name": node.name,
+                "line_start": node.lineno,
+                "line_end": node.end_lineno,
+                "is_async": False,
+                "decorator_count": len(node.decorator_list),
+                "docstring": ast.get_docstring(node),
+                "match_score": 100,
+            }
+        return None

--- a/velocity_claw/tools/test_runner.py
+++ b/velocity_claw/tools/test_runner.py
@@ -18,19 +18,32 @@ class TestRunnerTool:
         self.fs = FileSystemTool(settings)
         self.workspace_root = Path(settings.workspace_root).resolve()
 
-    def run(self, runner: str, target: Optional[str] = None, timeout: int = 120, extra_args: Optional[list[str]] = None, dry_run: bool = False) -> dict:
+    def run(
+        self,
+        runner: str,
+        target: Optional[str] = None,
+        timeout: int = 120,
+        extra_args: Optional[list[str]] = None,
+        dry_run: bool = False,
+        keyword: Optional[str] = None,
+        marker: Optional[str] = None,
+        nodeid: Optional[str] = None,
+    ) -> dict:
         extra_args = extra_args or []
-        cmd = self._build_command(runner, target, extra_args)
+        cmd = self._build_command(runner, target, extra_args, keyword=keyword, marker=marker, nodeid=nodeid)
         if dry_run:
             return {
                 "runner": runner,
                 "target": target,
+                "nodeid": nodeid,
+                "keyword": keyword,
+                "marker": marker,
                 "code": 0,
                 "status": "simulated",
                 "stdout": "",
                 "stderr": "",
                 "duration_ms": 0,
-                "summary": {"passed": 0, "failed": 0, "errors": 0, "skipped": 0},
+                "summary": self._empty_summary(),
                 "command": cmd,
                 "parsed_failures": [],
             }
@@ -47,11 +60,15 @@ class TestRunnerTool:
             duration_ms = int((time.monotonic() - start) * 1000)
             stdout = completed.stdout
             stderr = completed.stderr
-            summary = self._extract_summary(stdout + "\n" + stderr)
-            status = "passed" if completed.returncode == 0 and summary["failed"] == 0 and summary["errors"] == 0 else "failed"
+            combined = stdout + "\n" + stderr
+            summary = self._extract_summary(combined)
+            status = self._determine_status(completed.returncode, summary)
             return {
                 "runner": runner,
                 "target": target,
+                "nodeid": nodeid,
+                "keyword": keyword,
+                "marker": marker,
                 "code": completed.returncode,
                 "status": status,
                 "stdout": stdout,
@@ -59,27 +76,42 @@ class TestRunnerTool:
                 "duration_ms": duration_ms,
                 "summary": summary,
                 "command": cmd,
-                "parsed_failures": self.parse_failures(stdout + "\n" + stderr),
+                "parsed_failures": self.parse_failures(combined),
             }
         except subprocess.TimeoutExpired as e:
             duration_ms = int((time.monotonic() - start) * 1000)
             return {
                 "runner": runner,
                 "target": target,
+                "nodeid": nodeid,
+                "keyword": keyword,
+                "marker": marker,
                 "code": -1,
                 "status": "timeout",
                 "stdout": e.stdout or "",
                 "stderr": e.stderr or "",
                 "duration_ms": duration_ms,
-                "summary": {"passed": 0, "failed": 0, "errors": 1, "skipped": 0},
+                "summary": {**self._empty_summary(), "errors": 1},
                 "command": cmd,
                 "parsed_failures": [],
             }
 
-    def _build_command(self, runner: str, target: Optional[str], extra_args: list[str]) -> list[str]:
+    def _build_command(
+        self,
+        runner: str,
+        target: Optional[str],
+        extra_args: list[str],
+        *,
+        keyword: Optional[str] = None,
+        marker: Optional[str] = None,
+        nodeid: Optional[str] = None,
+    ) -> list[str]:
         safe_extra = [arg for arg in extra_args if arg and arg.startswith("-")]
         if target:
             self.fs._validate_path(target)
+        if nodeid:
+            node_path = nodeid.split("::", 1)[0]
+            self.fs._validate_path(node_path)
         if runner == "pytest":
             cmd = ["pytest"]
         elif runner == "python -m pytest":
@@ -88,21 +120,53 @@ class TestRunnerTool:
             raise ValueError(f"Unsupported runner: {runner}")
         if target:
             cmd.append(target)
+        if nodeid:
+            cmd.append(nodeid)
+        if keyword:
+            cmd.extend(["-k", keyword])
+        if marker:
+            cmd.extend(["-m", marker])
         cmd.extend(safe_extra)
         return cmd
 
+    def _empty_summary(self) -> dict:
+        return {
+            "collected": 0,
+            "passed": 0,
+            "failed": 0,
+            "errors": 0,
+            "skipped": 0,
+            "xfailed": 0,
+            "xpassed": 0,
+        }
+
+    def _determine_status(self, code: int, summary: dict) -> str:
+        if code == 0 and summary["failed"] == 0 and summary["errors"] == 0:
+            return "passed"
+        if summary["failed"] > 0 or summary["errors"] > 0:
+            return "failed"
+        return "failed" if code != 0 else "passed"
+
     def _extract_summary(self, output: str) -> dict:
-        summary = {"passed": 0, "failed": 0, "errors": 0, "skipped": 0}
+        summary = self._empty_summary()
+        collected = re.search(r"collected\s+(\d+)\s+items?", output)
+        if collected:
+            summary["collected"] = int(collected.group(1))
         patterns = {
             "passed": r"(\d+) passed",
             "failed": r"(\d+) failed",
             "errors": r"(\d+) error[s]?",
             "skipped": r"(\d+) skipped",
+            "xfailed": r"(\d+) xfailed",
+            "xpassed": r"(\d+) xpassed",
         }
         for key, pattern in patterns.items():
             m = re.search(pattern, output)
             if m:
                 summary[key] = int(m.group(1))
+        if summary["collected"] == 0:
+            counted = summary["passed"] + summary["failed"] + summary["errors"] + summary["skipped"] + summary["xfailed"] + summary["xpassed"]
+            summary["collected"] = counted
         return summary
 
     def parse_failures(self, output: str) -> list[dict]:
@@ -111,20 +175,24 @@ class TestRunnerTool:
         for line in output.splitlines():
             if line.startswith("FAILED "):
                 tail = line[len("FAILED "):]
-                file_line = None
-                message = tail
-                m = re.match(r"(.+?):(\d+):\s+(.*)", tail)
-                if m:
-                    file_line = (m.group(1), int(m.group(2)))
-                    message = m.group(3)
+                parts = tail.split(" - ", 1)
+                node = parts[0].strip()
+                message = parts[1].strip() if len(parts) > 1 else tail
+                file_name = node.split("::", 1)[0] if "::" in node else None
                 current = {
-                    "failed_test_name": message.split(" - ")[0],
-                    "file": file_line[0] if file_line else None,
-                    "line": file_line[1] if file_line else None,
+                    "failed_test_name": node,
+                    "nodeid": node,
+                    "file": file_name,
+                    "line": None,
                     "assertion": message,
                     "traceback_summary": message,
                 }
                 failures.append(current)
+            elif current and re.match(r".+\.py:\d+:\s+in\s+", line.strip()):
+                m = re.match(r"(.+\.py):(\d+):\s+in\s+", line.strip())
+                if m:
+                    current["file"] = m.group(1)
+                    current["line"] = int(m.group(2))
             elif current and line.startswith("E       "):
                 current["assertion"] = line.replace("E       ", "", 1).strip()
                 current["traceback_summary"] = current["assertion"]


### PR DESCRIPTION
## Summary
This PR starts Wave B on top of the current master after Wave A.

## What is included
- test runner v2:
  - richer summaries
  - keyword/marker/nodeid support
  - improved parsed failures
- symbol navigation v2:
  - richer symbol metadata
  - ambiguity explanation
  - simple reference search
- auto-fix loop v2:
  - richer attempt summaries
  - patch/failure signatures
  - clearer stop reasons
  - stronger linkage to symbol navigation and parsed failures
- Wave B tests for all three areas

## Related issues
- #22 Wave B: Auto-fix loop v2
- #23 Wave B: Test runner v2
- #24 Wave B: Symbol navigation v2

## Notes
This is the first Wave B pass. The purpose is to improve the quality of the dev-agent loop before deeper iterations.
