### PR TITLE
Auto-fix intelligence v2: richer stop reasons and attempt forensics

### DIFF
--- a/tests/test_auto_fix_intelligence_v2.py
+++ b/tests/test_auto_fix_intelligence_v2.py
@@ -1,0 +1,98 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from velocity_claw.api.server import create_app
+from velocity_claw.config.settings import Settings
+from velocity_claw.core.auto_fix import AutoFixLoop
+
+
+class _PatchEngineStub:
+    def __init__(self, diffs):
+        self._diffs = diffs
+        self._idx = 0
+
+    def apply(self, patch, dry_run=False):
+        diff = self._diffs[self._idx]
+        self._idx += 1
+        return {"diff": diff, "status": "applied"}
+
+
+class _TestRunnerStub:
+    def __init__(self, results):
+        self._results = results
+        self._idx = 0
+
+    def run(self, runner, target=None, dry_run=False):
+        result = self._results[self._idx]
+        self._idx += 1
+        return result
+
+
+class _CodeNavStub:
+    def explain_ambiguity(self, symbol):
+        return {"symbol": symbol, "matches": [symbol]}
+
+
+class AutoFixIntelligenceV2Tests(unittest.TestCase):
+    def test_auto_fix_returns_forensics_and_stop_reason(self):
+        loop = AutoFixLoop(
+            _PatchEngineStub(["diff-1", "diff-2"]),
+            _TestRunnerStub([
+                {
+                    "status": "failed",
+                    "stdout": "assert one",
+                    "parsed_failures": [{"nodeid": "t::a", "file": "test_a.py", "line": 10, "assertion": "x == y"}],
+                },
+                {
+                    "status": "failed",
+                    "stdout": "assert one",
+                    "parsed_failures": [{"nodeid": "t::a", "file": "test_a.py", "line": 10, "assertion": "x == y"}],
+                },
+            ]),
+            _CodeNavStub(),
+        )
+        result = loop.run(
+            target_test="tests/test_a.py",
+            patch_plan=[{"name": "foo"}, {"name": "bar"}],
+            max_attempts=2,
+        )
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(result["stop_reason"], "repeated_failure_signature")
+        self.assertIn("forensics", result)
+        self.assertEqual(result["forensics"]["attempt_count"], 2)
+        self.assertIn("forensic_summary", result["attempts"][0])
+
+    def test_auto_fix_api_returns_stop_reason_and_forensics(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        settings = Settings(workspace_root=workspace, memory_db_path=db_path)
+        with patch("velocity_claw.api.server.load_settings", return_value=settings):
+            app = create_app()
+            client = TestClient(app)
+            with patch.object(app.state.agent, "run_auto_fix", return_value={
+                "mode": "auto_fix",
+                "max_attempts": 2,
+                "attempts": [{"attempt": 1, "status": "failed", "forensic_summary": {"failure_count": 1}}],
+                "status": "failed",
+                "stop_reason": "max_attempts_reached",
+                "forensics": {"attempt_count": 1, "last_attempt_status": "failed"},
+                "run_id": "demo-run",
+            }):
+                response = client.post("/auto-fix", json={
+                    "target_test": "tests/test_demo.py",
+                    "patch_plan": [{"name": "foo"}],
+                    "runner": "pytest",
+                    "max_attempts": 2,
+                })
+                self.assertEqual(response.status_code, 200)
+                payload = response.json()
+                self.assertEqual(payload["stop_reason"], "max_attempts_reached")
+                self.assertIn("forensics", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/velocity_claw/core/agent.py
+++ b/velocity_claw/core/agent.py
@@ -180,9 +180,13 @@ class VelocityClawAgent:
         result = self.auto_fix.run(target_test=target_test, patch_plan=patch_plan, runner=runner, max_attempts=max_attempts, dry_run=self.settings.dry_run)
         for attempt in result["attempts"]:
             self.memory.save_fix_attempt(run_id, attempt["attempt"], attempt)
-            self.memory.save_artifact(run_id, f"auto_fix_attempt_{attempt['attempt']}", str(attempt), artifact_type="auto_fix")
+            self.memory.save_artifact(run_id, f"auto_fix_attempt_{attempt['attempt']}", json.dumps(attempt, ensure_ascii=False), artifact_type="auto_fix")
+            if attempt.get("forensic_summary"):
+                self.memory.save_artifact(run_id, f"auto_fix_attempt_{attempt['attempt']}_forensics", json.dumps(attempt["forensic_summary"], ensure_ascii=False), artifact_type="auto_fix_forensics")
+        if result.get("forensics"):
+            self.memory.save_artifact(run_id, "auto_fix_loop_forensics", json.dumps(result["forensics"], ensure_ascii=False), artifact_type="auto_fix_forensics")
         self.memory.update_run_status(run_id, "completed" if result["status"] == "completed" else "failed")
-        self.memory.save_project_note("auto_fix", f"Auto-fix run {run_id} ended with status {result['status']}")
+        self.memory.save_project_note("auto_fix", f"Auto-fix run {run_id} ended with status {result['status']} ({result.get('stop_reason')})")
         result["run_id"] = run_id
         return result
 

--- a/velocity_claw/core/auto_fix.py
+++ b/velocity_claw/core/auto_fix.py
@@ -19,6 +19,7 @@ class AutoFixAttempt:
     stop_reason: Optional[str] = None
     failure_signature: Optional[str] = None
     repair_summary: Optional[dict] = None
+    forensic_summary: Optional[dict] = None
 
 
 class AutoFixLoop:
@@ -31,15 +32,20 @@ class AutoFixLoop:
         attempts: List[dict] = []
         previous_patch_signatures = set()
         previous_failure_signatures = set()
+        final_stop_reason: Optional[str] = None
+
         for idx, patch in enumerate(patch_plan[:max_attempts], start=1):
             attempt = AutoFixAttempt(attempt=idx, reason="test failure", patches=[patch], status="running")
             attempt.target_symbols = self._extract_target_symbols(patch)
             patch_result = self.patch_engine.apply(patch, dry_run=dry_run)
             patch_signature = patch_result.get("diff", "")
+
             if patch_signature in previous_patch_signatures:
                 attempt.status = "stopped"
                 attempt.stop_reason = "repeated_patch_signature"
+                attempt.forensic_summary = self._build_forensic_summary(attempt, patch_result, None)
                 attempts.append(attempt.__dict__)
+                final_stop_reason = attempt.stop_reason
                 break
             previous_patch_signatures.add(patch_signature)
 
@@ -48,11 +54,13 @@ class AutoFixLoop:
             failure_signature = self._build_failure_signature(test_result)
             attempt.failure_signature = failure_signature
             attempt.repair_summary = self._build_repair_summary(attempt.target_symbols, test_result)
+            attempt.forensic_summary = self._build_forensic_summary(attempt, patch_result, test_result)
 
             if failure_signature and failure_signature in previous_failure_signatures:
                 attempt.status = "stopped"
                 attempt.stop_reason = "repeated_failure_signature"
                 attempts.append(attempt.__dict__)
+                final_stop_reason = attempt.stop_reason
                 break
             if failure_signature:
                 previous_failure_signatures.add(failure_signature)
@@ -65,12 +73,19 @@ class AutoFixLoop:
                     "max_attempts": max_attempts,
                     "attempts": attempts,
                     "status": "completed",
+                    "stop_reason": "tests_passed",
+                    "forensics": self._build_loop_forensics(attempts, "tests_passed"),
                 }
+
+        if not final_stop_reason:
+            final_stop_reason = "max_attempts_reached" if attempts else "no_attempts_executed"
         return {
             "mode": "auto_fix",
             "max_attempts": max_attempts,
             "attempts": attempts,
             "status": "failed",
+            "stop_reason": final_stop_reason,
+            "forensics": self._build_loop_forensics(attempts, final_stop_reason),
         }
 
     def _extract_target_symbols(self, patch: dict) -> List[str]:
@@ -119,3 +134,34 @@ class AutoFixLoop:
                 }
             )
         return summary
