### PR TITLE
Wave C: improve queue persistence, diagnostics, and artifact UX

### DIFF
--- a/tests/test_wave_c_artifacts_v2.py
+++ b/tests/test_wave_c_artifacts_v2.py
@@ -1,0 +1,33 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.core.agent import VelocityClawAgent
+
+
+class ArtifactRunDetailV2Tests(unittest.IsolatedAsyncioTestCase):
+    async def test_run_has_groupable_artifacts(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        settings = Settings(workspace_root=workspace, memory_db_path=db_path, execution_profile="dev")
+        Path(workspace, "sample.py").write_text("print('old')\n")
+        agent = VelocityClawAgent(settings)
+
+        async def fake_plan(task, context=None):
+            return {
+                "task": task,
+                "steps": [
+                    {"id": 1, "title": "patch file", "tool": "patch.apply", "args": {"patch": {"op": "replace_block", "path": "sample.py", "target": "old", "replacement": "new"}}, "expected_output": "patched"}
+                ],
+            }
+
+        agent.planner.create_plan = fake_plan
+        result = await agent.run_task("patch")
+        run = agent.memory.load_run(result["run_id"])
+        self.assertTrue(run["artifacts"])
+        self.assertEqual(run["status"], "completed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wave_c_metrics_v2.py
+++ b/tests/test_wave_c_metrics_v2.py
@@ -1,0 +1,30 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from velocity_claw.api.server import create_app
+from velocity_claw.core.metrics import MetricsRegistry
+
+
+class MetricsDiagnosticsV2Tests(unittest.TestCase):
+    def test_metrics_registry_has_diagnostics_summary(self):
+        registry = MetricsRegistry()
+        registry.incr("tasks_total")
+        registry.incr("tasks_completed")
+        registry.observe_task_duration(120)
+        registry.observe_task_duration(80)
+        summary = registry.diagnostics_summary()
+        self.assertIn("task_health", summary)
+        self.assertEqual(summary["task_health"]["avg_duration_ms"], 100)
+
+    def test_app_exposes_diagnostics_shape(self):
+        tmp = tempfile.mkdtemp()
+        Path(tmp, ".keep").write_text("x")
+        app = create_app()
+        self.assertTrue(hasattr(app.state, "metrics"))
+        data = app.state.metrics.snapshot()
+        self.assertIn("avg_task_duration_ms", data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wave_c_queue_v2.py
+++ b/tests/test_wave_c_queue_v2.py
@@ -1,0 +1,33 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from velocity_claw.core.queue import RunQueue
+
+
+class QueuePersistenceV2Tests(unittest.IsolatedAsyncioTestCase):
+    async def test_queue_persists_jobs(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "queue.db")
+        queue = RunQueue(db_path=db_path)
+        job = queue.enqueue("task-one", {"x": 1})
+
+        queue_reloaded = RunQueue(db_path=db_path)
+        loaded = queue_reloaded.get(job.job_id)
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded.task, "task-one")
+        self.assertEqual(loaded.context, {"x": 1})
+
+    async def test_queue_cancel_and_list(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "queue.db")
+        queue = RunQueue(db_path=db_path)
+        job = queue.enqueue("task-two")
+        queue.cancel(job.job_id)
+        listed = queue.list_jobs()
+        self.assertTrue(listed)
+        self.assertEqual(listed[0]["status"], "cancelled")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/velocity_claw/api/server.py
+++ b/velocity_claw/api/server.py
@@ -92,6 +92,13 @@ def create_app() -> FastAPI:
         app.state.metrics.set_value("queue_failed", sum(1 for job in queue_jobs if job["status"] == "failed"))
         app.state.metrics.set_value("queue_cancelled", sum(1 for job in queue_jobs if job["status"] == "cancelled"))
 
+    def group_artifacts(run_data: dict) -> dict:
+        grouped: dict[str, list[dict]] = {}
+        for artifact in run_data.get("artifacts", []):
+            key = f"step_{artifact['step_id']}" if artifact.get("step_id") is not None else "run_level"
+            grouped.setdefault(key, []).append(artifact)
+        return grouped
+
     @app.get("/health")
     def health():
         refresh_runtime_metrics()
@@ -229,6 +236,46 @@ def create_app() -> FastAPI:
             raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Run not found"})
         return data
 
+    @app.get("/runs/{run_id}/artifacts")
+    def run_artifacts(run_id: str):
+        data = app.state.agent.memory.load_run(run_id)
+        if not data:
+            raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Run not found"})
+        return {"run_id": run_id, "grouped_artifacts": group_artifacts(data)}
+
+    @app.get("/runs/{run_id}/view", response_class=HTMLResponse)
+    def run_detail_view(run_id: str):
+        data = app.state.agent.memory.load_run(run_id)
+        if not data:
+            raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Run not found"})
+        grouped = group_artifacts(data)
+        body = [
+            "<html><body style='font-family:Arial,sans-serif;max-width:1100px;margin:24px auto;padding:0 16px'>",
+            f"<h1>Run detail: {run_id}</h1>",
+            f"<p>Task: <b>{data['task']}</b></p>",
+            f"<p>Status: <b>{data['status']}</b></p>",
+            f"<p>Created: {data['created_at']}</p>",
+            "<h2>Steps</h2>",
+            "<table border='1' cellpadding='6' cellspacing='0' style='border-collapse:collapse;width:100%'>",
+            "<tr><th>ID</th><th>Title</th><th>Tool</th><th>Status</th><th>Error</th></tr>",
+        ]
+        for step in data.get("steps", []):
+            body.append(f"<tr><td>{step['id']}</td><td>{step['title']}</td><td>{step.get('tool') or ''}</td><td>{step['status']}</td><td>{step.get('error') or ''}</td></tr>")
+        body.append("</table>")
+        body.append("<h2>Approval history</h2><ul>")
+        for item in data.get("approval_history", []):
+            body.append(f"<li>step {item['step_id']} — {item['decision']} — actor: {item.get('actor') or 'n/a'} — reason: {item.get('reason') or 'n/a'}</li>")
+        body.append("</ul>")
+        body.append("<h2>Artifacts</h2>")
+        for group_name, artifacts in grouped.items():
+            body.append(f"<h3>{group_name}</h3><ul>")
+            for artifact in artifacts:
+                preview = (artifact.get('content') or '')[:180].replace('<', '&lt;').replace('>', '&gt;')
+                body.append(f"<li>{artifact['name']} [{artifact['artifact_type']}]<pre>{preview}</pre></li>")
+            body.append("</ul>")
+        body.append("</body></html>")
+        return "".join(body)
+
     @app.get("/runs/{run_id}/approval-history")
     def approval_history(run_id: str):
         return {"run_id": run_id, "history": app.state.agent.get_approval_history(run_id)}
@@ -301,16 +348,16 @@ def create_app() -> FastAPI:
 
         body.append("<h2>Recent runs</h2>")
         body.append("<table border='1' cellpadding='6' cellspacing='0' style='border-collapse:collapse;width:100%'>")
-        body.append("<tr><th>Run ID</th><th>Task</th><th>Status</th><th>Created</th></tr>")
+        body.append("<tr><th>Run ID</th><th>Task</th><th>Status</th><th>Created</th><th>View</th></tr>")
         for run in recent:
             body.append(
-                f"<tr><td><code>{run['run_id']}</code></td><td>{run['task']}</td><td>{badge(run['status'])}</td><td>{run['created_at']}</td></tr>"
+                f"<tr><td><code>{run['run_id']}</code></td><td>{run['task']}</td><td>{badge(run['status'])}</td><td>{run['created_at']}</td><td><a href='/runs/{run['run_id']}/view'>open</a></td></tr>"
             )
         body.append("</table>")
 
         body.append("<h2>Last failed run</h2>")
         if last_failed:
-            body.append(f"<p><code>{last_failed['run_id']}</code> — {last_failed['task']} — {badge(last_failed['status'])}</p>")
+            body.append(f"<p><code>{last_failed['run_id']}</code> — {last_failed['task']} — {badge(last_failed['status'])} — <a href='/runs/{last_failed['run_id']}/view'>details</a></p>")
         else:
             body.append("<p>No failed runs recorded.</p>")
 

--- a/velocity_claw/api/server.py
+++ b/velocity_claw/api/server.py
@@ -78,7 +78,7 @@ def create_app() -> FastAPI:
     app.state.settings = settings
     app.state.logger = get_logger("velocity_claw.api")
     app.state.agent = VelocityClawAgent(settings=settings)
-    app.state.queue = RunQueue()
+    app.state.queue = RunQueue(db_path=f"{settings.memory_db_path}.queue")
     app.state.metrics = MetricsRegistry()
     app.state.profiles = ExecutionProfileManager(settings)
 
@@ -141,9 +141,20 @@ def create_app() -> FastAPI:
         asyncio.create_task(app.state.queue.run_job(job.job_id, app.state.agent.run_task))
         return {"job_id": job.job_id, "status": job.status}
 
+    @app.get("/queue")
+    def queue_list():
+        return {"jobs": app.state.queue.list_jobs()}
+
     @app.get("/queue/{job_id}")
     def queue_status(job_id: str):
         job = app.state.queue.get(job_id)
+        if not job:
+            raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Job not found"})
+        return job.__dict__
+
+    @app.post("/queue/{job_id}/cancel")
+    def queue_cancel(job_id: str):
+        job = app.state.queue.cancel(job_id)
         if not job:
             raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Job not found"})
         return job.__dict__
@@ -206,6 +217,7 @@ def create_app() -> FastAPI:
         profile = app.state.profiles.get_capability_matrix()
         metrics_snapshot = app.state.metrics.snapshot()
         last_failed = app.state.agent.resume_last_failed_run()
+        queue_jobs = app.state.queue.list_jobs()[:10]
 
         def badge(status: str) -> str:
             return f"<span style='padding:2px 8px;border-radius:999px;border:1px solid #999'>{status}</span>"
@@ -214,7 +226,7 @@ def create_app() -> FastAPI:
             "<html><body style='font-family:Arial,sans-serif;max-width:1100px;margin:24px auto;padding:0 16px'>",
             "<h1>Velocity Claw Dashboard</h1>",
             f"<p>Execution profile: <b>{app.state.settings.execution_profile}</b></p>",
-            "<p>Quick links: <a href='/status'>/status</a> | <a href='/metrics'>/metrics</a> | <a href='/runs'>/runs</a> | <a href='/approvals'>/approvals</a> | <a href='/profiles'>/profiles</a></p>",
+            "<p>Quick links: <a href='/status'>/status</a> | <a href='/metrics'>/metrics</a> | <a href='/runs'>/runs</a> | <a href='/approvals'>/approvals</a> | <a href='/profiles'>/profiles</a> | <a href='/queue'>/queue</a></p>",
             "<h2>Metrics</h2>",
             "<ul>",
         ]
@@ -228,6 +240,16 @@ def create_app() -> FastAPI:
         for key, value in profile["capabilities"].items():
             body.append(f"<li>{key}: <b>{value}</b></li>")
         body.append("</ul>")
+
+        body.append("<h2>Queue jobs</h2>")
+        if queue_jobs:
+            body.append("<table border='1' cellpadding='6' cellspacing='0' style='border-collapse:collapse;width:100%'>")
+            body.append("<tr><th>Job ID</th><th>Task</th><th>Status</th><th>Attempts</th></tr>")
+            for job in queue_jobs:
+                body.append(f"<tr><td><code>{job['job_id']}</code></td><td>{job['task']}</td><td>{badge(job['status'])}</td><td>{job['attempts']}</td></tr>")
+            body.append("</table>")
+        else:
+            body.append("<p>No queue jobs recorded.</p>")
 
         body.append("<h2>Recent runs</h2>")
         body.append("<table border='1' cellpadding='6' cellspacing='0' style='border-collapse:collapse;width:100%'>")

--- a/velocity_claw/api/server.py
+++ b/velocity_claw/api/server.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Optional
 import asyncio
+import time
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
@@ -82,8 +83,18 @@ def create_app() -> FastAPI:
     app.state.metrics = MetricsRegistry()
     app.state.profiles = ExecutionProfileManager(settings)
 
+    def refresh_runtime_metrics() -> None:
+        approvals_pending = len(app.state.agent.list_pending_approvals())
+        queue_jobs = app.state.queue.list_jobs()
+        app.state.metrics.set_value("approvals_pending", approvals_pending)
+        app.state.metrics.set_value("queue_total", len(queue_jobs))
+        app.state.metrics.set_value("queue_running", sum(1 for job in queue_jobs if job["status"] == "running"))
+        app.state.metrics.set_value("queue_failed", sum(1 for job in queue_jobs if job["status"] == "failed"))
+        app.state.metrics.set_value("queue_cancelled", sum(1 for job in queue_jobs if job["status"] == "cancelled"))
+
     @app.get("/health")
     def health():
+        refresh_runtime_metrics()
         return {"status": "ok", "metrics": app.state.metrics.snapshot()}
 
     @app.post("/task", response_model=TaskResponse)
@@ -91,6 +102,7 @@ def create_app() -> FastAPI:
         if not request.task or not request.task.strip():
             raise HTTPException(status_code=400, detail={"status": "failed", "error": "invalid_task", "detail": "Task must not be empty"})
         app.state.metrics.incr("tasks_total")
+        started = time.monotonic()
         try:
             result = await app.state.agent.run_task(request.task, request.context)
             app.state.metrics.incr("tasks_completed")
@@ -107,16 +119,24 @@ def create_app() -> FastAPI:
             app.state.metrics.incr("tasks_failed")
             app.state.logger.error("Task execution failed: %s", e)
             raise HTTPException(status_code=500, detail={"status": "failed", "error": "internal_error", "detail": str(e)})
+        finally:
+            app.state.metrics.observe_task_duration(int((time.monotonic() - started) * 1000))
+            refresh_runtime_metrics()
 
     @app.post("/modes/run")
     async def run_mode(request: ModeRequest):
         app.state.metrics.incr("tasks_total")
-        result = await app.state.agent.run_mode(request.mode, request.task, request.context)
-        if result["status"] == "completed":
-            app.state.metrics.incr("tasks_completed")
-        else:
-            app.state.metrics.incr("tasks_failed")
-        return result
+        started = time.monotonic()
+        try:
+            result = await app.state.agent.run_mode(request.mode, request.task, request.context)
+            if result["status"] == "completed":
+                app.state.metrics.incr("tasks_completed")
+            else:
+                app.state.metrics.incr("tasks_failed")
+            return result
+        finally:
+            app.state.metrics.observe_task_duration(int((time.monotonic() - started) * 1000))
+            refresh_runtime_metrics()
 
     @app.get("/modes")
     def modes():
@@ -138,11 +158,13 @@ def create_app() -> FastAPI:
     @app.post("/queue/submit")
     async def queue_submit(request: TaskRequest):
         job = app.state.queue.enqueue(request.task, request.context)
+        refresh_runtime_metrics()
         asyncio.create_task(app.state.queue.run_job(job.job_id, app.state.agent.run_task))
         return {"job_id": job.job_id, "status": job.status}
 
     @app.get("/queue")
     def queue_list():
+        refresh_runtime_metrics()
         return {"jobs": app.state.queue.list_jobs()}
 
     @app.get("/queue/{job_id}")
@@ -150,6 +172,7 @@ def create_app() -> FastAPI:
         job = app.state.queue.get(job_id)
         if not job:
             raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Job not found"})
+        refresh_runtime_metrics()
         return job.__dict__
 
     @app.post("/queue/{job_id}/cancel")
@@ -157,11 +180,13 @@ def create_app() -> FastAPI:
         job = app.state.queue.cancel(job_id)
         if not job:
             raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Job not found"})
+        refresh_runtime_metrics()
         return job.__dict__
 
     @app.post("/auto-fix")
     def auto_fix(request: AutoFixRequest):
         app.state.metrics.incr("auto_fix_total")
+        refresh_runtime_metrics()
         return app.state.agent.run_auto_fix(
             target_test=request.target_test,
             patch_plan=request.patch_plan,
@@ -171,13 +196,23 @@ def create_app() -> FastAPI:
 
     @app.get("/status", response_model=StatusResponse)
     def status():
-        app.state.metrics.set_value("approvals_pending", len(app.state.agent.list_pending_approvals()))
+        refresh_runtime_metrics()
         return StatusResponse(**app.state.agent.get_status())
 
     @app.get("/metrics")
     def metrics():
-        app.state.metrics.set_value("approvals_pending", len(app.state.agent.list_pending_approvals()))
+        refresh_runtime_metrics()
         return app.state.metrics.snapshot()
+
+    @app.get("/diagnostics")
+    def diagnostics():
+        refresh_runtime_metrics()
+        return {
+            "metrics": app.state.metrics.snapshot(),
+            "diagnostics": app.state.metrics.diagnostics_summary(),
+            "last_failed_run": app.state.agent.resume_last_failed_run(),
+            "queue_jobs_preview": app.state.queue.list_jobs()[:10],
+        }
 
     @app.post("/reset", response_model=ResetResponse)
     def reset():
@@ -212,10 +247,12 @@ def create_app() -> FastAPI:
 
     @app.get("/dashboard", response_class=HTMLResponse)
     def dashboard():
+        refresh_runtime_metrics()
         recent = app.state.agent.memory.list_recent_runs(limit=10)
         approvals = app.state.agent.list_pending_approvals()
         profile = app.state.profiles.get_capability_matrix()
         metrics_snapshot = app.state.metrics.snapshot()
+        diagnostics_snapshot = app.state.metrics.diagnostics_summary()
         last_failed = app.state.agent.resume_last_failed_run()
         queue_jobs = app.state.queue.list_jobs()[:10]
 
@@ -226,12 +263,23 @@ def create_app() -> FastAPI:
             "<html><body style='font-family:Arial,sans-serif;max-width:1100px;margin:24px auto;padding:0 16px'>",
             "<h1>Velocity Claw Dashboard</h1>",
             f"<p>Execution profile: <b>{app.state.settings.execution_profile}</b></p>",
-            "<p>Quick links: <a href='/status'>/status</a> | <a href='/metrics'>/metrics</a> | <a href='/runs'>/runs</a> | <a href='/approvals'>/approvals</a> | <a href='/profiles'>/profiles</a> | <a href='/queue'>/queue</a></p>",
+            "<p>Quick links: <a href='/status'>/status</a> | <a href='/metrics'>/metrics</a> | <a href='/diagnostics'>/diagnostics</a> | <a href='/runs'>/runs</a> | <a href='/approvals'>/approvals</a> | <a href='/profiles'>/profiles</a> | <a href='/queue'>/queue</a></p>",
             "<h2>Metrics</h2>",
             "<ul>",
         ]
         for key, value in metrics_snapshot.items():
             body.append(f"<li>{key}: <b>{value}</b></li>")
+        body.append("</ul>")
+
+        body.append("<h2>Diagnostics summary</h2><ul>")
+        for section, payload in diagnostics_snapshot.items():
+            if isinstance(payload, dict):
+                body.append(f"<li><b>{section}</b><ul>")
+                for k, v in payload.items():
+                    body.append(f"<li>{k}: <b>{v}</b></li>")
+                body.append("</ul></li>")
+            else:
+                body.append(f"<li>{section}: <b>{payload}</b></li>")
         body.append("</ul>")
 
         body.append("<h2>Active profile matrix</h2>")

--- a/velocity_claw/core/metrics.py
+++ b/velocity_claw/core/metrics.py
@@ -11,6 +11,12 @@ class MetricsState:
     tasks_completed: int = 0
     auto_fix_total: int = 0
     approvals_pending: int = 0
+    queue_total: int = 0
+    queue_running: int = 0
+    queue_failed: int = 0
+    queue_cancelled: int = 0
+    total_task_duration_ms: int = 0
+    task_duration_samples: int = 0
 
 
 class MetricsRegistry:
@@ -26,6 +32,34 @@ class MetricsRegistry:
         with self._lock:
             setattr(self._state, field, value)
 
+    def observe_task_duration(self, duration_ms: int) -> None:
+        with self._lock:
+            self._state.total_task_duration_ms += duration_ms
+            self._state.task_duration_samples += 1
+
     def snapshot(self) -> dict:
         with self._lock:
-            return asdict(self._state)
+            data = asdict(self._state)
+        samples = data.get("task_duration_samples", 0)
+        total = data.get("total_task_duration_ms", 0)
+        data["avg_task_duration_ms"] = int(total / samples) if samples else 0
+        return data
+
+    def diagnostics_summary(self) -> dict:
+        snapshot = self.snapshot()
+        return {
+            "task_health": {
+                "total": snapshot["tasks_total"],
+                "completed": snapshot["tasks_completed"],
+                "failed": snapshot["tasks_failed"],
+                "avg_duration_ms": snapshot["avg_task_duration_ms"],
+            },
+            "queue_health": {
+                "total": snapshot["queue_total"],
+                "running": snapshot["queue_running"],
+                "failed": snapshot["queue_failed"],
+                "cancelled": snapshot["queue_cancelled"],
+            },
+            "approvals_pending": snapshot["approvals_pending"],
+            "auto_fix_total": snapshot["auto_fix_total"],
+        }

--- a/velocity_claw/core/queue.py
+++ b/velocity_claw/core/queue.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import json
+import sqlite3
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
+from pathlib import Path
 from typing import Dict, Optional
 
 
@@ -16,30 +19,124 @@ class QueueJob:
     updated_at: str = field(default_factory=lambda: datetime.now().isoformat())
     result: Optional[dict] = None
     error: Optional[str] = None
+    attempts: int = 0
 
 
 class RunQueue:
-    def __init__(self):
+    def __init__(self, db_path: Optional[str] = None):
         self.jobs: Dict[str, QueueJob] = {}
+        self.db_path = db_path
+        if self.db_path:
+            self._ensure_tables()
+            self._load_jobs_from_db()
+
+    def _ensure_tables(self):
+        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS queue_jobs (
+                    job_id TEXT PRIMARY KEY,
+                    task TEXT NOT NULL,
+                    context TEXT,
+                    status TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    result TEXT,
+                    error TEXT,
+                    attempts INTEGER NOT NULL DEFAULT 0
+                )
+                """
+            )
+
+    def _load_jobs_from_db(self):
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute(
+                "SELECT job_id, task, context, status, created_at, updated_at, result, error, attempts FROM queue_jobs"
+            ).fetchall()
+        for row in rows:
+            self.jobs[row[0]] = QueueJob(
+                job_id=row[0],
+                task=row[1],
+                context=json.loads(row[2]) if row[2] else None,
+                status=row[3],
+                created_at=row[4],
+                updated_at=row[5],
+                result=json.loads(row[6]) if row[6] else None,
+                error=row[7],
+                attempts=row[8] or 0,
+            )
+
+    def _persist_job(self, job: QueueJob):
+        if not self.db_path:
+            return
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO queue_jobs (job_id, task, context, status, created_at, updated_at, result, error, attempts)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(job_id) DO UPDATE SET
+                    task = excluded.task,
+                    context = excluded.context,
+                    status = excluded.status,
+                    created_at = excluded.created_at,
+                    updated_at = excluded.updated_at,
+                    result = excluded.result,
+                    error = excluded.error,
+                    attempts = excluded.attempts
+                """,
+                (
+                    job.job_id,
+                    job.task,
+                    json.dumps(job.context, ensure_ascii=False) if job.context is not None else None,
+                    job.status,
+                    job.created_at,
+                    job.updated_at,
+                    json.dumps(job.result, ensure_ascii=False) if job.result is not None else None,
+                    job.error,
+                    job.attempts,
+                ),
+            )
 
     def enqueue(self, task: str, context: Optional[dict] = None) -> QueueJob:
         job = QueueJob(job_id=str(uuid.uuid4()), task=task, context=context)
         self.jobs[job.job_id] = job
