### PR TITLE
Release readiness and packaging v1: add packaging checks and readiness endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Velocity Claw — self-hosted AI dev-agent с модульной архитек�
 - `memory/store.py` — runs, steps, artifacts, preferences, project facts, fix attempts
 - `security/policy.py` — workspace/path/url/command validation
 - `security/access.py` — execution profiles + approval classification
+- `core/release.py` — release readiness evaluation
 
 ### Code / Dev-Agent слой
 - `tools/patch.py` — patch engine:
@@ -59,11 +60,12 @@ Velocity Claw — self-hosted AI dev-agent с модульной архитек�
 - dashboard foundation (`/dashboard`)
 - queue foundation (`/queue/submit`, `/queue/{job_id}`)
 - metrics foundation (`/metrics`)
+- release readiness endpoint (`/release/readiness`)
 
 ### Tools
 - `tools/fs.py` — filesystem operations
 - `tools/shell.py` — safe shell execution
-- `tools/git.py` — restricted git execution
+- `tools/git.py` — restricted git execution + safe repo inspection
 - `tools/http.py` — HTTP GET/POST with allowlist and limits
 - `tools/docker.py` — docker command wrapper foundation
 - `tools/editor.py` — helper text editor utilities
@@ -157,12 +159,37 @@ docker run --env-file .env -p 8000:8000 velocity-claw
 
 ---
 
+## Release readiness
+
+Теперь в проекте есть отдельный readiness layer:
+
+```bash
+curl http://127.0.0.1:8000/release/readiness
+```
+
+Он показывает:
+- есть ли ключевые packaging/runtime файлы
+- есть ли тесты
+- есть ли CLI/API entrypoints
+- есть ли blocking issues
+- есть ли warnings
+- какие packaging targets сейчас реально готовы:
+  - CLI
+  - API
+  - Docker
+  - Telegram
+
+Это удобно для быстрой проверки перед упаковкой, Docker build или публикацией очередного релиза.
+
+---
+
 ## Основные API endpoints
 
-### Health / metrics
+### Health / metrics / release
 ```bash
 curl http://127.0.0.1:8000/health
 curl http://127.0.0.1:8000/metrics
+curl http://127.0.0.1:8000/release/readiness
 ```
 
 ### Run task
@@ -218,7 +245,7 @@ pytest -q
 velocity_claw/
   api/            FastAPI server
   config/         settings / env loading
-  core/           agent, queue, modes, metrics, auto_fix
+  core/           agent, queue, modes, metrics, auto_fix, release
   executor/       tool dispatch
   logs/           logger
   memory/         SQLite run/step/artifact/project facts store

