### PR TITLE
Task queue and worker resilience v2: add terminal reasons and job history

### DIFF
--- a/tests/test_task_queue_worker_resilience_v2.py
+++ b/tests/test_task_queue_worker_resilience_v2.py
@@ -1,0 +1,65 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from velocity_claw.api.server import create_app
+from velocity_claw.config.settings import Settings
+from velocity_claw.core.queue import RunQueue
+
+
+class TaskQueueWorkerResilienceV2Tests(unittest.IsolatedAsyncioTestCase):
+    async def test_queue_tracks_terminal_reason_and_history(self):
+        queue = RunQueue(max_concurrency=1)
+        job = queue.enqueue("demo task", {"k": "v"})
+
+        async def failing_runner(task, context):
+            raise RuntimeError("boom")
+
+        await queue.run_job(job.job_id, failing_runner)
+        loaded = queue.get(job.job_id)
+        self.assertEqual(loaded.status, "failed")
+        self.assertEqual(loaded.terminal_reason, "runner_exception")
+        self.assertTrue(loaded.history)
+        self.assertEqual(loaded.history[0]["status"], "queued")
+        self.assertEqual(loaded.history[-1]["status"], "failed")
+
+    async def test_queue_detail_route_exposes_history(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        settings = Settings(workspace_root=workspace, memory_db_path=db_path)
+        with patch("velocity_claw.api.server.load_settings", return_value=settings):
+            app = create_app()
+            client = TestClient(app)
+            job = app.state.queue.enqueue("demo task", {"k": "v"})
+            stored = app.state.queue.get(job.job_id)
+            stored.terminal_reason = "cancelled_by_operator"
+            stored.history = [{"status": "queued", "reason": "initial_enqueue", "at": "2026-04-24T00:00:00", "attempts": 0}]
+            response = client.get(f"/queue/{job.job_id}")
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+            self.assertEqual(payload["job_id"], job.job_id)
+            self.assertEqual(payload["terminal_reason"], "cancelled_by_operator")
+            self.assertIn("history", payload)
+
+    async def test_dashboard_shows_queue_terminal_reason(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        settings = Settings(workspace_root=workspace, memory_db_path=db_path)
+        with patch("velocity_claw.api.server.load_settings", return_value=settings):
+            app = create_app()
+            client = TestClient(app)
+            job = app.state.queue.enqueue("demo task", None)
+            stored = app.state.queue.get(job.job_id)
+            stored.status = "failed"
+            stored.terminal_reason = "runner_exception"
+            dashboard = client.get("/dashboard")
+            self.assertEqual(dashboard.status_code, 200)
+            self.assertIn("Terminal reason", dashboard.text)
+            self.assertIn("runner_exception", dashboard.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/velocity_claw/api/server.py
+++ b/velocity_claw/api/server.py
@@ -475,9 +475,9 @@ def create_app() -> FastAPI:
         body.append("<h2>Queue jobs</h2>")
         if queue_jobs:
             body.append("<table border='1' cellpadding='6' cellspacing='0' style='border-collapse:collapse;width:100%'>")
-            body.append("<tr><th>Job ID</th><th>Task</th><th>Status</th><th>Attempts</th><th>Worker Slot</th></tr>")
+            body.append("<tr><th>Job ID</th><th>Task</th><th>Status</th><th>Attempts</th><th>Terminal reason</th><th>Worker Slot</th></tr>")
             for job in queue_jobs:
-                body.append(f"<tr><td><code>{job['job_id']}</code></td><td>{job['task']}</td><td>{badge(job['status'])}</td><td>{job['attempts']}</td><td>{job.get('worker_slot') or ''}</td></tr>")
+                body.append(f"<tr><td><code>{job['job_id']}</code></td><td>{job['task']}</td><td>{badge(job['status'])}</td><td>{job['attempts']}</td><td>{job.get('terminal_reason') or ''}</td><td>{job.get('worker_slot') or ''}</td></tr>")
             body.append("</table>")
         else:
             body.append("<p>No queue jobs recorded.</p>")

--- a/velocity_claw/core/queue.py
+++ b/velocity_claw/core/queue.py
@@ -22,6 +22,9 @@ class QueueJob:
     error: Optional[str] = None
     attempts: int = 0
     worker_slot: Optional[str] = None
+    terminal_reason: Optional[str] = None
+    last_attempt_started_at: Optional[str] = None
+    history: list[dict] = field(default_factory=list)
 
 
 class RunQueue:
@@ -50,7 +53,10 @@ class RunQueue:
                     result TEXT,
                     error TEXT,
                     attempts INTEGER NOT NULL DEFAULT 0,
-                    worker_slot TEXT
+                    worker_slot TEXT,
+                    terminal_reason TEXT,
+                    last_attempt_started_at TEXT,
+                    history TEXT
                 )
                 """
             )
@@ -58,7 +64,7 @@ class RunQueue:
     def _load_jobs_from_db(self):
         with sqlite3.connect(self.db_path) as conn:
             rows = conn.execute(
-                "SELECT job_id, task, context, status, created_at, updated_at, result, error, attempts, worker_slot FROM queue_jobs"
+                "SELECT job_id, task, context, status, created_at, updated_at, result, error, attempts, worker_slot, terminal_reason, last_attempt_started_at, history FROM queue_jobs"
             ).fetchall()
         for row in rows:
             self.jobs[row[0]] = QueueJob(
@@ -72,6 +78,9 @@ class RunQueue:
                 error=row[7],
                 attempts=row[8] or 0,
                 worker_slot=row[9],
+                terminal_reason=row[10],
+                last_attempt_started_at=row[11],
+                history=json.loads(row[12]) if row[12] else [],
             )
 
     def _persist_job(self, job: QueueJob):
@@ -80,8 +89,8 @@ class RunQueue:
         with sqlite3.connect(self.db_path) as conn:
             conn.execute(
                 """
-                INSERT INTO queue_jobs (job_id, task, context, status, created_at, updated_at, result, error, attempts, worker_slot)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO queue_jobs (job_id, task, context, status, created_at, updated_at, result, error, attempts, worker_slot, terminal_reason, last_attempt_started_at, history)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(job_id) DO UPDATE SET
                     task = excluded.task,
                     context = excluded.context,
@@ -91,7 +100,10 @@ class RunQueue:
                     result = excluded.result,
                     error = excluded.error,
                     attempts = excluded.attempts,
-                    worker_slot = excluded.worker_slot
+                    worker_slot = excluded.worker_slot,
+                    terminal_reason = excluded.terminal_reason,
+                    last_attempt_started_at = excluded.last_attempt_started_at,
+                    history = excluded.history
                 """,
                 (
                     job.job_id,
@@ -104,11 +116,25 @@ class RunQueue:
                     job.error,
                     job.attempts,
                     job.worker_slot,
+                    job.terminal_reason,
+                    job.last_attempt_started_at,
+                    json.dumps(job.history, ensure_ascii=False),
                 ),
             )
 
+    def _append_history(self, job: QueueJob, status: str, reason: Optional[str] = None):
+        job.history.append(
+            {
+                "status": status,
+                "reason": reason,
+                "at": datetime.now().isoformat(),
+                "attempts": job.attempts,
+            }
+        )
+
     def enqueue(self, task: str, context: Optional[dict] = None) -> QueueJob:
         job = QueueJob(job_id=str(uuid.uuid4()), task=task, context=context)
+        self._append_history(job, "queued", "initial_enqueue")
         self.jobs[job.job_id] = job
         self._persist_job(job)
         return job
@@ -129,8 +155,10 @@ class RunQueue:
         if job.status in {"completed", "failed", "cancelled"}:
             return job
         job.status = "cancelled"
+        job.terminal_reason = "cancelled_by_operator"
         job.worker_slot = None
         job.updated_at = datetime.now().isoformat()
+        self._append_history(job, "cancelled", job.terminal_reason)
         self._persist_job(job)
         return job
 
@@ -140,11 +168,14 @@ class RunQueue:
             return None
         if job.status not in {"failed", "cancelled"}:
             return job
+        previous = job.status
         job.status = "queued"
         job.error = None
         job.result = None
         job.worker_slot = None
+        job.terminal_reason = None
         job.updated_at = datetime.now().isoformat()
+        self._append_history(job, "queued", f"requeued_from_{previous}")
         self._persist_job(job)
         return job
 
@@ -158,17 +189,23 @@ class RunQueue:
             self._active_jobs.add(job.job_id)
             job.status = "running"
             job.attempts += 1
+            job.last_attempt_started_at = datetime.now().isoformat()
             job.worker_slot = f"slot-{self.active_count()}"
             job.updated_at = datetime.now().isoformat()
+            self._append_history(job, "running", f"attempt_{job.attempts}_started")
             self._persist_job(job)
             try:
                 result = await runner(job.task, job.context)
                 job.result = result
                 job.status = "completed"
                 job.error = None
+                job.terminal_reason = "runner_completed"
+                self._append_history(job, "completed", job.terminal_reason)
             except Exception as e:
                 job.error = str(e)
                 job.status = "failed"
+                job.terminal_reason = "runner_exception"
+                self._append_history(job, "failed", job.terminal_reason)
             finally:
                 job.worker_slot = None
                 job.updated_at = datetime.now().isoformat()


### PR DESCRIPTION
## Summary
This PR strengthens queue resilience by making job lifecycle transitions more inspectable and by exposing terminal reasons for completed, failed, or cancelled jobs.

## What is included
- queue job `terminal_reason`
- queue job `history`
- `last_attempt_started_at` tracking
- dashboard visibility for queue terminal reasons
- tests for queue lifecycle history, terminal reasons, queue detail route, and dashboard rendering

## Why
The project already had a queue foundation, but it lacked enough job lifecycle detail to understand how and why a queued task ended. This PR improves resilience visibility without changing execution permissions.
