### PR TITLE
Planner and executor autonomy v3: inspection-first planning guidance

### DIFF
--- a/tests/test_planner_executor_autonomy_v3.py
+++ b/tests/test_planner_executor_autonomy_v3.py
@@ -1,0 +1,37 @@
+import unittest
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.models.router import ModelRouter
+from velocity_claw.planner.planner import Planner
+
+
+class PlannerExecutorAutonomyV3Tests(unittest.TestCase):
+    def test_planner_prompt_includes_inspection_first_guidance(self):
+        planner = Planner(ModelRouter(Settings()))
+        prompt = planner._build_plan_prompt(
+            "fix failing tests in repo",
+            {
+                "project_root": "/repo",
+                "planning_context": {
+                    "recent_failed_tasks": ["fix failing tests"],
+                    "recent_notes": [{"note_type": "note", "content": "prefer reproducing tests first"}],
+                },
+            },
+        )
+        self.assertIn("inspection-first", prompt)
+        self.assertIn("git.inspect", prompt)
+        self.assertIn("code.find_symbol", prompt)
+        self.assertIn("code.read_symbol", prompt)
+        self.assertIn("Не начинай план с patch.apply", prompt)
+
+    def test_planner_prompt_lists_editing_tools_separately(self):
+        planner = Planner(ModelRouter(Settings()))
+        prompt = planner._build_plan_prompt("implement feature", {})
+        self.assertIn("Editing tools", prompt)
+        self.assertIn("patch.apply", prompt)
+        self.assertIn("fs.write", prompt)
+        self.assertIn("shell.run", prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/velocity_claw/planner/planner.py
+++ b/velocity_claw/planner/planner.py
@@ -19,6 +19,24 @@ class Plan(BaseModel):
     steps: List[PlanStep]
 
 
+INSPECTION_FIRST_TOOLS = [
+    "git.inspect",
+    "code.find_symbol",
+    "code.read_symbol",
+    "test.run",
+    "fs.read",
+    "analysis",
+]
+
+EDITING_TOOLS = [
+    "fs.write",
+    "fs.append",
+    "fs.replace",
+    "patch.apply",
+    "shell.run",
+    "git.run",
+]
+
 
 def extract_json_payload(raw: str):
     text = raw.strip()
@@ -74,10 +92,15 @@ class Planner:
             "Для каждого шага укажи:",
             "- id: уникальный номер",
             "- title: краткое описание",
-            "- tool: инструмент (fs.read, fs.write, git.run, shell.run, http.get, analysis, patch.apply, test.run)",
+            "- tool: инструмент (fs.read, fs.write, git.inspect, git.run, shell.run, http.get, analysis, patch.apply, test.run, code.find_symbol, code.read_symbol)",
             "- args: аргументы для инструмента",
             "- expected_output: ожидаемый результат",
             "Верни только валидный JSON без лишнего текста.",
+            "Сначала предпочитай inspection-first шаги, если задача связана с кодом, багом, тестами, архитектурой или репозиторием.",
+            f"Inspection-first tools: {', '.join(INSPECTION_FIRST_TOOLS)}",
+            f"Editing tools: {', '.join(EDITING_TOOLS)}",
+            "Не начинай план с patch.apply, fs.write, shell.run или git.run, если сначала можно понять ситуацию через inspection tools.",
+            "Перед редактированием предпочитай сначала хотя бы один из шагов: git.inspect, code.find_symbol, code.read_symbol, test.run, fs.read или analysis.",
             f"Задача: {task}",
         ]
         if context.get("project_root"):


### PR DESCRIPTION
## Summary
This PR strengthens planner autonomy by biasing plans toward inspection-first steps before editing or execution-heavy steps.

## What is included
- stronger planner prompt guidance for inspection-first behavior
- explicit listing of inspection-first tools vs editing tools
- support in the planning prompt for `git.inspect`, `code.find_symbol`, and `code.read_symbol`
- tests covering the new planning guidance

## Why
The project already had stronger runtime, memory, dashboard, approval, and release layers. This PR improves planning quality so the agent is more likely to inspect repository and code state before applying edits.