--- a/tests/test_release_readiness_packaging_v1.py
+++ b/tests/test_release_readiness_packaging_v1.py
@@ -1,0 +1,63 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from velocity_claw.api.server import create_app
+from velocity_claw.config.settings import Settings
+from velocity_claw.core.release import ReleaseReadinessEvaluator
+
+
+class ReleaseReadinessPackagingV1Tests(unittest.TestCase):
+    def test_release_evaluator_reports_readiness_shape(self):
+        workspace = tempfile.mkdtemp()
+        Path(workspace, "README.md").write_text("# Demo\n")
+        Path(workspace, "requirements.txt").write_text("fastapi\n")
+        Path(workspace, "Dockerfile").write_text("FROM python:3.12-slim\n")
+        Path(workspace, ".env.example").write_text("OPENAI_API_KEY=\n")
+        Path(workspace, "cli.py").write_text("print('ok')\n")
+        (Path(workspace) / "velocity_claw" / "api").mkdir(parents=True)
+        (Path(workspace) / "velocity_claw" / "telegram_bot").mkdir(parents=True)
+        (Path(workspace) / "tests").mkdir(parents=True)
+        Path(workspace, "velocity_claw", "api", "server.py").write_text("app = None\n")
+        Path(workspace, "velocity_claw", "telegram_bot", "bot.py").write_text("bot = None\n")
+        Path(workspace, "tests", "test_demo.py").write_text("def test_ok():\n    assert True\n")
+
+        evaluator = ReleaseReadinessEvaluator(Settings(workspace_root=workspace))
+        result = evaluator.evaluate()
+        self.assertIn("readiness", result)
+        self.assertIn("checks", result)
+        self.assertIn("packaging_targets", result)
+        self.assertEqual(result["readiness"], "ready")
+
+    def test_release_readiness_route_and_dashboard(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        settings = Settings(workspace_root=workspace, memory_db_path=db_path)
+
+        with patch("velocity_claw.api.server.load_settings", return_value=settings):
+            app = create_app()
+            client = TestClient(app)
+            with patch.object(app.state.release, "evaluate", return_value={
+                "readiness": "ready",
+                "score": 8,
+                "total_checks": 10,
+                "checks": {"readme_present": True},
+                "blocking_issues": [],
+                "warnings": ["Dockerfile missing"],
+                "packaging_targets": {"cli": True, "api": True, "docker": False, "telegram": True},
+            }):
+                response = client.get("/release/readiness")
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.json()["readiness"], "ready")
+
+                dashboard = client.get("/dashboard")
+                self.assertEqual(dashboard.status_code, 200)
+                self.assertIn("Release readiness", dashboard.text)
+                self.assertIn("Score", dashboard.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/velocity_claw/api/server.py
+++ b/velocity_claw/api/server.py
@@ -12,6 +12,7 @@ from velocity_claw.config.settings import load_settings
 from velocity_claw.core.agent import VelocityClawAgent
 from velocity_claw.core.queue import RunQueue
 from velocity_claw.core.metrics import MetricsRegistry
+from velocity_claw.core.release import ReleaseReadinessEvaluator
 from velocity_claw.logs.logger import get_logger
 from velocity_claw.security.policy import SecurityViolationError
 from velocity_claw.security.access import ExecutionProfileManager
@@ -94,6 +95,7 @@ def create_app() -> FastAPI:
     app.state.queue = RunQueue(db_path=f"{settings.memory_db_path}.queue", max_concurrency=2)
     app.state.metrics = MetricsRegistry()
     app.state.profiles = ExecutionProfileManager(settings)
+    app.state.release = ReleaseReadinessEvaluator(settings)
     app.state.limiter = limiter
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
@@ -126,6 +128,10 @@ def create_app() -> FastAPI:
     def health():
         refresh_runtime_metrics()
         return {"status": "ok", "metrics": app.state.metrics.snapshot()}
+
+    @app.get("/release/readiness")
+    def release_readiness():
+        return app.state.release.evaluate()
 
     @app.post("/task", response_model=TaskResponse)
     @limiter.limit("10/minute")
@@ -403,6 +409,7 @@ def create_app() -> FastAPI:
         queue_jobs = app.state.queue.list_jobs()[:10]
         provider_health = app.state.agent.router.get_provider_health()
         git_state = app.state.agent.executor.git.inspect_repo()
+        release_state = app.state.release.evaluate()
 
         def badge(status: str) -> str:
             return f"<span style='padding:2px 8px;border-radius:999px;border:1px solid #999'>{status}</span>"
@@ -412,7 +419,10 @@ def create_app() -> FastAPI:
             "<h1>Velocity Claw Dashboard</h1>",
             f"<p>Execution profile: <b>{app.state.settings.execution_profile}</b></p>",
             f"<p>Queue concurrency: <b>{app.state.queue.max_concurrency}</b> | Active workers: <b>{app.state.queue.active_count()}</b></p>",
-            "<p>Quick links: <a href='/status'>/status</a> | <a href='/metrics'>/metrics</a> | <a href='/diagnostics'>/diagnostics</a> | <a href='/git/summary'>/git/summary</a> | <a href='/memory/context'>/memory/context</a> | <a href='/memory/resume?task=fix'>/memory/resume</a> | <a href='/providers/health'>/providers/health</a> | <a href='/runs'>/runs</a> | <a href='/approvals'>/approvals</a> | <a href='/profiles'>/profiles</a> | <a href='/queue'>/queue</a></p>",
+            "<p>Quick links: <a href='/status'>/status</a> | <a href='/metrics'>/metrics</a> | <a href='/diagnostics'>/diagnostics</a> | <a href='/release/readiness'>/release/readiness</a> | <a href='/git/summary'>/git/summary</a> | <a href='/memory/context'>/memory/context</a> | <a href='/memory/resume?task=fix'>/memory/resume</a> | <a href='/providers/health'>/providers/health</a> | <a href='/runs'>/runs</a> | <a href='/approvals'>/approvals</a> | <a href='/profiles'>/profiles</a> | <a href='/queue'>/queue</a></p>",
+            "<h2>Release readiness</h2>",
+            f"<p>Status: <b>{release_state.get('readiness')}</b> | Score: <b>{release_state.get('score')}/{release_state.get('total_checks')}</b></p>",
+            f"<p>Blocking issues: <b>{len(release_state.get('blocking_issues', []))}</b> | Warnings: <b>{len(release_state.get('warnings', []))}</b></p>",
             "<h2>Git summary</h2>",
             f"<p>Branch: <b>{git_state.get('branch') or ''}</b> | Clean: <b>{git_state.get('is_clean')}</b></p>",
             f"<pre>{(git_state.get('diff_stat') or '(no diff)')[:1500]}</pre>",

--- a/velocity_claw/core/release.py
+++ b/velocity_claw/core/release.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+from velocity_claw.config.settings import Settings
+
+
+class ReleaseReadinessEvaluator:
+    def __init__(self, settings: Settings):
+        self.settings = settings
+        self.repo_root = Path(settings.workspace_root).resolve()
+
+    def evaluate(self) -> Dict:
+        checks = {
+            "readme_present": self._exists("README.md"),
+            "requirements_present": self._exists("requirements.txt"),
+            "dockerfile_present": self._exists("Dockerfile"),
+            "env_example_present": self._exists(".env.example"),
+            "cli_entrypoint_present": self._exists("cli.py"),
+            "api_server_present": self._exists("velocity_claw/api/server.py"),
+            "telegram_bot_present": self._exists("velocity_claw/telegram_bot/bot.py"),
+            "tests_present": self._has_tests(),
+            "memory_enabled": bool(self.settings.memory_enabled),
+            "safe_mode_configured": self.settings.safe_mode is not None,
+        }
+        blocking_issues: List[str] = []
+        warnings: List[str] = []
+
+        if not checks["readme_present"]:
+            blocking_issues.append("README.md missing")
+        if not checks["requirements_present"]:
+            blocking_issues.append("requirements.txt missing")
+        if not checks["env_example_present"]:
+            blocking_issues.append(".env.example missing")
+        if not checks["cli_entrypoint_present"]:
+            blocking_issues.append("cli.py missing")
+        if not checks["api_server_present"]:
+            blocking_issues.append("api server missing")
+        if not checks["tests_present"]:
+            blocking_issues.append("tests missing")
+        if not checks["dockerfile_present"]:
+            warnings.append("Dockerfile missing")
+        if not checks["telegram_bot_present"]:
+            warnings.append("telegram bot interface missing")
+        if not checks["memory_enabled"]:
+            warnings.append("memory disabled in current configuration")
+
+        score = sum(1 for value in checks.values() if value)
+        total = len(checks)
+        readiness = "ready" if not blocking_issues else "not_ready"
+        return {
+            "readiness": readiness,
+            "score": score,
+            "total_checks": total,
+            "checks": checks,
+            "blocking_issues": blocking_issues,
+            "warnings": warnings,
+            "packaging_targets": {
+                "cli": checks["cli_entrypoint_present"],
+                "api": checks["api_server_present"],
+                "docker": checks["dockerfile_present"],
+                "telegram": checks["telegram_bot_present"],
+            },
+        }
+
+    def _exists(self, relative_path: str) -> bool:
+        return (self.repo_root / relative_path).exists()
+
+    def _has_tests(self) -> bool:
+        tests_dir = self.repo_root / "tests"
+        if not tests_dir.exists() or not tests_dir.is_dir():
+            return False
+        return any(path.suffix == ".py" for path in tests_dir.rglob("*.py"))


### PR DESCRIPTION
## Summary
This PR adds a release-readiness layer so the project can report whether key packaging and delivery prerequisites are present.

## What is included
- `ReleaseReadinessEvaluator`
- `/release/readiness` API endpoint
- dashboard visibility for release readiness
- README updates documenting the readiness layer
- tests for evaluator output, API route, and dashboard rendering

## Why
The project already had strong runtime and operator layers, but it still lacked a concrete readiness view for packaging and release workflows. This PR adds that missing release-facing visibility without pretending the system is more production-ready than it really is.
