### PR TITLE
Wave D: improve workers, approval continuation, and repo-aware memory

### DIFF
--- a/tests/test_wave_d_approval_v3.py
+++ b/tests/test_wave_d_approval_v3.py
@@ -1,0 +1,56 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.core.agent import VelocityClawAgent
+
+
+class ApprovalContinuationV3Tests(unittest.IsolatedAsyncioTestCase):
+    async def test_resume_can_pause_again_on_next_sensitive_step(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        settings = Settings(workspace_root=workspace, memory_db_path=db_path, execution_profile="safe")
+        Path(workspace, "sample.py").write_text("print('old')\n")
+        agent = VelocityClawAgent(settings)
+
+        async def fake_plan(task, context=None):
+            return {
+                "task": task,
+                "steps": [
+                    {"id": 1, "title": "first patch", "tool": "patch.apply", "args": {"patch": {"op": "replace_block", "path": "sample.py", "target": "old", "replacement": "mid"}}, "expected_output": "patched"},
+                    {"id": 2, "title": "second patch", "tool": "patch.apply", "args": {"patch": {"op": "replace_block", "path": "sample.py", "target": "mid", "replacement": "new"}}, "expected_output": "patched"},
+                ],
+            }
+
+        agent.planner.create_plan = fake_plan
+        initial = await agent.run_task("patch")
+        self.assertEqual(initial["status"], "awaiting_approval")
+        approve = agent.approve_step(initial["run_id"], 1, actor="tester", reason="continue")
+        self.assertEqual(approve["resume"]["status"], "awaiting_approval")
+        self.assertEqual(approve["resume"]["boundary_step_id"], 2)
+
+    async def test_reject_sets_rejected_status(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        settings = Settings(workspace_root=workspace, memory_db_path=db_path, execution_profile="safe")
+        Path(workspace, "sample.py").write_text("print('old')\n")
+        agent = VelocityClawAgent(settings)
+
+        async def fake_plan(task, context=None):
+            return {
+                "task": task,
+                "steps": [
+                    {"id": 1, "title": "first patch", "tool": "patch.apply", "args": {"patch": {"op": "replace_block", "path": "sample.py", "target": "old", "replacement": "new"}}, "expected_output": "patched"}
+                ],
+            }
+
+        agent.planner.create_plan = fake_plan
+        initial = await agent.run_task("patch")
+        agent.reject_step(initial["run_id"], 1, actor="tester", reason="stop")
+        run = agent.memory.load_run(initial["run_id"])
+        self.assertEqual(run["status"], "rejected")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wave_d_memory_v2.py
+++ b/tests/test_wave_d_memory_v2.py
@@ -1,0 +1,25 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.memory.store import MemoryStore
+
+
+class RepoAwareMemoryV2Tests(unittest.TestCase):
+    def test_repo_context_summary_includes_notes_and_facts(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        settings = Settings(workspace_root=workspace, memory_db_path=db_path)
+        store = MemoryStore(settings)
+        store.save_project_fact("framework", {"name": "python"})
+        store.save_project_note("task", "improve queue")
+        summary = store.build_repo_context_summary()
+        self.assertIn("project_facts", summary)
+        self.assertIn("recent_notes", summary)
+        self.assertEqual(summary["project_facts"]["framework"]["name"], "python")
+        self.assertTrue(summary["recent_notes"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wave_d_workers_v2.py
+++ b/tests/test_wave_d_workers_v2.py
@@ -1,0 +1,28 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from velocity_claw.core.queue import RunQueue
+
+
+class WorkerOrchestrationV2Tests(unittest.IsolatedAsyncioTestCase):
+    async def test_queue_has_max_concurrency_and_active_count(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "queue.db")
+        queue = RunQueue(db_path=db_path, max_concurrency=2)
+        self.assertEqual(queue.max_concurrency, 2)
+        self.assertEqual(queue.active_count(), 0)
+
+    async def test_requeue_failed_or_cancelled_job(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "queue.db")
+        queue = RunQueue(db_path=db_path, max_concurrency=1)
+        job = queue.enqueue("task")
+        queue.cancel(job.job_id)
+        requeued = queue.requeue(job.job_id)
+        self.assertEqual(requeued.status, "queued")
+        self.assertEqual(requeued.attempts, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/velocity_claw/api/server.py
+++ b/velocity_claw/api/server.py
@@ -79,7 +79,7 @@ def create_app() -> FastAPI:
     app.state.settings = settings
     app.state.logger = get_logger("velocity_claw.api")
     app.state.agent = VelocityClawAgent(settings=settings)
-    app.state.queue = RunQueue(db_path=f"{settings.memory_db_path}.queue")
+    app.state.queue = RunQueue(db_path=f"{settings.memory_db_path}.queue", max_concurrency=2)
     app.state.metrics = MetricsRegistry()
     app.state.profiles = ExecutionProfileManager(settings)
 
@@ -172,7 +172,11 @@ def create_app() -> FastAPI:
     @app.get("/queue")
     def queue_list():
         refresh_runtime_metrics()
-        return {"jobs": app.state.queue.list_jobs()}
+        return {
+            "jobs": app.state.queue.list_jobs(),
+            "active_workers": app.state.queue.active_count(),
+            "max_concurrency": app.state.queue.max_concurrency,
+        }
 
     @app.get("/queue/{job_id}")
     def queue_status(job_id: str):
@@ -185,6 +189,14 @@ def create_app() -> FastAPI:
     @app.post("/queue/{job_id}/cancel")
     def queue_cancel(job_id: str):
         job = app.state.queue.cancel(job_id)
+        if not job:
+            raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Job not found"})
+        refresh_runtime_metrics()
+        return job.__dict__
+
+    @app.post("/queue/{job_id}/requeue")
+    def queue_requeue(job_id: str):
+        job = app.state.queue.requeue(job_id)
         if not job:
             raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Job not found"})
         refresh_runtime_metrics()
@@ -219,6 +231,8 @@ def create_app() -> FastAPI:
             "diagnostics": app.state.metrics.diagnostics_summary(),
             "last_failed_run": app.state.agent.resume_last_failed_run(),
             "queue_jobs_preview": app.state.queue.list_jobs()[:10],
+            "active_workers": app.state.queue.active_count(),
+            "max_concurrency": app.state.queue.max_concurrency,
         }
 
     @app.post("/reset", response_model=ResetResponse)
@@ -310,6 +324,7 @@ def create_app() -> FastAPI:
             "<html><body style='font-family:Arial,sans-serif;max-width:1100px;margin:24px auto;padding:0 16px'>",
             "<h1>Velocity Claw Dashboard</h1>",
             f"<p>Execution profile: <b>{app.state.settings.execution_profile}</b></p>",
+            f"<p>Queue concurrency: <b>{app.state.queue.max_concurrency}</b> | Active workers: <b>{app.state.queue.active_count()}</b></p>",
             "<p>Quick links: <a href='/status'>/status</a> | <a href='/metrics'>/metrics</a> | <a href='/diagnostics'>/diagnostics</a> | <a href='/runs'>/runs</a> | <a href='/approvals'>/approvals</a> | <a href='/profiles'>/profiles</a> | <a href='/queue'>/queue</a></p>",
             "<h2>Metrics</h2>",
             "<ul>",
@@ -339,9 +354,9 @@ def create_app() -> FastAPI:
         body.append("<h2>Queue jobs</h2>")
         if queue_jobs:
             body.append("<table border='1' cellpadding='6' cellspacing='0' style='border-collapse:collapse;width:100%'>")
-            body.append("<tr><th>Job ID</th><th>Task</th><th>Status</th><th>Attempts</th></tr>")
+            body.append("<tr><th>Job ID</th><th>Task</th><th>Status</th><th>Attempts</th><th>Worker Slot</th></tr>")
             for job in queue_jobs:
-                body.append(f"<tr><td><code>{job['job_id']}</code></td><td>{job['task']}</td><td>{badge(job['status'])}</td><td>{job['attempts']}</td></tr>")
+                body.append(f"<tr><td><code>{job['job_id']}</code></td><td>{job['task']}</td><td>{badge(job['status'])}</td><td>{job['attempts']}</td><td>{job.get('worker_slot') or ''}</td></tr>")
             body.append("</table>")
         else:
             body.append("<p>No queue jobs recorded.</p>")

--- a/velocity_claw/api/server.py
+++ b/velocity_claw/api/server.py
@@ -162,6 +162,10 @@ def create_app() -> FastAPI:
         tool = tool_name.replace("__", ".")
         return app.state.profiles.explain_tool_access(tool)
 
+    @app.get("/memory/context")
+    def memory_context():
+        return app.state.agent.get_repo_context_summary()
+
     @app.post("/queue/submit")
     async def queue_submit(request: TaskRequest):
         job = app.state.queue.enqueue(request.task, request.context)
@@ -314,6 +318,7 @@ def create_app() -> FastAPI:
         profile = app.state.profiles.get_capability_matrix()
         metrics_snapshot = app.state.metrics.snapshot()
         diagnostics_snapshot = app.state.metrics.diagnostics_summary()
+        repo_context = app.state.agent.get_repo_context_summary()
         last_failed = app.state.agent.resume_last_failed_run()
         queue_jobs = app.state.queue.list_jobs()[:10]
 
@@ -325,7 +330,7 @@ def create_app() -> FastAPI:
             "<h1>Velocity Claw Dashboard</h1>",
             f"<p>Execution profile: <b>{app.state.settings.execution_profile}</b></p>",
             f"<p>Queue concurrency: <b>{app.state.queue.max_concurrency}</b> | Active workers: <b>{app.state.queue.active_count()}</b></p>",
-            "<p>Quick links: <a href='/status'>/status</a> | <a href='/metrics'>/metrics</a> | <a href='/diagnostics'>/diagnostics</a> | <a href='/runs'>/runs</a> | <a href='/approvals'>/approvals</a> | <a href='/profiles'>/profiles</a> | <a href='/queue'>/queue</a></p>",
+            "<p>Quick links: <a href='/status'>/status</a> | <a href='/metrics'>/metrics</a> | <a href='/diagnostics'>/diagnostics</a> | <a href='/memory/context'>/memory/context</a> | <a href='/runs'>/runs</a> | <a href='/approvals'>/approvals</a> | <a href='/profiles'>/profiles</a> | <a href='/queue'>/queue</a></p>",
             "<h2>Metrics</h2>",
             "<ul>",
         ]
@@ -343,6 +348,9 @@ def create_app() -> FastAPI:
             else:
                 body.append(f"<li>{section}: <b>{payload}</b></li>")
         body.append("</ul>")
+
+        body.append("<h2>Repo context summary</h2>")
+        body.append(f"<p>Project facts: <b>{len(repo_context.get('project_facts', {}))}</b> | Recent notes: <b>{len(repo_context.get('recent_notes', []))}</b></p>")
 
         body.append("<h2>Active profile matrix</h2>")
         body.append(f"<p>{profile['description']}</p>")

--- a/velocity_claw/core/agent.py
+++ b/velocity_claw/core/agent.py
@@ -43,10 +43,12 @@ class VelocityClawAgent:
         run_id = self.memory.create_run(task)
         self.logger.info("Starting run %s for task: %s", run_id, task)
         self.memory.save_project_fact("last_task", task)
+        self.memory.save_project_note("task", task)
         try:
             self.logger.info("Run %s: Planning", run_id)
             plan = await self.planner.create_plan(task, context)
             self.memory.save_artifact(run_id, "run_plan", json.dumps(plan, ensure_ascii=False), artifact_type="plan")
+            self.memory.save_project_note("plan_summary", f"Planned {len(plan.get('steps', []))} steps for task: {task}")
             results = []
             for step in plan["steps"]:
                 step_id = step["id"]
@@ -116,6 +118,7 @@ class VelocityClawAgent:
             summary = self._build_summary(results)
             self.memory.update_run_status(run_id, status)
             self.memory.save_artifact(run_id, "run_summary", summary, artifact_type="summary")
+            self.memory.save_project_note("run_summary", f"Run {run_id} finished with status {status}: {summary}")
             report = {
                 "run_id": run_id,
                 "task": task,
@@ -129,6 +132,7 @@ class VelocityClawAgent:
         except Exception as e:
             self.logger.error("Run %s failed: %s", run_id, e)
             self.memory.update_run_status(run_id, "failed")
+            self.memory.save_project_note("run_error", f"Run {run_id} failed: {e}")
             raise
 
     def _pause_for_approval(self, run_id: str, task: str, step: dict, started_at: str, profile_name: str, results: list, boundary_type: str) -> dict:
@@ -151,6 +155,7 @@ class VelocityClawAgent:
         self.memory.save_artifact(run_id, f"approval_step_{step_id}", str(approval), step_id=step_id, artifact_type="approval")
         self.memory.save_artifact(run_id, f"approval_boundary_step_{step_id}", json.dumps({"step_id": step_id, "boundary_type": boundary_type}, ensure_ascii=False), step_id=step_id, artifact_type="approval_boundary")
         self.memory.save_approval_decision(run_id, step_id, "requested", actor=None, reason=approval.get("reason"), payload=approval)
+        self.memory.save_project_note("approval_pause", f"Run {run_id} paused for approval at step {step_id}")
         self.memory.update_run_status(run_id, "awaiting_approval")
         return {
             "run_id": run_id,
@@ -168,6 +173,7 @@ class VelocityClawAgent:
             self.memory.save_fix_attempt(run_id, attempt["attempt"], attempt)
             self.memory.save_artifact(run_id, f"auto_fix_attempt_{attempt['attempt']}", str(attempt), artifact_type="auto_fix")
         self.memory.update_run_status(run_id, "completed" if result["status"] == "completed" else "failed")
+        self.memory.save_project_note("auto_fix", f"Auto-fix run {run_id} ended with status {result['status']}")
         result["run_id"] = run_id
         return result
 
@@ -180,6 +186,9 @@ class VelocityClawAgent:
     def get_approval_history(self, run_id: str):
         return self.memory.load_approval_history(run_id)
 
+    def get_repo_context_summary(self) -> dict:
+        return self.memory.build_repo_context_summary()
+
     def approve_step(self, run_id: str, step_id: int, actor: str = "owner", reason: str | None = None) -> dict:
         payload = {
             "decision": "approved",
@@ -190,6 +199,7 @@ class VelocityClawAgent:
         self.memory.update_step_status(run_id, step_id, "approved", result=payload)
         self.memory.save_approval_decision(run_id, step_id, "approved", actor=actor, reason=reason, payload=payload)
         self.memory.save_artifact(run_id, f"approval_decision_step_{step_id}", str(payload), step_id=step_id, artifact_type="approval")
+        self.memory.save_project_note("approval_decision", f"Run {run_id} step {step_id} approved by {actor}")
         self.memory.update_run_status(run_id, "resuming_after_approval")
         resume = self.resume_after_approval(run_id, step_id)
         payload["resume"] = resume
@@ -205,6 +215,7 @@ class VelocityClawAgent:
         self.memory.update_step_status(run_id, step_id, "rejected", result=payload, error="Rejected by reviewer")
         self.memory.save_approval_decision(run_id, step_id, "rejected", actor=actor, reason=reason, payload=payload)
         self.memory.save_artifact(run_id, f"approval_decision_step_{step_id}", str(payload), step_id=step_id, artifact_type="approval")
+        self.memory.save_project_note("approval_decision", f"Run {run_id} step {step_id} rejected by {actor}")
         self.memory.update_run_status(run_id, "rejected")
         return payload
 
@@ -249,8 +260,10 @@ class VelocityClawAgent:
             executed.append(result)
             if result.get("status") == "failed":
                 self.memory.update_run_status(run_id, "failed")
+                self.memory.save_project_note("resume_failure", f"Run {run_id} failed again during continuation at step {step.get('id')}")
                 return {"status": "failed", "executed": executed}
         self.memory.update_run_status(run_id, "completed")
+        self.memory.save_project_note("resume_complete", f"Run {run_id} completed after approval continuation")
         return {"status": "completed", "executed": executed}
 
     def get_status(self) -> Dict:

--- a/velocity_claw/core/agent.py
+++ b/velocity_claw/core/agent.py
@@ -54,32 +54,7 @@ class VelocityClawAgent:
                 started_at = datetime.now().isoformat()
                 profile_name = self.settings.execution_profile
                 if self.approvals.requires_approval(step, profile_name):
-                    completed_at = datetime.now().isoformat()
-                    approval = self.approvals.build_record(step, f"Sensitive step for profile {profile_name}")
-                    step_result = {
-                        "id": step_id,
-                        "title": step["title"],
-                        "tool": step.get("tool"),
-                        "args": step.get("args", {}),
-                        "status": "pending_approval",
-                        "result": approval,
-                        "error": None,
-                        "started_at": started_at,
-                        "completed_at": completed_at,
-                    }
-                    results.append(step_result)
-                    self.memory.save_step(run_id, step_result)
-                    self.memory.save_artifact(run_id, f"approval_step_{step_id}", str(approval), step_id=step_id, artifact_type="approval")
-                    self.memory.save_approval_decision(run_id, step_id, "requested", actor=None, reason=approval.get("reason"), payload=approval)
-                    self.memory.update_run_status(run_id, "awaiting_approval")
-                    return {
-                        "run_id": run_id,
-                        "task": task,
-                        "status": "awaiting_approval",
-                        "summary": f"Run paused at step {step_id} awaiting approval.",
-                        "steps": results,
-                        "signature": "velocity claw",
-                    }
+                    return self._pause_for_approval(run_id, task, step, started_at, profile_name, results, boundary_type="initial_pause")
 
                 if not self.profile_manager.is_tool_allowed(step.get("tool", ""), profile_name):
                     completed_at = datetime.now().isoformat()
@@ -156,6 +131,36 @@ class VelocityClawAgent:
             self.memory.update_run_status(run_id, "failed")
             raise
 
+    def _pause_for_approval(self, run_id: str, task: str, step: dict, started_at: str, profile_name: str, results: list, boundary_type: str) -> dict:
+        step_id = step["id"]
+        completed_at = datetime.now().isoformat()
+        approval = self.approvals.build_record(step, f"Sensitive step for profile {profile_name}")
+        step_result = {
+            "id": step_id,
+            "title": step["title"],
+            "tool": step.get("tool"),
+            "args": step.get("args", {}),
+            "status": "pending_approval",
+            "result": approval,
+            "error": None,
+            "started_at": started_at,
+            "completed_at": completed_at,
+        }
+        results.append(step_result)
+        self.memory.save_step(run_id, step_result)
+        self.memory.save_artifact(run_id, f"approval_step_{step_id}", str(approval), step_id=step_id, artifact_type="approval")
+        self.memory.save_artifact(run_id, f"approval_boundary_step_{step_id}", json.dumps({"step_id": step_id, "boundary_type": boundary_type}, ensure_ascii=False), step_id=step_id, artifact_type="approval_boundary")
+        self.memory.save_approval_decision(run_id, step_id, "requested", actor=None, reason=approval.get("reason"), payload=approval)
+        self.memory.update_run_status(run_id, "awaiting_approval")
+        return {
+            "run_id": run_id,
+            "task": task,
+            "status": "awaiting_approval",
+            "summary": f"Run paused at step {step_id} awaiting approval.",
+            "steps": results,
+            "signature": "velocity claw",
+        }
+
     def run_auto_fix(self, *, target_test: str, patch_plan: list[dict], runner: str = "pytest", max_attempts: int = 2) -> dict:
         run_id = self.memory.create_run(f"auto_fix:{target_test}")
         result = self.auto_fix.run(target_test=target_test, patch_plan=patch_plan, runner=runner, max_attempts=max_attempts, dry_run=self.settings.dry_run)
@@ -185,6 +190,7 @@ class VelocityClawAgent:
         self.memory.update_step_status(run_id, step_id, "approved", result=payload)
         self.memory.save_approval_decision(run_id, step_id, "approved", actor=actor, reason=reason, payload=payload)
         self.memory.save_artifact(run_id, f"approval_decision_step_{step_id}", str(payload), step_id=step_id, artifact_type="approval")
+        self.memory.update_run_status(run_id, "resuming_after_approval")
         resume = self.resume_after_approval(run_id, step_id)
         payload["resume"] = resume
         return payload
@@ -216,11 +222,27 @@ class VelocityClawAgent:
         except Exception:
             self.memory.update_run_status(run_id, "approved_waiting_manual_resume")
             return {"status": "manual_resume_required", "reason": "run_plan_invalid"}
-        pending_steps = [s for s in plan.get("steps", []) if s.get("id", 0) >= step_id]
+
+        steps = plan.get("steps", [])
+        start_index = next((idx for idx, item in enumerate(steps) if item.get("id") == step_id), None)
+        if start_index is None:
+            self.memory.update_run_status(run_id, "approved_waiting_manual_resume")
+            return {"status": "manual_resume_required", "reason": "step_boundary_missing"}
+
         executed = []
-        for step in pending_steps:
+        profile_name = self.settings.execution_profile
+        for index, step in enumerate(steps[start_index:], start=start_index):
+            started_at = datetime.now().isoformat()
+            if index > start_index and self.approvals.requires_approval(step, profile_name):
+                pause = self._pause_for_approval(run_id, run["task"], step, started_at, profile_name, [], boundary_type="continuation_pause")
+                return {
+                    "status": "awaiting_approval",
+                    "boundary_step_id": step.get("id"),
+                    "executed": executed,
+                    "pause": pause,
+                }
             result = asyncio.run(self.executor.execute_step(step, {}))
-            result["started_at"] = result.get("started_at") or datetime.now().isoformat()
+            result["started_at"] = result.get("started_at") or started_at
             result["completed_at"] = datetime.now().isoformat()
             self.memory.save_step(run_id, result)
             self._persist_artifacts(run_id, result)

--- a/velocity_claw/core/queue.py
+++ b/velocity_claw/core/queue.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import sqlite3
 import uuid
@@ -20,12 +21,16 @@ class QueueJob:
     result: Optional[dict] = None
     error: Optional[str] = None
     attempts: int = 0
+    worker_slot: Optional[str] = None
 
 
 class RunQueue:
-    def __init__(self, db_path: Optional[str] = None):
+    def __init__(self, db_path: Optional[str] = None, max_concurrency: int = 1):
         self.jobs: Dict[str, QueueJob] = {}
         self.db_path = db_path
+        self.max_concurrency = max(1, max_concurrency)
+        self._semaphore = asyncio.Semaphore(self.max_concurrency)
+        self._active_jobs: set[str] = set()
         if self.db_path:
             self._ensure_tables()
             self._load_jobs_from_db()
@@ -44,7 +49,8 @@ class RunQueue:
                     updated_at TEXT NOT NULL,
                     result TEXT,
                     error TEXT,
-                    attempts INTEGER NOT NULL DEFAULT 0
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    worker_slot TEXT
                 )
                 """
             )
@@ -52,7 +58,7 @@ class RunQueue:
     def _load_jobs_from_db(self):
         with sqlite3.connect(self.db_path) as conn:
             rows = conn.execute(
-                "SELECT job_id, task, context, status, created_at, updated_at, result, error, attempts FROM queue_jobs"
+                "SELECT job_id, task, context, status, created_at, updated_at, result, error, attempts, worker_slot FROM queue_jobs"
             ).fetchall()
         for row in rows:
             self.jobs[row[0]] = QueueJob(
@@ -65,6 +71,7 @@ class RunQueue:
                 result=json.loads(row[6]) if row[6] else None,
                 error=row[7],
                 attempts=row[8] or 0,
+                worker_slot=row[9],
             )
 
     def _persist_job(self, job: QueueJob):
@@ -73,8 +80,8 @@ class RunQueue:
         with sqlite3.connect(self.db_path) as conn:
             conn.execute(
                 """
-                INSERT INTO queue_jobs (job_id, task, context, status, created_at, updated_at, result, error, attempts)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO queue_jobs (job_id, task, context, status, created_at, updated_at, result, error, attempts, worker_slot)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(job_id) DO UPDATE SET
                     task = excluded.task,
                     context = excluded.context,
@@ -83,7 +90,8 @@ class RunQueue:
                     updated_at = excluded.updated_at,
                     result = excluded.result,
                     error = excluded.error,
-                    attempts = excluded.attempts
+                    attempts = excluded.attempts,
+                    worker_slot = excluded.worker_slot
                 """,
                 (
                     job.job_id,
@@ -95,6 +103,7 @@ class RunQueue:
                     json.dumps(job.result, ensure_ascii=False) if job.result is not None else None,
                     job.error,
                     job.attempts,
+                    job.worker_slot,
                 ),
             )
 
@@ -110,6 +119,9 @@ class RunQueue:
     def list_jobs(self) -> list[dict]:
         return [asdict(job) for job in sorted(self.jobs.values(), key=lambda item: item.created_at, reverse=True)]
 
+    def active_count(self) -> int:
+        return len(self._active_jobs)
+
     def cancel(self, job_id: str) -> Optional[QueueJob]:
         job = self.jobs.get(job_id)
         if not job:
@@ -117,6 +129,21 @@ class RunQueue:
         if job.status in {"completed", "failed", "cancelled"}:
             return job
         job.status = "cancelled"
+        job.worker_slot = None
+        job.updated_at = datetime.now().isoformat()
+        self._persist_job(job)
+        return job
+
+    def requeue(self, job_id: str) -> Optional[QueueJob]:
+        job = self.jobs.get(job_id)
+        if not job:
+            return None
+        if job.status not in {"failed", "cancelled"}:
+            return job
+        job.status = "queued"
+        job.error = None
+        job.result = None
+        job.worker_slot = None
         job.updated_at = datetime.now().isoformat()
         self._persist_job(job)
         return job
@@ -125,18 +152,26 @@ class RunQueue:
         job = self.jobs[job_id]
         if job.status == "cancelled":
             return job
-        job.status = "running"
-        job.attempts += 1
-        job.updated_at = datetime.now().isoformat()
-        self._persist_job(job)
-        try:
-            result = await runner(job.task, job.context)
-            job.result = result
-            job.status = "completed"
-            job.error = None
-        except Exception as e:
-            job.error = str(e)
-            job.status = "failed"
-        job.updated_at = datetime.now().isoformat()
-        self._persist_job(job)
-        return job
+        async with self._semaphore:
+            if job.status == "cancelled":
+                return job
+            self._active_jobs.add(job.job_id)
+            job.status = "running"
+            job.attempts += 1
+            job.worker_slot = f"slot-{self.active_count()}"
+            job.updated_at = datetime.now().isoformat()
+            self._persist_job(job)
+            try:
+                result = await runner(job.task, job.context)
+                job.result = result
+                job.status = "completed"
+                job.error = None
+            except Exception as e:
+                job.error = str(e)
+                job.status = "failed"
+            finally:
+                job.worker_slot = None
+                job.updated_at = datetime.now().isoformat()
+                self._persist_job(job)
+                self._active_jobs.discard(job.job_id)
+            return job

--- a/velocity_claw/memory/store.py
+++ b/velocity_claw/memory/store.py
@@ -71,6 +71,14 @@ class MemoryStore:
                 )
             """)
             conn.execute("""
+                CREATE TABLE IF NOT EXISTS project_notes (
+                    id INTEGER PRIMARY KEY,
+                    note_type TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+            conn.execute("""
                 CREATE TABLE IF NOT EXISTS fix_attempts (
                     id INTEGER PRIMARY KEY,
                     run_id TEXT NOT NULL,
@@ -131,7 +139,7 @@ class MemoryStore:
         with sqlite3.connect(self.db_path) as conn:
             conn.execute(
                 "UPDATE runs SET status = ?, completed_at = ? WHERE run_id = ?",
-                (status, datetime.now().isoformat() if status in ["completed", "failed"] else None, run_id)
+                (status, datetime.now().isoformat() if status in ["completed", "failed", "rejected"] else None, run_id)
             )
 
     def load_run(self, run_id: str) -> Optional[Dict]:
@@ -231,6 +239,42 @@ class MemoryStore:
         with sqlite3.connect(self.db_path) as conn:
             row = conn.execute("SELECT value FROM project_facts WHERE key = ?", (key,)).fetchone()
             return json.loads(row[0]) if row else None
+
+    def list_project_facts(self) -> dict:
+        if not self.enabled:
+            return {}
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute("SELECT key, value FROM project_facts ORDER BY key").fetchall()
+        return {key: json.loads(value) for key, value in rows}
+
+    def save_project_note(self, note_type: str, content: str) -> None:
+        if not self.enabled:
+            return
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "INSERT INTO project_notes (note_type, content) VALUES (?, ?)",
+                (note_type, content),
+            )
+
+    def load_recent_project_notes(self, limit: int = 10) -> list[dict]:
+        if not self.enabled:
+            return []
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute(
+                "SELECT note_type, content, created_at FROM project_notes ORDER BY id DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        return [
+            {"note_type": row[0], "content": row[1], "created_at": row[2]}
+            for row in rows
+        ]
+
+    def build_repo_context_summary(self, limit: int = 5) -> dict:
+        return {
+            "project_facts": self.list_project_facts(),
+            "recent_notes": self.load_recent_project_notes(limit=limit),
+            "recent_runs": self.list_recent_runs(limit=limit),
+        }
 
     def save_fix_attempt(self, run_id: str, attempt_no: int, summary: Any) -> None:
         if not self.enabled:


### PR DESCRIPTION
## Summary
This PR starts Wave D on top of the current master after Wave C.

## What is included
- worker orchestration and concurrency v2:
  - queue worker slots
  - max concurrency controls
  - active worker visibility
  - requeue lifecycle support
- approval continuation flow v3:
  - explicit continuation boundaries
  - richer continuation status handling
  - re-pause on the next approval checkpoint
- repo-aware planning and memory v2:
  - project notes
  - repo context summary
  - API/dashboard exposure for reusable project context
- Wave D tests for workers, approval continuation, and repo-aware memory

## Related issues
- #30 Wave D: Worker orchestration and concurrency v2
- #31 Wave D: Approval continuation flow v3
- #32 Wave D: Repo-aware planning and memory v2

## Notes
This is the first Wave D pass. The goal is to make execution flow more reliable and to reduce repeated rediscovery of project context across runs.
