### PR TITLE
Dashboard operations console v3: add ops snapshot and console summary

### DIFF
--- a/tests/test_dashboard_operations_console_v3.py
+++ b/tests/test_dashboard_operations_console_v3.py
@@ -1,0 +1,57 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from velocity_claw.api.ops_console import build_operations_console
+from velocity_claw.api.server import create_app
+from velocity_claw.config.settings import Settings
+
+
+class DashboardOperationsConsoleV3Tests(unittest.TestCase):
+    def test_build_operations_console_shape(self):
+        snapshot = build_operations_console(
+            release_state={"readiness": "ready", "score": 8, "total_checks": 10, "blocking_issues": [], "warnings": ["x"]},
+            queue_jobs=[{"status": "running"}, {"status": "failed"}, {"status": "cancelled"}],
+            approvals=[{"step_id": 1}],
+            provider_observability={"summary": {"route_count": 3, "fallback_successes": 1, "failed_routes": 1}},
+            last_failed={"run_id": "r1", "task": "demo", "status": "failed"},
+            metrics={"queue_total": 3},
+            active_workers=1,
+            max_concurrency=2,
+        )
+        self.assertEqual(snapshot["status"], "ok")
+        self.assertEqual(snapshot["queue"]["running"], 1)
+        self.assertEqual(snapshot["queue"]["failed"], 1)
+        self.assertEqual(snapshot["approvals"]["pending"], 1)
+        self.assertEqual(snapshot["providers"]["failed_routes"], 1)
+
+    def test_ops_console_route_and_dashboard(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        settings = Settings(workspace_root=workspace, memory_db_path=db_path)
+        with patch("velocity_claw.api.server.load_settings", return_value=settings):
+            app = create_app()
+            client = TestClient(app)
+            with patch.object(app.state.release, "evaluate", return_value={
+                "readiness": "ready", "score": 8, "total_checks": 10, "blocking_issues": [], "warnings": []
+            }), patch.object(app.state.agent.router, "get_router_observability", return_value={
+                "summary": {"route_count": 2, "fallback_successes": 1, "failed_routes": 0},
+                "recent_route_history": [],
+                "providers": {}
+            }), patch.object(app.state.agent.router, "get_provider_health", return_value={}):
+                response = client.get("/ops/console")
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.json()["status"], "ok")
+                self.assertIn("queue", response.json())
+
+                dashboard = client.get("/dashboard")
+                self.assertEqual(dashboard.status_code, 200)
+                self.assertIn("Operations console", dashboard.text)
+                self.assertIn("/ops/console", dashboard.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/velocity_claw/api/ops_console.py
+++ b/velocity_claw/api/ops_console.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+
+def build_operations_console(*, release_state: dict, queue_jobs: list[dict], approvals: list[dict], provider_observability: dict, last_failed: dict | None, metrics: dict, active_workers: int, max_concurrency: int) -> dict:
+    return {
+        "status": "ok",
+        "release": {
+            "readiness": release_state.get("readiness"),
+            "score": release_state.get("score"),
+            "total_checks": release_state.get("total_checks"),
+            "blocking_issues": len(release_state.get("blocking_issues", [])),
+            "warnings": len(release_state.get("warnings", [])),
+        },
+        "queue": {
+            "total": len(queue_jobs),
+            "running": sum(1 for job in queue_jobs if job.get("status") == "running"),
+            "failed": sum(1 for job in queue_jobs if job.get("status") == "failed"),
+            "cancelled": sum(1 for job in queue_jobs if job.get("status") == "cancelled"),
+            "active_workers": active_workers,
+            "max_concurrency": max_concurrency,
+        },
+        "approvals": {
+            "pending": len(approvals),
+        },
+        "providers": provider_observability.get("summary", {}),
+        "last_failed_run": {
+            "run_id": last_failed.get("run_id"),
+            "task": last_failed.get("task"),
+            "status": last_failed.get("status"),
+        } if last_failed else None,
+        "metrics": metrics,
+    }

--- a/velocity_claw/api/server.py
+++ b/velocity_claw/api/server.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
+from velocity_claw.api.ops_console import build_operations_console
 from velocity_claw.config.settings import load_settings
 from velocity_claw.core.agent import VelocityClawAgent
 from velocity_claw.core.queue import RunQueue
@@ -124,10 +125,33 @@ def create_app() -> FastAPI:
                     return {"raw": artifact.get("content")}
         return None
 
+    def build_console_snapshot() -> dict:
+        refresh_runtime_metrics()
+        release_state = app.state.release.evaluate()
+        queue_jobs = app.state.queue.list_jobs()
+        approvals = app.state.agent.list_pending_approvals()
+        provider_observability = app.state.agent.router.get_router_observability()
+        last_failed = app.state.agent.resume_last_failed_run()
+        metrics = app.state.metrics.snapshot()
+        return build_operations_console(
+            release_state=release_state,
+            queue_jobs=queue_jobs,
+            approvals=approvals,
+            provider_observability=provider_observability,
+            last_failed=last_failed,
+            metrics=metrics,
+            active_workers=app.state.queue.active_count(),
+            max_concurrency=app.state.queue.max_concurrency,
+        )
+
     @app.get("/health")
     def health():
         refresh_runtime_metrics()
         return {"status": "ok", "metrics": app.state.metrics.snapshot()}
+
+    @app.get("/ops/console")
+    def ops_console():
+        return build_console_snapshot()
 
     @app.get("/release/readiness")
     def release_readiness():
@@ -414,7 +438,7 @@ def create_app() -> FastAPI:
 
     @app.get("/dashboard", response_class=HTMLResponse)
     def dashboard():
-        refresh_runtime_metrics()
+        console = build_console_snapshot()
         recent = app.state.agent.memory.list_recent_runs(limit=10)
         approvals = app.state.agent.list_pending_approvals()
         profile = app.state.profiles.get_capability_matrix()
@@ -436,7 +460,15 @@ def create_app() -> FastAPI:
             "<h1>Velocity Claw Dashboard</h1>",
             f"<p>Execution profile: <b>{app.state.settings.execution_profile}</b></p>",
             f"<p>Queue concurrency: <b>{app.state.queue.max_concurrency}</b> | Active workers: <b>{app.state.queue.active_count()}</b></p>",
-            "<p>Quick links: <a href='/status'>/status</a> | <a href='/metrics'>/metrics</a> | <a href='/diagnostics'>/diagnostics</a> | <a href='/release/readiness'>/release/readiness</a> | <a href='/providers/health'>/providers/health</a> | <a href='/providers/observability'>/providers/observability</a> | <a href='/git/summary'>/git/summary</a> | <a href='/memory/context'>/memory/context</a> | <a href='/memory/resume?task=fix'>/memory/resume</a> | <a href='/runs'>/runs</a> | <a href='/approvals'>/approvals</a> | <a href='/profiles'>/profiles</a> | <a href='/queue'>/queue</a></p>",
+            "<p>Quick links: <a href='/status'>/status</a> | <a href='/ops/console'>/ops/console</a> | <a href='/metrics'>/metrics</a> | <a href='/diagnostics'>/diagnostics</a> | <a href='/release/readiness'>/release/readiness</a> | <a href='/providers/health'>/providers/health</a> | <a href='/providers/observability'>/providers/observability</a> | <a href='/git/summary'>/git/summary</a> | <a href='/memory/context'>/memory/context</a> | <a href='/memory/resume?task=fix'>/memory/resume</a> | <a href='/runs'>/runs</a> | <a href='/approvals'>/approvals</a> | <a href='/profiles'>/profiles</a> | <a href='/queue'>/queue</a></p>",
+            "<h2>Operations console</h2>",
+            f"<p>Release: <b>{console['release']['readiness']}</b> ({console['release']['score']}/{console['release']['total_checks']}) | Queue running: <b>{console['queue']['running']}</b> | Queue failed: <b>{console['queue']['failed']}</b> | Approvals pending: <b>{console['approvals']['pending']}</b> | Failed routes: <b>{console['providers'].get('failed_routes', 0)}</b></p>",
+        ]
+        if console.get("last_failed_run"):
+            body.append(f"<p>Last failed run: <code>{console['last_failed_run']['run_id']}</code> — {console['last_failed_run']['task']} — <a href='/runs/{console['last_failed_run']['run_id']}/view'>open</a></p>")
+        else:
+            body.append("<p>No failed runs currently recorded.</p>")
+        body.extend([
             "<h2>Release readiness</h2>",
             f"<p>Status: <b>{release_state.get('readiness')}</b> | Score: <b>{release_state.get('score')}/{release_state.get('total_checks')}</b></p>",
             f"<p>Blocking issues: <b>{len(release_state.get('blocking_issues', []))}</b> | Warnings: <b>{len(release_state.get('warnings', []))}</b></p>",
@@ -447,7 +479,7 @@ def create_app() -> FastAPI:
             f"<pre>{(git_state.get('diff_stat') or '(no diff)')[:1500]}</pre>",
             "<h2>Metrics</h2>",
             "<ul>",
-        ]
+        ])
         for key, value in metrics_snapshot.items():
             body.append(f"<li>{key}: <b>{value}</b></li>")
         body.append("</ul>")


### PR DESCRIPTION
## Summary
This PR strengthens the dashboard as an operations console by adding a unified ops snapshot and a top-level console summary block.

## What is included
- `velocity_claw/api/ops_console.py`
- `GET /ops/console`
- dashboard operations console summary block
- quick link to `/ops/console`
- tests for helper snapshot shape, API route, and dashboard rendering

## Why
The project already had many separate operator-facing sections, but no unified operations snapshot. This PR adds a concise control-plane style summary without changing execution permissions.
