### PR TITLE
Planner repo intelligence v2: inject project memory into planning

### DIFF
--- a/tests/test_planner_repo_intelligence_v2.py
+++ b/tests/test_planner_repo_intelligence_v2.py
@@ -1,0 +1,66 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.core.agent import VelocityClawAgent
+from velocity_claw.memory.store import MemoryStore
+from velocity_claw.models.router import ModelRouter
+from velocity_claw.planner.planner import Planner
+
+
+class PlannerRepoIntelligenceV2Tests(unittest.IsolatedAsyncioTestCase):
+    async def test_memory_builds_planning_context(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        store = MemoryStore(Settings(workspace_root=workspace, memory_db_path=db_path))
+        run_id = store.create_run("fix tests")
+        store.update_run_status(run_id, "failed")
+        store.save_project_fact("language", {"name": "python"})
+        store.save_project_note("convention", "use pytest")
+        context = store.build_planning_context()
+        self.assertIn("project_facts", context)
+        self.assertIn("recent_notes", context)
+        self.assertEqual(context["project_facts"]["language"]["name"], "python")
+        self.assertTrue(context["last_failed_run"])
+
+    async def test_planner_prompt_includes_planning_context(self):
+        settings = Settings()
+        planner = Planner(ModelRouter(settings))
+        prompt = planner._build_plan_prompt(
+            "fix tests",
+            {
+                "project_root": "/repo",
+                "planning_context": {
+                    "project_facts": {"language": {"name": "python"}},
+                    "recent_notes": [{"note_type": "convention", "content": "use pytest"}],
+                    "recent_run_tasks": ["fix tests"],
+                    "recent_failed_tasks": ["fix tests"],
+                    "last_failed_run": {"task": "fix tests", "status": "failed"},
+                },
+            },
+        )
+        self.assertIn("Project facts", prompt)
+        self.assertIn("Recent failed tasks", prompt)
+        self.assertIn("Last failed run", prompt)
+
+    async def test_agent_injects_planning_context_automatically(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        settings = Settings(workspace_root=workspace, memory_db_path=db_path)
+        agent = VelocityClawAgent(settings)
+        captured = {}
+
+        async def fake_plan(task, context=None):
+            captured["context"] = context
+            return {"task": task, "steps": []}
+
+        agent.planner.create_plan = fake_plan
+        result = await agent.run_task("analyze repo")
+        self.assertEqual(result["status"], "failed")
+        self.assertIn("planning_context", captured["context"])
+        self.assertEqual(captured["context"]["project_root"], workspace)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/velocity_claw/core/agent.py
+++ b/velocity_claw/core/agent.py
@@ -35,6 +35,12 @@ class VelocityClawAgent:
             return "workspace_write"
         return "read_only"
 
+    def _build_planning_context(self, context: Optional[Dict]) -> Dict:
+        merged = dict(context or {})
+        merged.setdefault("project_root", self.settings.workspace_root)
+        merged["planning_context"] = self.memory.build_planning_context()
+        return merged
+
     async def run_mode(self, mode: str, task: str, context: Optional[Dict] = None) -> Dict:
         return await self.run_task(build_mode_task(mode, task), context)
 
@@ -45,8 +51,10 @@ class VelocityClawAgent:
         self.memory.save_project_note("task", task)
         try:
             self.logger.info("Run %s: Planning", run_id)
-            plan = await self.planner.create_plan(task, context)
+            planning_context = self._build_planning_context(context)
+            plan = await self.planner.create_plan(task, planning_context)
             self.memory.save_artifact(run_id, "run_plan", json.dumps(plan, ensure_ascii=False), artifact_type="plan")
+            self.memory.save_artifact(run_id, "planning_context", json.dumps(planning_context, ensure_ascii=False), artifact_type="planning_context")
             self.memory.save_project_note("plan_summary", f"Planned {len(plan.get('steps', []))} steps for task: {task}")
             results = []
             for step in plan["steps"]:

--- a/velocity_claw/memory/store.py
+++ b/velocity_claw/memory/store.py
@@ -274,6 +274,22 @@ class MemoryStore:
             "project_facts": self.list_project_facts(),
             "recent_notes": self.load_recent_project_notes(limit=limit),
             "recent_runs": self.list_recent_runs(limit=limit),
+            "last_failed_run": self.get_last_failed_run(),
+        }
+
+    def build_planning_context(self, limit: int = 5) -> dict:
+        recent_notes = self.load_recent_project_notes(limit=limit)
+        recent_runs = self.list_recent_runs(limit=limit)
+        last_failed = self.get_last_failed_run()
+        return {
+            "project_facts": self.list_project_facts(),
+            "recent_notes": recent_notes,
+            "recent_run_tasks": [item["task"] for item in recent_runs],
+            "recent_failed_tasks": [item["task"] for item in recent_runs if item["status"] == "failed"],
+            "last_failed_run": {
+                "task": last_failed["task"],
+                "status": last_failed["status"],
+            } if last_failed else None,
         }
 
     def save_fix_attempt(self, run_id: str, attempt_no: int, summary: Any) -> None:

--- a/velocity_claw/planner/planner.py
+++ b/velocity_claw/planner/planner.py
@@ -74,7 +74,7 @@ class Planner:
             "Для каждого шага укажи:",
             "- id: уникальный номер",
             "- title: краткое описание",
-            "- tool: инструмент (fs.read, fs.write, git.run, shell.run, http.get, analysis)",
+            "- tool: инструмент (fs.read, fs.write, git.run, shell.run, http.get, analysis, patch.apply, test.run)",
             "- args: аргументы для инструмента",
             "- expected_output: ожидаемый результат",
             "Верни только валидный JSON без лишнего текста.",
@@ -82,6 +82,25 @@ class Planner:
         ]
         if context.get("project_root"):
             instructions.append(f"Проект: {context['project_root']}")
