### PR TITLE
Patch engine safety v2: add binary guards, size guards, and ambiguity diagnostics

### DIFF
--- a/tests/test_patch_engine_safety_v2.py
+++ b/tests/test_patch_engine_safety_v2.py
@@ -1,0 +1,45 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.tools.patch import PatchEngine, PatchError
+
+
+class PatchEngineSafetyV2Tests(unittest.TestCase):
+    def test_insert_ambiguous_anchor_fails(self):
+        workspace = tempfile.mkdtemp()
+        Path(workspace, "sample.py").write_text("hello\nhello\n")
+        engine = PatchEngine(Settings(workspace_root=workspace))
+        with self.assertRaises(PatchError) as ctx:
+            engine.apply({"op": "insert", "path": "sample.py", "anchor": "hello", "content": "X"})
+        self.assertIn("ambiguous anchor match", str(ctx.exception))
+
+    def test_binary_file_is_rejected(self):
+        workspace = tempfile.mkdtemp()
+        Path(workspace, "sample.bin").write_bytes(b"\x00\xff\x00\xff")
+        engine = PatchEngine(Settings(workspace_root=workspace))
+        with self.assertRaises(PatchError) as ctx:
+            engine.apply({"op": "append", "path": "sample.bin", "content": "text"})
+        self.assertIn("binary file", str(ctx.exception))
+
+    def test_file_too_large_is_rejected(self):
+        workspace = tempfile.mkdtemp()
+        content = "a" * 32
+        Path(workspace, "sample.txt").write_text(content)
+        engine = PatchEngine(Settings(workspace_root=workspace, max_file_size=8))
+        with self.assertRaises(PatchError) as ctx:
+            engine.apply({"op": "append", "path": "sample.txt", "content": "b"})
+        self.assertIn("file too large", str(ctx.exception))
+
+    def test_details_include_match_diagnostics(self):
+        workspace = tempfile.mkdtemp()
+        Path(workspace, "sample.py").write_text("hello\n")
+        engine = PatchEngine(Settings(workspace_root=workspace))
+        result = engine.preview({"op": "insert", "path": "sample.py", "anchor": "hello", "content": " world"})
+        self.assertEqual(result["details"]["anchor_matches"], 1)
+        self.assertEqual(result["details"]["position"], "after")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/velocity_claw/tools/patch.py
+++ b/velocity_claw/tools/patch.py
@@ -53,13 +53,30 @@ class PatchEngine:
             raise PatchError("Patch must include op and path")
 
         resolved = self.fs._validate_path(path)
-        original = self.fs.read(path) if resolved.exists() else ""
-        updated = self._execute_patch(op, original, patch)
+        details = {"resolved_path": str(resolved)}
+        try:
+            original = self.fs.read(path) if resolved.exists() else ""
+        except ValueError as e:
+            message = str(e)
+            if "Binary file detected" in message:
+                raise PatchError("binary file")
+            if "File too large" in message or "Content too large" in message:
+                raise PatchError("file too large")
+            raise PatchError(message)
+
+        updated, patch_details = self._execute_patch(op, original, patch)
+        details.update(patch_details)
         changed = updated != original
         diff = self._make_diff(str(Path(path)), original, updated)
 
         if not preview_only and changed:
-            self.fs.write(path, updated)
+            try:
+                self.fs.write(path, updated)
+            except ValueError as e:
+                message = str(e)
+                if "Content too large" in message or "File too large" in message:
+                    raise PatchError("file too large")
+                raise PatchError(message)
 
         return PatchResult(
             op=op,
@@ -67,23 +84,26 @@ class PatchEngine:
             changed=changed,
             diff=diff,
             preview_only=preview_only,
-            details={"resolved_path": str(resolved)},
+            details=details,
         )
 
-    def _execute_patch(self, op: str, content: str, patch: dict) -> str:
+    def _execute_patch(self, op: str, content: str, patch: dict) -> tuple[str, dict]:
         if op == "insert":
             anchor = patch.get("anchor")
             new_text = patch.get("content", "")
             if anchor is None:
                 raise PatchError("insert requires anchor")
-            if anchor not in content:
+            count = content.count(anchor)
+            if count == 0:
                 raise PatchError("anchor not found")
+            if count > 1:
+                raise PatchError("ambiguous anchor match")
             position = patch.get("position", "after")
             idx = content.find(anchor)
             if position == "before":
-                return content[:idx] + new_text + content[idx:]
+                return content[:idx] + new_text + content[idx:], {"anchor_matches": count, "position": position}
             idx += len(anchor)
-            return content[:idx] + new_text + content[idx:]
+            return content[:idx] + new_text + content[idx:], {"anchor_matches": count, "position": position}
         if op == "replace_block":
             target = patch.get("target")
             replacement = patch.get("replacement")
@@ -96,14 +116,16 @@ class PatchEngine:
                 raise PatchError("target block not found")
             if count > 1:
                 raise PatchError("ambiguous target block match")
-            return content.replace(target, replacement, 1)
+            return content.replace(target, replacement, 1), {"target_matches": count}
         if op == "append":
             new_text = patch.get("content", "")
-            return content + new_text
+            return content + new_text, {"appended_bytes": len(new_text.encode("utf-8"))}
         if op == "replace_function":
-            return self._replace_symbol_block(content, patch.get("name"), "function", patch.get("replacement"))
+            updated = self._replace_symbol_block(content, patch.get("name"), "function", patch.get("replacement"))
+            return updated, {"symbol_kind": "function", "symbol_name": patch.get("name")}
         if op == "replace_class":
-            return self._replace_symbol_block(content, patch.get("name"), "class", patch.get("replacement"))
+            updated = self._replace_symbol_block(content, patch.get("name"), "class", patch.get("replacement"))
+            return updated, {"symbol_kind": "class", "symbol_name": patch.get("name")}
         raise PatchError(f"Unsupported patch op: {op}")
 
     def _replace_symbol_block(self, content: str, name: Optional[str], kind: str, replacement: Optional[str]) -> str:


### PR DESCRIPTION
## Summary
This PR strengthens the patch engine after the recent router/runtime hardening work.

## What is included
- explicit patch errors for binary files
- explicit patch errors for file-too-large cases
- ambiguity detection for `insert` anchor matches
- richer patch diagnostics in `details`
- tests for ambiguous insert, binary rejection, file-too-large rejection, and diagnostics

## Why
The patch engine already had a solid core, but it still lacked some of the safety and diagnosability expected from a stronger self-hosted dev-agent runtime.
