### PR TITLE
Router hardening v2: add session reuse, retries, and provider health

### DIFF
--- a/tests/test_router_hardening_v2.py
+++ b/tests/test_router_hardening_v2.py
@@ -1,0 +1,81 @@
+import unittest
+from unittest.mock import patch
+
+import aiohttp
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.models.router import ModelRouter, ProviderRequestError
+
+
+class RouterHardeningV2Tests(unittest.IsolatedAsyncioTestCase):
+    async def test_route_fallback_records_provider_health(self):
+        settings = Settings(openai_api_key="x", openrouter_api_key="y")
+
+        class FakeRouter(ModelRouter):
+            async def call_openai(self, prompt: str, task_type: str):
+                raise ProviderRequestError("boom")
+
+            async def call_openrouter(self, prompt: str, task_type: str):
+                return {
+                    "choices": [{"message": {"content": "ok"}}],
+                    "usage": {"total_tokens": 1},
+                    "model": "fake-openrouter",
+                }
+
+        router = FakeRouter(settings)
+        result = await router.route("planning", "hello")
+        self.assertEqual(result["provider"], "openrouter")
+        self.assertEqual(router.get_provider_health()["openai"]["failures"], 1)
+        self.assertEqual(router.get_provider_health()["openrouter"]["successes"], 1)
+        await router.close()
+
+    async def test_cooldown_skips_failed_provider(self):
+        settings = Settings(openai_api_key="x", openrouter_api_key="y", provider_health_cooldown_seconds=60)
+
+        class FakeRouter(ModelRouter):
+            def __init__(self, settings):
+                super().__init__(settings)
+                self.calls = []
+
+            async def call_openai(self, prompt: str, task_type: str):
+                self.calls.append("openai")
+                raise ProviderRequestError("boom")
+
+            async def call_openrouter(self, prompt: str, task_type: str):
+                self.calls.append("openrouter")
+                return {
+                    "choices": [{"message": {"content": "ok"}}],
+                    "usage": {},
+                    "model": "fake-openrouter",
+                }
+
+        router = FakeRouter(settings)
+        router._record_provider_failure("openai", "boom")
+        result = await router.route("planning", "hello")
+        self.assertEqual(result["provider"], "openrouter")
+        self.assertEqual(router.calls, ["openrouter"])
+        await router.close()
+
+    async def test_session_is_reused(self):
+        settings = Settings()
+        created = []
+
+        class DummySession:
+            def __init__(self, *args, **kwargs):
+                self.closed = False
+                created.append(self)
+
+            async def close(self):
+                self.closed = True
+
+        router = ModelRouter(settings)
+        with patch.object(aiohttp, "ClientSession", DummySession):
+            first = await router._get_session()
+            second = await router._get_session()
+            self.assertIs(first, second)
+            self.assertEqual(len(created), 1)
+            await router.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/velocity_claw/config/settings.py
+++ b/velocity_claw/config/settings.py
@@ -51,6 +51,10 @@ class Settings:
     git_enabled: bool = True
     dry_run: bool = False
     execution_profile: str = "safe"
+    provider_request_timeout_seconds: int = 60
+    provider_max_retries: int = 2
+    provider_retry_backoff_ms: int = 250
+    provider_health_cooldown_seconds: int = 30
 
     def __post_init__(self):
         self.env = os.getenv("ENV", self.env)
@@ -81,6 +85,10 @@ class Settings:
         self.git_enabled = parse_bool(os.getenv("GIT_ENABLED"), self.git_enabled)
         self.dry_run = parse_bool(os.getenv("DRY_RUN"), self.dry_run)
         self.execution_profile = os.getenv("EXECUTION_PROFILE", self.execution_profile)
+        self.provider_request_timeout_seconds = int(os.getenv("PROVIDER_REQUEST_TIMEOUT_SECONDS", self.provider_request_timeout_seconds))
+        self.provider_max_retries = int(os.getenv("PROVIDER_MAX_RETRIES", self.provider_max_retries))
+        self.provider_retry_backoff_ms = int(os.getenv("PROVIDER_RETRY_BACKOFF_MS", self.provider_retry_backoff_ms))
+        self.provider_health_cooldown_seconds = int(os.getenv("PROVIDER_HEALTH_COOLDOWN_SECONDS", self.provider_health_cooldown_seconds))
 
     @property
     def provider_order(self) -> List[str]:

--- a/velocity_claw/models/router.py
+++ b/velocity_claw/models/router.py
@@ -1,4 +1,7 @@
 from typing import Dict, List
+import asyncio
+import time
+
 import aiohttp
 from velocity_claw.config.settings import Settings
 from velocity_claw.logs.logger import get_logger
@@ -20,18 +23,35 @@ class ModelRouter:
     def __init__(self, settings: Settings):
         self.settings = settings
         self.logger = get_logger("velocity_claw.models")