+        self._persist_job(job)
         return job
 
     def get(self, job_id: str) -> Optional[QueueJob]:
         return self.jobs.get(job_id)
 
+    def list_jobs(self) -> list[dict]:
+        return [asdict(job) for job in sorted(self.jobs.values(), key=lambda item: item.created_at, reverse=True)]
+
+    def cancel(self, job_id: str) -> Optional[QueueJob]:
+        job = self.jobs.get(job_id)
+        if not job:
+            return None
+        if job.status in {"completed", "failed", "cancelled"}:
+            return job
+        job.status = "cancelled"
+        job.updated_at = datetime.now().isoformat()
+        self._persist_job(job)
+        return job
+
     async def run_job(self, job_id: str, runner):
         job = self.jobs[job_id]
+        if job.status == "cancelled":
+            return job
         job.status = "running"
+        job.attempts += 1
         job.updated_at = datetime.now().isoformat()
+        self._persist_job(job)
         try:
             result = await runner(job.task, job.context)
             job.result = result
             job.status = "completed"
+            job.error = None
         except Exception as e:
             job.error = str(e)
             job.status = "failed"
         job.updated_at = datetime.now().isoformat()
+        self._persist_job(job)
         return job


### PR DESCRIPTION
## Summary
This PR starts Wave C on top of the current master after Wave B.

## What is included
- queue and worker persistence v2:
  - SQLite-backed queue storage
  - persisted job lifecycle
  - queue listing and cancellation
- metrics and diagnostics v2:
  - richer queue/task counters
  - task duration aggregation
  - diagnostics summary endpoint
- artifact and run-detail UX v2:
  - grouped artifact view
  - run detail HTML page
  - better dashboard links into run details
- Wave C tests for queue, metrics, and artifact/run-detail work

## Related issues
- #26 Wave C: Queue and worker persistence v2
- #27 Wave C: Metrics and diagnostics v2
- #28 Wave C: Artifact and run-detail UX v2

## Notes
This is the first Wave C pass. The goal is to strengthen runtime maturity, observability, and inspectability without overcomplicating the system.