+
+    def _build_forensic_summary(self, attempt: AutoFixAttempt, patch_result: Optional[dict], test_result: Optional[dict]) -> dict:
+        diff_preview = (patch_result or {}).get("diff", "")[:300]
+        failures = (test_result or {}).get("parsed_failures") or []
+        stdout_preview = (test_result or {}).get("stdout", "")[:300]
+        return {
+            "attempt": attempt.attempt,
+            "target_symbols": attempt.target_symbols,
+            "patch_diff_preview": diff_preview,
+            "test_status": (test_result or {}).get("status"),
+            "failure_count": len(failures),
+            "failed_tests": [
+                {
+                    "nodeid": failure.get("nodeid") or failure.get("failed_test_name"),
+                    "file": failure.get("file"),
+                    "line": failure.get("line"),
+                }
+                for failure in failures[:5]
+            ],
+            "stdout_preview": stdout_preview,
+        }
+
+    def _build_loop_forensics(self, attempts: List[dict], stop_reason: str) -> dict:
+        last_attempt = attempts[-1] if attempts else None
+        return {
+            "attempt_count": len(attempts),
+            "stop_reason": stop_reason,
+            "last_attempt_status": last_attempt.get("status") if last_attempt else None,
+            "last_failure_signature": last_attempt.get("failure_signature") if last_attempt else None,
+            "attempt_statuses": [item.get("status") for item in attempts],
+        }


### PR DESCRIPTION
## Summary
This PR strengthens the auto-fix layer by making each repair attempt more inspectable and by returning clearer stop reasons when the loop stops.

## What is included
- richer attempt forensics in `AutoFixLoop`
- explicit loop-level `stop_reason`
- loop-level `forensics` summary
- richer auto-fix forensic artifacts persisted in memory
- tests for stop reasons, forensic summaries, and API response shape

## Why
The project already had a bounded auto-fix loop, but it did not explain enough about why a repair cycle stopped or what happened on each attempt. This PR makes the repair loop more inspectable without changing execution permissions.
