### PR TITLE
Provider and router observability v3: route history and fallback visibility

### DIFF
--- a/tests/test_provider_router_observability_v3.py
+++ b/tests/test_provider_router_observability_v3.py
@@ -1,0 +1,62 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from velocity_claw.api.server import create_app
+from velocity_claw.config.settings import Settings
+from velocity_claw.models.router import ModelRouter
+
+
+class ProviderRouterObservabilityV3Tests(unittest.TestCase):
+    def test_router_observability_summary(self):
+        router = ModelRouter(Settings())
+        router.route_history = [
+            {
+                "task_type": "planning",
+                "attempts": [{"provider": "openai", "status": "failed"}, {"provider": "ollama", "status": "success"}],
+                "selected_provider": "ollama",
+                "status": "success",
+            },
+            {
+                "task_type": "analysis",
+                "attempts": [{"provider": "openai", "status": "failed"}],
+                "selected_provider": None,
+                "status": "failed",
+            },
+        ]
+        snapshot = router.get_router_observability()
+        self.assertIn("providers", snapshot)
+        self.assertIn("recent_route_history", snapshot)
+        self.assertEqual(snapshot["summary"]["route_count"], 2)
+        self.assertEqual(snapshot["summary"]["fallback_successes"], 1)
+        self.assertEqual(snapshot["summary"]["failed_routes"], 1)
+
+    def test_provider_observability_route_and_dashboard(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        settings = Settings(workspace_root=workspace, memory_db_path=db_path)
+        with patch("velocity_claw.api.server.load_settings", return_value=settings):
+            app = create_app()
+            client = TestClient(app)
+            with patch.object(app.state.agent.router, "get_router_observability", return_value={
+                "providers": {"openai": {"requests": 2, "successes": 1, "failures": 1, "in_cooldown": False, "last_task_type": "planning", "last_error": None}},
+                "recent_route_history": [{"task_type": "planning", "status": "success", "selected_provider": "openai", "attempts": [{"provider": "openai", "status": "success"}]}],
+                "summary": {"route_count": 1, "fallback_successes": 0, "failed_routes": 0},
+            }), patch.object(app.state.agent.router, "get_provider_health", return_value={
+                "openai": {"requests": 2, "successes": 1, "failures": 1, "in_cooldown": False, "last_task_type": "planning", "last_error": None}
+            }):
+                response = client.get("/providers/observability")
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.json()["summary"]["route_count"], 1)
+
+                dashboard = client.get("/dashboard")
+                self.assertEqual(dashboard.status_code, 200)
+                self.assertIn("Provider/router observability", dashboard.text)
+                self.assertIn("Recent route history", dashboard.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/velocity_claw/api/server.py
+++ b/velocity_claw/api/server.py
@@ -197,6 +197,10 @@ def create_app() -> FastAPI:
     def provider_health():
         return {"providers": app.state.agent.router.get_provider_health()}
 
+    @app.get("/providers/observability")
+    def provider_observability():
+        return app.state.agent.router.get_router_observability()
+
     @app.get("/git/summary")
     def git_summary():
         return app.state.agent.executor.git.inspect_repo()
@@ -289,6 +293,7 @@ def create_app() -> FastAPI:
             "active_workers": app.state.queue.active_count(),
             "max_concurrency": app.state.queue.max_concurrency,
             "provider_health": app.state.agent.router.get_provider_health(),
+            "provider_observability": app.state.agent.router.get_router_observability(),
         }
 
     @app.post("/reset", response_model=ResetResponse)
@@ -419,6 +424,7 @@ def create_app() -> FastAPI:
         last_failed = app.state.agent.resume_last_failed_run()
         queue_jobs = app.state.queue.list_jobs()[:10]
         provider_health = app.state.agent.router.get_provider_health()
+        provider_observability = app.state.agent.router.get_router_observability()
         git_state = app.state.agent.executor.git.inspect_repo()
         release_state = app.state.release.evaluate()
 
@@ -430,10 +436,12 @@ def create_app() -> FastAPI:
             "<h1>Velocity Claw Dashboard</h1>",
             f"<p>Execution profile: <b>{app.state.settings.execution_profile}</b></p>",
             f"<p>Queue concurrency: <b>{app.state.queue.max_concurrency}</b> | Active workers: <b>{app.state.queue.active_count()}</b></p>",