+        planning_context = context.get("planning_context") or {}
+        if planning_context:
+            instructions.append("Учитывай известный контекст проекта и недавнюю историю запусков.")
+            project_facts = planning_context.get("project_facts") or {}
+            if project_facts:
+                instructions.append(f"Project facts: {json.dumps(project_facts, ensure_ascii=False)}")
+            recent_tasks = planning_context.get("recent_run_tasks") or []
+            if recent_tasks:
+                instructions.append(f"Recent run tasks: {json.dumps(recent_tasks, ensure_ascii=False)}")
+            recent_failed = planning_context.get("recent_failed_tasks") or []
+            if recent_failed:
+                instructions.append(f"Recent failed tasks: {json.dumps(recent_failed, ensure_ascii=False)}")
+            recent_notes = planning_context.get("recent_notes") or []
+            if recent_notes:
+                compact_notes = [f"{item.get('note_type')}: {item.get('content')}" for item in recent_notes[:5]]
+                instructions.append(f"Recent project notes: {json.dumps(compact_notes, ensure_ascii=False)}")
+            last_failed = planning_context.get("last_failed_run")
+            if last_failed:
+                instructions.append(f"Last failed run: {json.dumps(last_failed, ensure_ascii=False)}")
         return "\n".join(instructions)
 
     def _parse_plan(self, response: str) -> Plan:


### PR DESCRIPTION
## Summary
This PR strengthens the planning layer by making it automatically aware of repo and project memory context.

## What is included
- planning-focused repo memory summary
- automatic planning context injection from agent runtime
- planner prompt enrichment with:
  - project facts
  - recent notes
  - recent run tasks
  - recent failed tasks
  - last failed run
- planning context artifact persistence
- tests for planning context generation, prompt enrichment, and agent-side injection

## Why
The runtime and execution layers have become much stronger, but planning still needed better awareness of the project and recent execution history. This PR makes planning more context-aware without adding unnecessary complexity.
