### PR TITLE
Artifact report generation v2: add run report summaries

### DIFF
--- a/tests/test_reports_v2.py
+++ b/tests/test_reports_v2.py
@@ -1,0 +1,36 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.memory.store import MemoryStore
+
+
+class ReportsV2Tests(unittest.TestCase):
+    def test_run_report_exists(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        store = MemoryStore(Settings(workspace_root=workspace, memory_db_path=db_path))
+        run_id = store.create_run("demo run")
+        store.save_step(run_id, {
+            "id": 1,
+            "title": "run tests",
+            "tool": "test.run",
+            "args": {"runner": "pytest"},
+            "status": "failed",
+            "result": None,
+            "error": "AssertionError",
+            "started_at": "2026-04-24T00:00:00",
+            "completed_at": "2026-04-24T00:00:01",
+        })
+        store.save_artifact(run_id, "step_1_stdout", "trace log", step_id=1, artifact_type="log")
+        run = store.load_run(run_id)
+        report = run["report"]
+        self.assertIn("executive_summary", report)
+        self.assertEqual(report["artifact_overview"]["total"], 1)
+        self.assertEqual(report["step_overview"]["failed"], 1)
+        self.assertTrue(report["key_steps"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/velocity_claw/memory/store.py
+++ b/velocity_claw/memory/store.py
@@ -161,6 +161,7 @@ class MemoryStore:
                 "approval_history": self.load_approval_history(run_id),
             }
             run["forensics"] = self.build_run_forensics(run)
+            run["report"] = self.build_run_report(run)
             return run
 
     def load_steps(self, run_id: str):
@@ -358,6 +359,55 @@ class MemoryStore:
                 "status": last_step.get("status"),
             } if last_step else None,
             "previews": previews,
+        }
+
+    def build_run_report(self, run: Dict) -> dict:
+        steps = run.get("steps", [])
+        artifacts = run.get("artifacts", [])
+        approvals = run.get("approval_history", [])
+        fix_attempts = run.get("fix_attempts", [])
+        forensics = run.get("forensics") or self.build_run_forensics(run)
+        successful_steps = [step for step in steps if step.get("status") in {"success", "approved"}]
+        failed_step = forensics.get("failed_step")
+        executive_summary = f"Run {run.get('run_id')} for '{run.get('task')}' finished with status {run.get('status')}."
+        if failed_step:
+            executive_summary += f" Failed at step '{failed_step.get('title')}' via {failed_step.get('tool')}."
+        elif forensics.get("pending_approval_step"):
+            executive_summary += " Awaiting approval continuation."
+        report_steps = [
+            {
+                "id": step.get("id"),
+                "title": step.get("title"),
+                "tool": step.get("tool"),
+                "status": step.get("status"),
+            }
+            for step in steps[:10]
+        ]
+        return {
+            "executive_summary": executive_summary,
+            "status": run.get("status"),
+            "task": run.get("task"),
+            "step_overview": {
+                "total": len(steps),
+                "successful": len(successful_steps),
+                "failed": 1 if failed_step else 0,
+                "pending_approval": 1 if forensics.get("pending_approval_step") else 0,
+            },
+            "artifact_overview": {
+                "total": len(artifacts),
+                "counts_by_type": forensics.get("artifact_counts_by_type", {}),
+            },
+            "approval_overview": {
+                "total_events": len(approvals),
+            },
+            "fix_attempt_overview": {
+                "total_attempts": len(fix_attempts),
+            },
+            "key_steps": report_steps,
+            "forensic_highlights": {
+                "failed_step": failed_step,
+                "last_step": forensics.get("last_step"),
+            },
         }
 
     def save_fix_attempt(self, run_id: str, attempt_no: int, summary: Any) -> None:


### PR DESCRIPTION
## Summary
This PR adds a run report layer so each run can expose a more operator-friendly summary in addition to raw artifacts and forensics.

## What is included
- `build_run_report(...)` in `velocity_claw/memory/store.py`
- run-level `report` added to loaded runs
- report summary includes:
  - executive summary
  - step overview
  - artifact overview
  - approval overview
  - fix attempt overview
  - key steps
  - forensic highlights
- tests for report generation v2

## Why
The project already had strong forensics and artifact storage, but it still lacked a concise operator report layer. This PR adds that report summary without changing execution permissions.
