### PR TITLE
Artifact explorer and run forensics v1: add forensic summaries and API view

### DIFF
--- a/tests/test_artifact_explorer_run_forensics_v1.py
+++ b/tests/test_artifact_explorer_run_forensics_v1.py
@@ -1,0 +1,70 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from velocity_claw.api.server import create_app
+from velocity_claw.config.settings import Settings
+from velocity_claw.memory.store import MemoryStore
+
+
+class ArtifactExplorerRunForensicsV1Tests(unittest.TestCase):
+    def test_memory_store_builds_run_forensics(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        store = MemoryStore(Settings(workspace_root=workspace, memory_db_path=db_path))
+        run_id = store.create_run("debug failing run")
+        store.save_step(run_id, {
+            "id": 1,
+            "title": "run tests",
+            "tool": "test.run",
+            "args": {"runner": "pytest"},
+            "status": "failed",
+            "result": None,
+            "error": "AssertionError",
+            "started_at": "2026-04-23T00:00:00",
+            "completed_at": "2026-04-23T00:00:01",
+        })
+        store.save_artifact(run_id, "step_1_stdout", "trace log", step_id=1, artifact_type="log")
+        store.save_artifact(run_id, "step_1_diff", "diff preview", step_id=1, artifact_type="diff")
+        run = store.load_run(run_id)
+        forensic = run["forensics"]
+        self.assertEqual(forensic["step_count"], 1)
+        self.assertEqual(forensic["artifact_count"], 2)
+        self.assertEqual(forensic["failed_step"]["tool"], "test.run")
+        self.assertIn("log", forensic["artifact_counts_by_type"])
+
+    def test_run_forensics_route_and_dashboard(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        settings = Settings(workspace_root=workspace, memory_db_path=db_path)
+        with patch("velocity_claw.api.server.load_settings", return_value=settings):
+            app = create_app()
+            client = TestClient(app)
+            run_id = app.state.agent.memory.create_run("debug failing run")
+            app.state.agent.memory.save_step(run_id, {
+                "id": 1,
+                "title": "run tests",
+                "tool": "test.run",
+                "args": {"runner": "pytest"},
+                "status": "failed",
+                "result": None,
+                "error": "AssertionError",
+                "started_at": "2026-04-23T00:00:00",
+                "completed_at": "2026-04-23T00:00:01",
+            })
+            app.state.agent.memory.save_artifact(run_id, "step_1_stdout", "trace log", step_id=1, artifact_type="log")
+            response = client.get(f"/runs/{run_id}/forensics")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json()["run_id"], run_id)
+            self.assertIn("forensics", response.json())
+
+            dashboard = client.get("/dashboard")
+            self.assertEqual(dashboard.status_code, 200)
+            self.assertIn("forensics", dashboard.text.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/velocity_claw/api/server.py
+++ b/velocity_claw/api/server.py
@@ -306,6 +306,13 @@ def create_app() -> FastAPI:
             raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Run not found"})
         return data
 
+    @app.get("/runs/{run_id}/forensics")
+    def run_forensics(run_id: str):
+        data = app.state.agent.memory.load_run(run_id)
+        if not data:
+            raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Run not found"})
+        return {"run_id": run_id, "forensics": data.get("forensics", {})}
+
     @app.get("/runs/{run_id}/artifacts")
     def run_artifacts(run_id: str):
         data = app.state.agent.memory.load_run(run_id)
@@ -341,12 +348,16 @@ def create_app() -> FastAPI:
         grouped = group_artifacts(data)
         planning_context = load_artifact_json(data, "planning_context")
         resume_context = load_artifact_json(data, "resume_context")
+        forensics = data.get("forensics") or {}
         body = [
             "<html><body style='font-family:Arial,sans-serif;max-width:1100px;margin:24px auto;padding:0 16px'>",
             f"<h1>Run detail: {run_id}</h1>",
             f"<p>Task: <b>{data['task']}</b></p>",
             f"<p>Status: <b>{data['status']}</b></p>",
             f"<p>Created: {data['created_at']}</p>",
+            "<h2>Run forensics</h2>",
+            f"<p>Steps: <b>{forensics.get('step_count', 0)}</b> | Artifacts: <b>{forensics.get('artifact_count', 0)}</b></p>",
+            f"<pre>{json.dumps(forensics, ensure_ascii=False, indent=2)[:2500]}</pre>",
             "<h2>Steps</h2>",
             "<table border='1' cellpadding='6' cellspacing='0' style='border-collapse:collapse;width:100%'>",
             "<tr><th>ID</th><th>Title</th><th>Tool</th><th>Status</th><th>Error</th></tr>",
@@ -473,16 +484,18 @@ def create_app() -> FastAPI:
 
         body.append("<h2>Recent runs</h2>")
         body.append("<table border='1' cellpadding='6' cellspacing='0' style='border-collapse:collapse;width:100%'>")
-        body.append("<tr><th>Run ID</th><th>Task</th><th>Status</th><th>Created</th><th>View</th><th>Planning context</th><th>Resume context</th></tr>")
+        body.append("<tr><th>Run ID</th><th>Task</th><th>Status</th><th>Created</th><th>View</th><th>Planning context</th><th>Resume context</th><th>Forensics</th></tr>")
         for run in recent:
             body.append(
-                f"<tr><td><code>{run['run_id']}</code></td><td>{run['task']}</td><td>{badge(run['status'])}</td><td>{run['created_at']}</td><td><a href='/runs/{run['run_id']}/view'>open</a></td><td><a href='/runs/{run['run_id']}/planning-context'>json</a></td><td><a href='/runs/{run['run_id']}/resume-context'>json</a></td></tr>"
+                f"<tr><td><code>{run['run_id']}</code></td><td>{run['task']}</td><td>{badge(run['status'])}</td><td>{run['created_at']}</td><td><a href='/runs/{run['run_id']}/view'>open</a></td><td><a href='/runs/{run['run_id']}/planning-context'>json</a></td><td><a href='/runs/{run['run_id']}/resume-context'>json</a></td><td><a href='/runs/{run['run_id']}/forensics'>json</a></td></tr>"
             )
         body.append("</table>")
 
         body.append("<h2>Last failed run</h2>")
         if last_failed:
-            body.append(f"<p><code>{last_failed['run_id']}</code> — {last_failed['task']} — {badge(last_failed['status'])} — <a href='/runs/{last_failed['run_id']}/view'>details</a> — <a href='/runs/{last_failed['run_id']}/planning-context'>planning context</a> — <a href='/runs/{last_failed['run_id']}/resume-context'>resume context</a></p>")
+            forensic = last_failed.get('forensics') or {}
+            body.append(f"<p><code>{last_failed['run_id']}</code> — {last_failed['task']} — {badge(last_failed['status'])} — <a href='/runs/{last_failed['run_id']}/view'>details</a> — <a href='/runs/{last_failed['run_id']}/forensics'>forensics</a></p>")
+            body.append(f"<p>Failed step: <b>{(forensic.get('failed_step') or {}).get('title') or 'n/a'}</b> | Artifacts: <b>{forensic.get('artifact_count', 0)}</b></p>")
         else:
             body.append("<p>No failed runs recorded.</p>")
 

--- a/velocity_claw/memory/store.py
+++ b/velocity_claw/memory/store.py
@@ -149,7 +149,7 @@ class MemoryStore:
             run_row = conn.execute("SELECT * FROM runs WHERE run_id = ?", (run_id,)).fetchone()
             if not run_row:
                 return None
-            return {
+            run = {
                 "run_id": run_row[0],
                 "task": run_row[1],
                 "status": run_row[2],
@@ -160,6 +160,8 @@ class MemoryStore:
                 "fix_attempts": self.load_fix_attempts(run_id),
                 "approval_history": self.load_approval_history(run_id),
             }
+            run["forensics"] = self.build_run_forensics(run)
+            return run
 
     def load_steps(self, run_id: str):
         if not self.enabled:
@@ -310,6 +312,52 @@ class MemoryStore:
             } if last_failed else None,
             "recent_fix_attempts": self.list_recent_fix_attempts(limit=limit),
             "recent_notes": self.load_recent_project_notes(limit=limit),
+        }
+
+    def build_run_forensics(self, run: Dict) -> dict:
+        steps = run.get("steps", [])
+        artifacts = run.get("artifacts", [])
+        failed_step = next((step for step in steps if step.get("status") == "failed"), None)
+        pending_step = next((step for step in steps if step.get("status") == "pending_approval"), None)
+        last_step = steps[-1] if steps else None
+        artifact_counts: dict[str, int] = {}
+        previews: dict[str, list[dict]] = {"logs": [], "diffs": [], "failures": []}
+        for artifact in artifacts:
+            artifact_type = artifact.get("artifact_type") or "text"
+            artifact_counts[artifact_type] = artifact_counts.get(artifact_type, 0) + 1
+            preview = {
+                "name": artifact.get("name"),
+                "step_id": artifact.get("step_id"),
+                "preview": (artifact.get("content") or "")[:200],
+            }
+            if artifact_type == "log" and len(previews["logs"]) < 3:
+                previews["logs"].append(preview)
+            if artifact_type == "diff" and len(previews["diffs"]) < 3:
+                previews["diffs"].append(preview)
+            if artifact_type in {"failures", "auto_fix"} and len(previews["failures"]) < 3:
+                previews["failures"].append(preview)
+        return {
+            "step_count": len(steps),
+            "artifact_count": len(artifacts),
+            "artifact_counts_by_type": artifact_counts,
+            "failed_step": {
+                "id": failed_step.get("id"),
+                "title": failed_step.get("title"),
+                "tool": failed_step.get("tool"),
+                "error": failed_step.get("error"),
+            } if failed_step else None,
+            "pending_approval_step": {
+                "id": pending_step.get("id"),
+                "title": pending_step.get("title"),
+                "tool": pending_step.get("tool"),
+            } if pending_step else None,
+            "last_step": {
+                "id": last_step.get("id"),
+                "title": last_step.get("title"),
+                "tool": last_step.get("tool"),
+                "status": last_step.get("status"),
+            } if last_step else None,
+            "previews": previews,
         }
 
     def save_fix_attempt(self, run_id: str, attempt_no: int, summary: Any) -> None:


### PR DESCRIPTION
## Summary
This PR adds a run-forensics layer so operators can inspect failed runs and artifact patterns faster.

## What is included
- run forensics summaries in memory store
- `/runs/{run_id}/forensics` API endpoint
- run detail forensic block
- dashboard forensic visibility for recent and failed runs
- tests for forensic summary generation, API route, and dashboard rendering

## Why
The project already had runs, artifacts, and dashboard views, but it still lacked a concise forensic summary layer. This PR makes failure inspection faster without changing execution permissions.
