### PR TITLE
Resume memory intelligence v3: track prior fix attempts and expose resume context

### DIFF
--- a/tests/test_resume_memory_intelligence_v3.py
+++ b/tests/test_resume_memory_intelligence_v3.py
@@ -1,0 +1,75 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from velocity_claw.api.server import create_app
+from velocity_claw.config.settings import Settings
+from velocity_claw.memory.store import MemoryStore
+
+
+class ResumeMemoryIntelligenceV3Tests(unittest.IsolatedAsyncioTestCase):
+    async def test_memory_builds_resume_context_with_fix_attempts(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        store = MemoryStore(Settings(workspace_root=workspace, memory_db_path=db_path))
+        run_id = store.create_run("fix tests")
+        store.update_run_status(run_id, "failed")
+        store.save_fix_attempt(run_id, 1, {"summary": "tried patch A"})
+        store.save_project_note("note", "watch flaky tests")
+        ctx = store.build_resume_context("fix tests")
+        self.assertEqual(ctx["task"], "fix tests")
+        self.assertTrue(ctx["related_runs"])
+        self.assertTrue(ctx["recent_fix_attempts"])
+        self.assertTrue(ctx["recent_notes"])
+
+    async def test_agent_persists_resume_context_artifact(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        settings = Settings(workspace_root=workspace, memory_db_path=db_path)
+
+        with patch("velocity_claw.api.server.load_settings", return_value=settings):
+            app = create_app()
+            agent = app.state.agent
+
+            async def fake_plan(task, context=None):
+                return {"task": task, "steps": []}
+
+            agent.planner.create_plan = fake_plan
+            result = await agent.run_task("analyze repo")
+            self.assertEqual(result["status"], "failed")
+            run = agent.memory.load_run(result["run_id"])
+            names = [a["name"] for a in run["artifacts"]]
+            self.assertIn("resume_context", names)
+
+    async def test_resume_context_routes(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        settings = Settings(workspace_root=workspace, memory_db_path=db_path)
+
+        with patch("velocity_claw.api.server.load_settings", return_value=settings):
+            app = create_app()
+            client = TestClient(app)
+            run_id = app.state.agent.memory.create_run("fix tests")
+            app.state.agent.memory.save_fix_attempt(run_id, 1, {"summary": "tried patch A"})
+            app.state.agent.memory.save_artifact(
+                run_id,
+                "resume_context",
+                '{"task": "fix tests", "recent_fix_attempts": [{"attempt_no": 1}]}',
+                artifact_type="resume_context",
+            )
+
+            response = client.get(f"/runs/{run_id}/resume-context")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json()["run_id"], run_id)
+            self.assertIn("resume_context", response.json())
+
+            dashboard = client.get("/dashboard")
+            self.assertEqual(dashboard.status_code, 200)
+            self.assertIn("Resume context", dashboard.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/velocity_claw/api/server.py
+++ b/velocity_claw/api/server.py
@@ -108,9 +108,9 @@ def create_app() -> FastAPI:
             grouped.setdefault(key, []).append(artifact)
         return grouped
 
-    def load_planning_context(run_data: dict) -> Optional[dict]:
+    def load_artifact_json(run_data: dict, artifact_name: str) -> Optional[dict]:
         for artifact in run_data.get("artifacts", []):
-            if artifact.get("name") == "planning_context":
+            if artifact.get("name") == artifact_name:
                 try:
                     return json.loads(artifact.get("content") or "{}")
                 except json.JSONDecodeError:
@@ -189,6 +189,10 @@ def create_app() -> FastAPI:
     @app.get("/memory/context")
     def memory_context():
         return app.state.agent.get_repo_context_summary()
+
+    @app.get("/memory/resume")
+    def memory_resume(task: str):
+        return app.state.agent.get_resume_context(task)
 
     @app.post("/queue/submit")
     @limiter.limit("10/minute")
@@ -295,10 +299,20 @@ def create_app() -> FastAPI:
         data = app.state.agent.memory.load_run(run_id)
         if not data:
             raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Run not found"})
-        planning_context = load_planning_context(data)
+        planning_context = load_artifact_json(data, "planning_context")
         if planning_context is None:
             raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Planning context not found"})
         return {"run_id": run_id, "planning_context": planning_context}
+
+    @app.get("/runs/{run_id}/resume-context")
+    def run_resume_context(run_id: str):
+        data = app.state.agent.memory.load_run(run_id)
+        if not data:
+            raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Run not found"})
+        resume_context = load_artifact_json(data, "resume_context")
+        if resume_context is None:
+            raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Resume context not found"})
+        return {"run_id": run_id, "resume_context": resume_context}
 
     @app.get("/runs/{run_id}/view", response_class=HTMLResponse)
     def run_detail_view(run_id: str):
@@ -306,7 +320,8 @@ def create_app() -> FastAPI:
         if not data:
             raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Run not found"})
         grouped = group_artifacts(data)
-        planning_context = load_planning_context(data)
+        planning_context = load_artifact_json(data, "planning_context")
+        resume_context = load_artifact_json(data, "resume_context")
         body = [
             "<html><body style='font-family:Arial,sans-serif;max-width:1100px;margin:24px auto;padding:0 16px'>",
             f"<h1>Run detail: {run_id}</h1>",
@@ -325,6 +340,11 @@ def create_app() -> FastAPI:
             body.append(f"<pre>{json.dumps(planning_context, ensure_ascii=False, indent=2)[:2000]}</pre>")
         else:
             body.append("<p>No planning context artifact recorded for this run.</p>")
+        body.append("<h2>Resume context</h2>")
+        if resume_context:
+            body.append(f"<pre>{json.dumps(resume_context, ensure_ascii=False, indent=2)[:2000]}</pre>")
+        else:
+            body.append("<p>No resume context artifact recorded for this run.</p>")
         body.append("<h2>Approval history</h2><ul>")
         for item in data.get("approval_history", []):
             body.append(f"<li>step {item['step_id']} — {item['decision']} — actor: {item.get('actor') or 'n/a'} — reason: {item.get('reason') or 'n/a'}</li>")
@@ -378,7 +398,7 @@ def create_app() -> FastAPI:
             "<h1>Velocity Claw Dashboard</h1>",
             f"<p>Execution profile: <b>{app.state.settings.execution_profile}</b></p>",
             f"<p>Queue concurrency: <b>{app.state.queue.max_concurrency}</b> | Active workers: <b>{app.state.queue.active_count()}</b></p>",
-            "<p>Quick links: <a href='/status'>/status</a> | <a href='/metrics'>/metrics</a> | <a href='/diagnostics'>/diagnostics</a> | <a href='/memory/context'>/memory/context</a> | <a href='/providers/health'>/providers/health</a> | <a href='/runs'>/runs</a> | <a href='/approvals'>/approvals</a> | <a href='/profiles'>/profiles</a> | <a href='/queue'>/queue</a></p>",
+            "<p>Quick links: <a href='/status'>/status</a> | <a href='/metrics'>/metrics</a> | <a href='/diagnostics'>/diagnostics</a> | <a href='/memory/context'>/memory/context</a> | <a href='/memory/resume?task=fix'>/memory/resume</a> | <a href='/providers/health'>/providers/health</a> | <a href='/runs'>/runs</a> | <a href='/approvals'>/approvals</a> | <a href='/profiles'>/profiles</a> | <a href='/queue'>/queue</a></p>",
             "<h2>Metrics</h2>",
             "<ul>",
         ]
@@ -405,7 +425,7 @@ def create_app() -> FastAPI:
         body.append("</table>")
 
         body.append("<h2>Repo context summary</h2>")
-        body.append(f"<p>Project facts: <b>{len(repo_context.get('project_facts', {}))}</b> | Recent notes: <b>{len(repo_context.get('recent_notes', []))}</b></p>")
+        body.append(f"<p>Project facts: <b>{len(repo_context.get('project_facts', {}))}</b> | Recent notes: <b>{len(repo_context.get('recent_notes', []))}</b> | Recent fix attempts: <b>{len(repo_context.get('recent_fix_attempts', []))}</b></p>")
 
         body.append("<h2>Active profile matrix</h2>")
         body.append(f"<p>{profile['description']}</p>")
@@ -426,16 +446,16 @@ def create_app() -> FastAPI:
 
         body.append("<h2>Recent runs</h2>")
         body.append("<table border='1' cellpadding='6' cellspacing='0' style='border-collapse:collapse;width:100%'>")
-        body.append("<tr><th>Run ID</th><th>Task</th><th>Status</th><th>Created</th><th>View</th><th>Planning context</th></tr>")
+        body.append("<tr><th>Run ID</th><th>Task</th><th>Status</th><th>Created</th><th>View</th><th>Planning context</th><th>Resume context</th></tr>")
         for run in recent:
             body.append(
-                f"<tr><td><code>{run['run_id']}</code></td><td>{run['task']}</td><td>{badge(run['status'])}</td><td>{run['created_at']}</td><td><a href='/runs/{run['run_id']}/view'>open</a></td><td><a href='/runs/{run['run_id']}/planning-context'>json</a></td></tr>"
+                f"<tr><td><code>{run['run_id']}</code></td><td>{run['task']}</td><td>{badge(run['status'])}</td><td>{run['created_at']}</td><td><a href='/runs/{run['run_id']}/view'>open</a></td><td><a href='/runs/{run['run_id']}/planning-context'>json</a></td><td><a href='/runs/{run['run_id']}/resume-context'>json</a></td></tr>"
             )
         body.append("</table>")
 
         body.append("<h2>Last failed run</h2>")
         if last_failed:
-            body.append(f"<p><code>{last_failed['run_id']}</code> — {last_failed['task']} — {badge(last_failed['status'])} — <a href='/runs/{last_failed['run_id']}/view'>details</a> — <a href='/runs/{last_failed['run_id']}/planning-context'>planning context</a></p>")
+            body.append(f"<p><code>{last_failed['run_id']}</code> — {last_failed['task']} — {badge(last_failed['status'])} — <a href='/runs/{last_failed['run_id']}/view'>details</a> — <a href='/runs/{last_failed['run_id']}/planning-context'>planning context</a> — <a href='/runs/{last_failed['run_id']}/resume-context'>resume context</a></p>")
         else:
             body.append("<p>No failed runs recorded.</p>")
 

--- a/velocity_claw/core/agent.py
+++ b/velocity_claw/core/agent.py
@@ -52,9 +52,11 @@ class VelocityClawAgent:
         try:
             self.logger.info("Run %s: Planning", run_id)
             planning_context = self._build_planning_context(context)
+            resume_context = self.memory.build_resume_context(task)
             plan = await self.planner.create_plan(task, planning_context)
             self.memory.save_artifact(run_id, "run_plan", json.dumps(plan, ensure_ascii=False), artifact_type="plan")
             self.memory.save_artifact(run_id, "planning_context", json.dumps(planning_context, ensure_ascii=False), artifact_type="planning_context")
+            self.memory.save_artifact(run_id, "resume_context", json.dumps(resume_context, ensure_ascii=False), artifact_type="resume_context")
             self.memory.save_project_note("plan_summary", f"Planned {len(plan.get('steps', []))} steps for task: {task}")
             results = []
             for step in plan["steps"]:
@@ -195,6 +197,9 @@ class VelocityClawAgent:
 
     def get_repo_context_summary(self) -> dict:
         return self.memory.build_repo_context_summary()
+
+    def get_resume_context(self, task: str) -> dict:
+        return self.memory.build_resume_context(task)
 
     async def approve_step(self, run_id: str, step_id: int, actor: str = "owner", reason: str | None = None) -> dict:
         payload = {

--- a/velocity_claw/memory/store.py
+++ b/velocity_claw/memory/store.py
@@ -275,6 +275,7 @@ class MemoryStore:
             "recent_notes": self.load_recent_project_notes(limit=limit),
             "recent_runs": self.list_recent_runs(limit=limit),
             "last_failed_run": self.get_last_failed_run(),
+            "recent_fix_attempts": self.list_recent_fix_attempts(limit=limit),
         }
 
     def build_planning_context(self, limit: int = 5) -> dict:
@@ -290,6 +291,25 @@ class MemoryStore:
                 "task": last_failed["task"],
                 "status": last_failed["status"],
             } if last_failed else None,
+            "recent_fix_attempts": self.list_recent_fix_attempts(limit=limit),
+        }
+
+    def build_resume_context(self, task: str, limit: int = 5) -> dict:
+        recent_runs = self.list_recent_runs(limit=20)
+        related_runs = [item for item in recent_runs if task.lower() in item["task"].lower()][:limit]
+        related_failed = [item for item in related_runs if item["status"] == "failed"]
+        last_failed = self.get_last_failed_run()
+        return {
+            "task": task,
+            "related_runs": related_runs,
+            "related_failed_runs": related_failed,
+            "last_failed_run": {
+                "run_id": last_failed["run_id"],
+                "task": last_failed["task"],
+                "status": last_failed["status"],
+            } if last_failed else None,
+            "recent_fix_attempts": self.list_recent_fix_attempts(limit=limit),
+            "recent_notes": self.load_recent_project_notes(limit=limit),
         }
 
     def save_fix_attempt(self, run_id: str, attempt_no: int, summary: Any) -> None:
@@ -312,6 +332,24 @@ class MemoryStore:
             ).fetchall()
         return [
             {"attempt_no": r[0], "summary": json.loads(r[1]) if r[1] else None, "created_at": r[2]}
+            for r in rows
+        ]
+
+    def list_recent_fix_attempts(self, limit: int = 10):
+        if not self.enabled:
+            return []
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute(
+                "SELECT run_id, attempt_no, summary, created_at FROM fix_attempts ORDER BY id DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        return [
+            {
+                "run_id": r[0],
+                "attempt_no": r[1],
+                "summary": json.loads(r[2]) if r[2] else None,
+                "created_at": r[3],
+            }
             for r in rows
         ]
 


### PR DESCRIPTION
## Summary
This PR strengthens the memory and resume layer so the agent can better understand what was already tried and expose that context for later runs and operator inspection.

## What is included
- resume-context memory summaries
- recent fix-attempt summaries in repo/memory context
- resume-context artifact persistence during runs
- API endpoints for resume memory inspection
- dashboard and run-detail resume-context visibility
- tests for resume-context generation, artifact persistence, API routes, and dashboard visibility

## Why
The project already had strong artifacts, planning context, and run history, but it still needed a clearer way to capture and expose what had already been attempted across failed or iterative work. This PR improves that layer without adding unnecessary abstraction.