-            "<p>Quick links: <a href='/status'>/status</a> | <a href='/metrics'>/metrics</a> | <a href='/diagnostics'>/diagnostics</a> | <a href='/release/readiness'>/release/readiness</a> | <a href='/git/summary'>/git/summary</a> | <a href='/memory/context'>/memory/context</a> | <a href='/memory/resume?task=fix'>/memory/resume</a> | <a href='/providers/health'>/providers/health</a> | <a href='/runs'>/runs</a> | <a href='/approvals'>/approvals</a> | <a href='/profiles'>/profiles</a> | <a href='/queue'>/queue</a></p>",
+            "<p>Quick links: <a href='/status'>/status</a> | <a href='/metrics'>/metrics</a> | <a href='/diagnostics'>/diagnostics</a> | <a href='/release/readiness'>/release/readiness</a> | <a href='/providers/health'>/providers/health</a> | <a href='/providers/observability'>/providers/observability</a> | <a href='/git/summary'>/git/summary</a> | <a href='/memory/context'>/memory/context</a> | <a href='/memory/resume?task=fix'>/memory/resume</a> | <a href='/runs'>/runs</a> | <a href='/approvals'>/approvals</a> | <a href='/profiles'>/profiles</a> | <a href='/queue'>/queue</a></p>",
             "<h2>Release readiness</h2>",
             f"<p>Status: <b>{release_state.get('readiness')}</b> | Score: <b>{release_state.get('score')}/{release_state.get('total_checks')}</b></p>",
             f"<p>Blocking issues: <b>{len(release_state.get('blocking_issues', []))}</b> | Warnings: <b>{len(release_state.get('warnings', []))}</b></p>",
+            "<h2>Provider/router observability</h2>",
+            f"<p>Recent routes: <b>{provider_observability.get('summary', {}).get('route_count', 0)}</b> | Fallback successes: <b>{provider_observability.get('summary', {}).get('fallback_successes', 0)}</b> | Failed routes: <b>{provider_observability.get('summary', {}).get('failed_routes', 0)}</b></p>",
             "<h2>Git summary</h2>",
             f"<p>Branch: <b>{git_state.get('branch') or ''}</b> | Clean: <b>{git_state.get('is_clean')}</b></p>",
             f"<pre>{(git_state.get('diff_stat') or '(no diff)')[:1500]}</pre>",
@@ -457,10 +465,22 @@ def create_app() -> FastAPI:
 
         body.append("<h2>Provider health</h2>")
         body.append("<table border='1' cellpadding='6' cellspacing='0' style='border-collapse:collapse;width:100%'>")
-        body.append("<tr><th>Provider</th><th>Successes</th><th>Failures</th><th>Cooldown</th><th>Last error</th></tr>")
+        body.append("<tr><th>Provider</th><th>Requests</th><th>Successes</th><th>Failures</th><th>Cooldown</th><th>Last task type</th><th>Last error</th></tr>")
         for provider, state in provider_health.items():
-            body.append(f"<tr><td>{provider}</td><td>{state.get('successes', 0)}</td><td>{state.get('failures', 0)}</td><td>{badge('yes' if state.get('in_cooldown') else 'no')}</td><td>{state.get('last_error') or ''}</td></tr>")
+            body.append(f"<tr><td>{provider}</td><td>{state.get('requests', 0)}</td><td>{state.get('successes', 0)}</td><td>{state.get('failures', 0)}</td><td>{badge('yes' if state.get('in_cooldown') else 'no')}</td><td>{state.get('last_task_type') or ''}</td><td>{state.get('last_error') or ''}</td></tr>")
         body.append("</table>")
+
+        history = provider_observability.get('recent_route_history', [])
+        body.append("<h2>Recent route history</h2>")
+        if history:
+            body.append("<table border='1' cellpadding='6' cellspacing='0' style='border-collapse:collapse;width:100%'>")
+            body.append("<tr><th>Task type</th><th>Status</th><th>Selected provider</th><th>Attempts</th></tr>")
+            for item in history[-10:]:
+                attempts = "; ".join(f"{a.get('provider')}:{a.get('status')}" for a in item.get('attempts', []))
+                body.append(f"<tr><td>{item.get('task_type')}</td><td>{item.get('status')}</td><td>{item.get('selected_provider') or ''}</td><td>{attempts}</td></tr>")
+            body.append("</table>")
+        else:
+            body.append("<p>No route history recorded yet.</p>")
 
         body.append("<h2>Repo context summary</h2>")
         body.append(f"<p>Project facts: <b>{len(repo_context.get('project_facts', {}))}</b> | Recent notes: <b>{len(repo_context.get('recent_notes', []))}</b> | Recent fix attempts: <b>{len(repo_context.get('recent_fix_attempts', []))}</b></p>")

--- a/velocity_claw/models/router.py
+++ b/velocity_claw/models/router.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 import asyncio
 import time
 
@@ -103,7 +103,7 @@ class ModelRouter:
         state = self.provider_health.get(provider) or {}
         return bool(state.get("cooldown_until", 0.0) > time.time())
 
-    def _record_provider_success(self, provider: str, task_type: str) -> None:
+    def _record_provider_success(self, provider: str, task_type: Optional[str] = None) -> None:
         state = self.provider_health.setdefault(provider, {})
         state["requests"] = state.get("requests", 0) + 1
         state["successes"] = state.get("successes", 0) + 1
@@ -112,7 +112,7 @@ class ModelRouter:
         state["last_error"] = None
         state["cooldown_until"] = 0.0
 
-    def _record_provider_failure(self, provider: str, error: str, task_type: str) -> None:
+    def _record_provider_failure(self, provider: str, error: str, task_type: Optional[str] = None) -> None:
         state = self.provider_health.setdefault(provider, {})
         state["requests"] = state.get("requests", 0) + 1
         state["failures"] = state.get("failures", 0) + 1