-        self.timeout = aiohttp.ClientTimeout(total=60)
+        self.timeout = aiohttp.ClientTimeout(total=settings.provider_request_timeout_seconds)
+        self._session: aiohttp.ClientSession | None = None
+        self.provider_health: Dict[str, Dict] = {
+            provider: {
+                "failures": 0,
+                "successes": 0,
+                "last_error": None,
+                "last_failure_at": None,
+                "last_success_at": None,
+                "cooldown_until": 0.0,
+            }
+            for provider in settings.provider_order
+        }
 
     async def route(self, task_type: str, prompt: str) -> Dict:
         providers = self._provider_candidates(task_type)
         errors: List[str] = []
         for provider in providers:
+            if self._provider_in_cooldown(provider):
+                self.logger.info("Skipping provider %s because it is in cooldown", provider)
+                continue
             self.logger.info("Routing %s task to provider %s", task_type, provider)
             try:
                 response = await self._call_provider(provider, prompt, task_type)
+                self._record_provider_success(provider)
                 return self._normalize_response(provider, response)
             except (ProviderNotConfiguredError, ProviderRequestError, ProviderResponseError) as e:
                 self.logger.warning("Provider %s failed: %s", provider, e)
+                self._record_provider_failure(provider, str(e))
                 errors.append(f"{provider}: {e}")
                 continue
         raise ProviderRequestError("All providers failed: " + "; ".join(errors) if errors else "No providers available")
@@ -58,6 +78,41 @@ class ModelRouter:
             return True
         return bool(getattr(self.settings, f"{provider}_api_key", None))
 
+    def _provider_in_cooldown(self, provider: str) -> bool:
+        state = self.provider_health.get(provider) or {}
+        return bool(state.get("cooldown_until", 0.0) > time.time())
+
+    def _record_provider_success(self, provider: str) -> None:
+        state = self.provider_health.setdefault(provider, {})
+        state["successes"] = state.get("successes", 0) + 1
+        state["last_success_at"] = time.time()
+        state["last_error"] = None
+        state["cooldown_until"] = 0.0
+
+    def _record_provider_failure(self, provider: str, error: str) -> None:
+        state = self.provider_health.setdefault(provider, {})
+        state["failures"] = state.get("failures", 0) + 1
+        state["last_error"] = error
+        state["last_failure_at"] = time.time()
+        state["cooldown_until"] = time.time() + self.settings.provider_health_cooldown_seconds
+
+    def get_provider_health(self) -> Dict[str, Dict]:
+        snapshot = {}
+        for provider, state in self.provider_health.items():
+            snapshot[provider] = dict(state)
+            snapshot[provider]["in_cooldown"] = self._provider_in_cooldown(provider)
+        return snapshot
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+        self._session = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(timeout=self.timeout)
+        return self._session
+
     async def _call_provider(self, provider: str, prompt: str, task_type: str) -> Dict:
         if provider == "openai":
             return await self.call_openai(prompt, task_type)
@@ -72,15 +127,24 @@ class ModelRouter:
         raise ProviderNotConfiguredError(f"Unknown provider: {provider}")
 
     async def _post_json(self, url: str, *, headers=None, payload=None) -> Dict:
-        try:
-            async with aiohttp.ClientSession(timeout=self.timeout) as session:
+        last_error = None
+        for attempt in range(1, self.settings.provider_max_retries + 2):
+            try:
+                session = await self._get_session()
                 async with session.post(url, headers=headers, json=payload) as response:
                     response.raise_for_status()
                     return await response.json()
-        except aiohttp.ClientResponseError as e:
-            raise ProviderRequestError(f"HTTP {e.status}: {e.message}")
-        except aiohttp.ClientError as e:
-            raise ProviderRequestError(str(e))
+            except aiohttp.ClientResponseError as e:
+                last_error = ProviderRequestError(f"HTTP {e.status}: {e.message}")
+                if e.status < 500:
+                    raise last_error
+            except aiohttp.ClientError as e:
+                last_error = ProviderRequestError(str(e))
+
+            if attempt <= self.settings.provider_max_retries:
+                await asyncio.sleep((self.settings.provider_retry_backoff_ms / 1000.0) * attempt)
+
+        raise last_error or ProviderRequestError("unknown provider request failure")
 
     async def call_openai(self, prompt: str, task_type: str) -> Dict:
         if not self.settings.openai_api_key:


### PR DESCRIPTION
## Summary
This PR strengthens the model routing layer after the recent runtime and CI hardening work.

## What is included
- configurable provider retry and cooldown settings
- `aiohttp` session reuse instead of creating a new session on every request
- retry/backoff for provider requests
- provider health tracking with cooldown for recently failing providers
- tests for fallback behavior, cooldown skipping, and session reuse

## Why
The router was still a meaningful runtime weak point:
- new HTTP session per request
- no retry/backoff
- no provider health memory
- no cooldown for repeatedly failing providers

This PR makes the router more resilient and more production-like for a self-hosted dev-agent runtime.