--- a/velocity_claw/models/router.py
+++ b/velocity_claw/models/router.py
@@ -29,31 +29,52 @@ class ModelRouter:
             provider: {
                 "failures": 0,
                 "successes": 0,
+                "requests": 0,
                 "last_error": None,
                 "last_failure_at": None,
                 "last_success_at": None,
+                "last_task_type": None,
                 "cooldown_until": 0.0,
             }
             for provider in settings.provider_order
         }
+        self.route_history: List[Dict] = []
 
     async def route(self, task_type: str, prompt: str) -> Dict:
         providers = self._provider_candidates(task_type)
         errors: List[str] = []
+        route_attempt = {
+            "task_type": task_type,
+            "providers_considered": providers,
+            "attempts": [],
+            "selected_provider": None,
+            "status": "failed",
+            "started_at": time.time(),
+        }
         for provider in providers:
             if self._provider_in_cooldown(provider):
                 self.logger.info("Skipping provider %s because it is in cooldown", provider)
+                route_attempt["attempts"].append({"provider": provider, "status": "skipped_cooldown"})
                 continue
             self.logger.info("Routing %s task to provider %s", task_type, provider)
             try:
                 response = await self._call_provider(provider, prompt, task_type)
-                self._record_provider_success(provider)
+                self._record_provider_success(provider, task_type)
+                route_attempt["attempts"].append({"provider": provider, "status": "success"})
+                route_attempt["selected_provider"] = provider
+                route_attempt["status"] = "success"
+                route_attempt["completed_at"] = time.time()
+                self._record_route_attempt(route_attempt)
                 return self._normalize_response(provider, response)
             except (ProviderNotConfiguredError, ProviderRequestError, ProviderResponseError) as e:
                 self.logger.warning("Provider %s failed: %s", provider, e)
-                self._record_provider_failure(provider, str(e))
+                self._record_provider_failure(provider, str(e), task_type)
+                route_attempt["attempts"].append({"provider": provider, "status": "failed", "error": str(e)})
                 errors.append(f"{provider}: {e}")
                 continue
+        route_attempt["completed_at"] = time.time()
+        route_attempt["errors"] = errors
+        self._record_route_attempt(route_attempt)
         raise ProviderRequestError("All providers failed: " + "; ".join(errors) if errors else "No providers available")
 
     def choose_provider(self, task_type: str) -> str:
@@ -82,19 +103,27 @@ class ModelRouter:
         state = self.provider_health.get(provider) or {}
         return bool(state.get("cooldown_until", 0.0) > time.time())
 
-    def _record_provider_success(self, provider: str) -> None:
+    def _record_provider_success(self, provider: str, task_type: str) -> None:
         state = self.provider_health.setdefault(provider, {})
+        state["requests"] = state.get("requests", 0) + 1
         state["successes"] = state.get("successes", 0) + 1
         state["last_success_at"] = time.time()
+        state["last_task_type"] = task_type
         state["last_error"] = None
         state["cooldown_until"] = 0.0
 
-    def _record_provider_failure(self, provider: str, error: str) -> None:
+    def _record_provider_failure(self, provider: str, error: str, task_type: str) -> None:
         state = self.provider_health.setdefault(provider, {})
+        state["requests"] = state.get("requests", 0) + 1
         state["failures"] = state.get("failures", 0) + 1
         state["last_error"] = error
         state["last_failure_at"] = time.time()
+        state["last_task_type"] = task_type
         state["cooldown_until"] = time.time() + self.settings.provider_health_cooldown_seconds
+
+    def _record_route_attempt(self, payload: Dict) -> None:
+        self.route_history.append(payload)
+        self.route_history = self.route_history[-50:]
 
     def get_provider_health(self) -> Dict[str, Dict]:
         snapshot = {}
@@ -102,6 +131,20 @@ class ModelRouter:
             snapshot[provider] = dict(state)
             snapshot[provider]["in_cooldown"] = self._provider_in_cooldown(provider)
         return snapshot
+
+    def get_router_observability(self) -> Dict:
+        history = self.route_history[-20:]
+        fallback_count = sum(1 for item in history if len([a for a in item.get("attempts", []) if a.get("status") == "failed"]) > 0 and item.get("status") == "success")
+        failed_routes = sum(1 for item in history if item.get("status") == "failed")
+        return {
+            "providers": self.get_provider_health(),
+            "recent_route_history": history,
+            "summary": {
+                "route_count": len(history),
+                "fallback_successes": fallback_count,
+                "failed_routes": failed_routes,
+            },
+        }
 
     async def close(self) -> None:
         if self._session and not self._session.closed:


### PR DESCRIPTION
## Summary
This PR strengthens provider/router observability by exposing recent route attempts, fallback behavior, and richer per-provider request state.

## What is included
- provider `requests` and `last_task_type` tracking
- router `route_history`
- router observability summary with fallback and failure counts
- `/providers/observability` API endpoint
- dashboard visibility for provider/router observability and recent route history
- tests for observability snapshot, API route, and dashboard rendering

## Why
The project already had provider health and cooldown visibility, but it still lacked route-level observability. This PR makes fallback behavior and routing outcomes much easier to inspect.
