### PR TITLE
API contract and response schema hardening v2: add stable envelopes and run report route

### DIFF
--- a/tests/test_api_contract_response_schema_hardening_v2.py
+++ b/tests/test_api_contract_response_schema_hardening_v2.py
@@ -1,0 +1,63 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from velocity_claw.api.server import create_app
+from velocity_claw.config.settings import Settings
+
+
+class ApiContractResponseSchemaHardeningV2Tests(unittest.TestCase):
+    def test_read_endpoints_use_stable_envelopes(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        settings = Settings(workspace_root=workspace, memory_db_path=db_path)
+        with patch("velocity_claw.api.server.load_settings", return_value=settings):
+            app = create_app()
+            client = TestClient(app)
+
+            health = client.get("/health")
+            self.assertEqual(health.status_code, 200)
+            self.assertEqual(health.json()["status"], "ok")
+            self.assertIn("metrics", health.json())
+
+            providers = client.get("/providers/health")
+            self.assertEqual(providers.status_code, 200)
+            self.assertEqual(providers.json()["status"], "ok")
+            self.assertIn("providers", providers.json())
+
+            queue = client.get("/queue")
+            self.assertEqual(queue.status_code, 200)
+            self.assertEqual(queue.json()["status"], "ok")
+            self.assertIn("jobs", queue.json())
+
+    def test_run_report_endpoint_exists(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        settings = Settings(workspace_root=workspace, memory_db_path=db_path)
+        with patch("velocity_claw.api.server.load_settings", return_value=settings):
+            app = create_app()
+            client = TestClient(app)
+            run_id = app.state.agent.memory.create_run("demo")
+            app.state.agent.memory.save_step(run_id, {
+                "id": 1,
+                "title": "inspect repo",
+                "tool": "git.inspect",
+                "args": {},
+                "status": "success",
+                "result": {"ok": True},
+                "error": None,
+                "started_at": "2026-04-24T00:00:00",
+                "completed_at": "2026-04-24T00:00:01",
+            })
+            report = client.get(f"/runs/{run_id}/report")
+            self.assertEqual(report.status_code, 200)
+            self.assertEqual(report.json()["status"], "ok")
+            self.assertIn("report", report.json())
+            self.assertIn("executive_summary", report.json()["report"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_execution_policy_approval_intelligence_v2.py
+++ b/tests/test_execution_policy_approval_intelligence_v2.py
@@ -40,10 +40,12 @@ class ExecutionPolicyApprovalIntelligenceV2Tests(unittest.TestCase):
             )
             self.assertEqual(response.status_code, 200)
             payload = response.json()
-            self.assertTrue(payload["required"])
-            self.assertEqual(payload["tool"], "shell.run")
-            self.assertEqual(payload["profile"], "dev")
-            self.assertIn("triggers", payload)
+            self.assertEqual(payload["status"], "ok")
+            explanation = payload["explanation"]
+            self.assertTrue(explanation["required"])
+            self.assertEqual(explanation["tool"], "shell.run")
+            self.assertEqual(explanation["profile"], "dev")
+            self.assertIn("triggers", explanation)
 
     def test_dashboard_shows_richer_pending_approval_columns(self):
         workspace = tempfile.mkdtemp()

--- a/tests/test_git_pr_workflow_intelligence_v1.py
+++ b/tests/test_git_pr_workflow_intelligence_v1.py
@@ -48,7 +48,9 @@ class GitPrWorkflowIntelligenceV1Tests(unittest.TestCase):
             }):
                 response = client.get("/git/summary")
                 self.assertEqual(response.status_code, 200)
-                self.assertEqual(response.json()["branch"], "main")
+                payload = response.json()
+                self.assertEqual(payload["status"], "ok")
+                self.assertEqual(payload["git"]["branch"], "main")
 
                 dashboard = client.get("/dashboard")
                 self.assertEqual(dashboard.status_code, 200)

--- a/tests/test_provider_router_observability_v3.py
+++ b/tests/test_provider_router_observability_v3.py
@@ -50,7 +50,9 @@ class ProviderRouterObservabilityV3Tests(unittest.TestCase):
             }):
                 response = client.get("/providers/observability")
                 self.assertEqual(response.status_code, 200)
-                self.assertEqual(response.json()["summary"]["route_count"], 1)
+                payload = response.json()
+                self.assertEqual(payload["status"], "ok")
+                self.assertEqual(payload["observability"]["summary"]["route_count"], 1)
 
                 dashboard = client.get("/dashboard")
                 self.assertEqual(dashboard.status_code, 200)

--- a/tests/test_release_readiness_packaging_v1.py
+++ b/tests/test_release_readiness_packaging_v1.py
@@ -46,12 +46,14 @@ class ReleaseReadinessPackagingV1Tests(unittest.TestCase):
                 "total_checks": 10,
                 "checks": {"readme_present": True},
                 "blocking_issues": [],
-                "warnings": ["Dockerfile missing"],
+                "warnings": ["warning"],
                 "packaging_targets": {"cli": True, "api": True, "docker": False, "telegram": True},
             }):
                 response = client.get("/release/readiness")
                 self.assertEqual(response.status_code, 200)
-                self.assertEqual(response.json()["readiness"], "ready")
+                payload = response.json()
+                self.assertEqual(payload["status"], "ok")
+                self.assertEqual(payload["release"]["readiness"], "ready")
 
                 dashboard = client.get("/dashboard")
                 self.assertEqual(dashboard.status_code, 200)

--- a/tests/test_task_queue_worker_resilience_v2.py
+++ b/tests/test_task_queue_worker_resilience_v2.py
@@ -40,9 +40,11 @@ class TaskQueueWorkerResilienceV2Tests(unittest.IsolatedAsyncioTestCase):
             response = client.get(f"/queue/{job.job_id}")
             self.assertEqual(response.status_code, 200)
             payload = response.json()
-            self.assertEqual(payload["job_id"], job.job_id)
-            self.assertEqual(payload["terminal_reason"], "cancelled_by_operator")
-            self.assertIn("history", payload)
+            self.assertEqual(payload["status"], "ok")
+            job_data = payload["job"]
+            self.assertEqual(job_data["job_id"], job.job_id)
+            self.assertEqual(job_data["terminal_reason"], "cancelled_by_operator")
+            self.assertIn("history", job_data)
 
     async def test_dashboard_shows_queue_terminal_reason(self):
         workspace = tempfile.mkdtemp()

--- a/velocity_claw/api/server.py
+++ b/velocity_claw/api/server.py
@@ -100,6 +100,11 @@ def create_app() -> FastAPI:
     app.state.limiter = limiter
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
+    def ok(payload_key: str, payload: Any, **extra: Any) -> dict:
+        body = {"status": "ok", payload_key: payload}
+        body.update(extra)
+        return body
+
     def refresh_runtime_metrics() -> None:
         approvals_pending = len(app.state.agent.list_pending_approvals())
         queue_jobs = app.state.queue.list_jobs()
@@ -147,15 +152,17 @@ def create_app() -> FastAPI:
     @app.get("/health")
     def health():
         refresh_runtime_metrics()
-        return {"status": "ok", "metrics": app.state.metrics.snapshot()}
+        return ok("metrics", app.state.metrics.snapshot())
 
     @app.get("/ops/console")
     def ops_console():
-        return build_console_snapshot()
+        snapshot = build_console_snapshot()
+        snapshot["status"] = "ok"
+        return snapshot
 
     @app.get("/release/readiness")
     def release_readiness():
-        return app.state.release.evaluate()
+        return ok("release", app.state.release.evaluate())
 
     @app.post("/task", response_model=TaskResponse)
     @limiter.limit("10/minute")
@@ -202,44 +209,44 @@ def create_app() -> FastAPI:
 
     @app.get("/modes")
     def modes():
-        return {"modes": app.state.agent.get_status()["available_modes"]}
+        return ok("modes", app.state.agent.get_status()["available_modes"])
 
     @app.get("/profiles")
     def profiles():
-        return {"active": app.state.settings.execution_profile, "profiles": app.state.profiles.list_profiles()}
+        return ok("profiles", app.state.profiles.list_profiles(), active=app.state.settings.execution_profile)
 
     @app.get("/profiles/active")
     def active_profile():
-        return app.state.profiles.get_capability_matrix()
+        return ok("profile", app.state.profiles.get_capability_matrix())
 
     @app.get("/profiles/explain/{tool_name}")
     def explain_profile_tool(tool_name: str):
         tool = tool_name.replace("__", ".")
-        return app.state.profiles.explain_tool_access(tool)
+        return ok("explanation", app.state.profiles.explain_tool_access(tool), tool=tool)
 
     @app.get("/providers/health")
     def provider_health():
-        return {"providers": app.state.agent.router.get_provider_health()}
+        return ok("providers", app.state.agent.router.get_provider_health())
 
     @app.get("/providers/observability")
     def provider_observability():
-        return app.state.agent.router.get_router_observability()
+        return ok("observability", app.state.agent.router.get_router_observability())
 
     @app.get("/git/summary")
     def git_summary():
-        return app.state.agent.executor.git.inspect_repo()
+        return ok("git", app.state.agent.executor.git.inspect_repo())
 
     @app.get("/memory/context")
     def memory_context():
-        return app.state.agent.get_repo_context_summary()
+        return ok("context", app.state.agent.get_repo_context_summary())
 
     @app.get("/memory/resume")
     def memory_resume(task: str):
-        return app.state.agent.get_resume_context(task)
+        return ok("resume", app.state.agent.get_resume_context(task), task=task)
 
     @app.post("/approvals/explain")
     def explain_approval(payload: ApprovalExplainRequest):
-        return app.state.agent.explain_approval_requirement(payload.step, payload.profile_name)
+        return ok("explanation", app.state.agent.explain_approval_requirement(payload.step, payload.profile_name))
 
     @app.post("/queue/submit")
     @limiter.limit("10/minute")
@@ -247,16 +254,12 @@ def create_app() -> FastAPI:
         job = app.state.queue.enqueue(payload.task, payload.context)
         refresh_runtime_metrics()
         asyncio.create_task(app.state.queue.run_job(job.job_id, app.state.agent.run_task))
-        return {"job_id": job.job_id, "status": job.status}
+        return ok("job", {"job_id": job.job_id, "status": job.status})
 
     @app.get("/queue")
     def queue_list():
         refresh_runtime_metrics()
-        return {
-            "jobs": app.state.queue.list_jobs(),
-            "active_workers": app.state.queue.active_count(),
-            "max_concurrency": app.state.queue.max_concurrency,
-        }
+        return ok("jobs", app.state.queue.list_jobs(), active_workers=app.state.queue.active_count(), max_concurrency=app.state.queue.max_concurrency)
 
     @app.get("/queue/{job_id}")
     def queue_status(job_id: str):
@@ -264,7 +267,7 @@ def create_app() -> FastAPI:
         if not job:
             raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Job not found"})
         refresh_runtime_metrics()
-        return job.__dict__
+        return ok("job", job.__dict__)
 
     @app.post("/queue/{job_id}/cancel")
     @limiter.limit("20/minute")
@@ -273,7 +276,7 @@ def create_app() -> FastAPI:
         if not job:
             raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Job not found"})
         refresh_runtime_metrics()
-        return job.__dict__
+        return ok("job", job.__dict__)
 
     @app.post("/queue/{job_id}/requeue")
     @limiter.limit("20/minute")
@@ -282,7 +285,7 @@ def create_app() -> FastAPI:
         if not job:
             raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Job not found"})
         refresh_runtime_metrics()
-        return job.__dict__
+        return ok("job", job.__dict__)
 
     @app.post("/auto-fix")
     @limiter.limit("5/minute")
@@ -304,12 +307,12 @@ def create_app() -> FastAPI:
     @app.get("/metrics")
     def metrics():
         refresh_runtime_metrics()
-        return app.state.metrics.snapshot()
+        return ok("metrics", app.state.metrics.snapshot())
 
     @app.get("/diagnostics")
     def diagnostics():
         refresh_runtime_metrics()
-        return {
+        return ok("diagnostics", {
             "metrics": app.state.metrics.snapshot(),
             "diagnostics": app.state.metrics.diagnostics_summary(),
             "last_failed_run": app.state.agent.resume_last_failed_run(),
@@ -318,7 +321,7 @@ def create_app() -> FastAPI:
             "max_concurrency": app.state.queue.max_concurrency,
             "provider_health": app.state.agent.router.get_provider_health(),
             "provider_observability": app.state.agent.router.get_router_observability(),
-        }
+        })
 
     @app.post("/reset", response_model=ResetResponse)
     def reset():
@@ -326,28 +329,28 @@ def create_app() -> FastAPI:
 
     @app.get("/runs")
     def runs():
-        return {"recent": app.state.agent.memory.list_recent_runs(), "last_failed": app.state.agent.resume_last_failed_run()}
+        return ok("runs", app.state.agent.memory.list_recent_runs(), last_failed=app.state.agent.resume_last_failed_run())
 
     @app.get("/runs/{run_id}")
     def run_detail(run_id: str):
         data = app.state.agent.memory.load_run(run_id)
         if not data:
             raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Run not found"})
-        return data
+        return ok("run", data)
 
     @app.get("/runs/{run_id}/forensics")
     def run_forensics(run_id: str):
         data = app.state.agent.memory.load_run(run_id)
         if not data:
             raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Run not found"})
-        return {"run_id": run_id, "forensics": data.get("forensics", {})}
+        return ok("forensics", data.get("forensics", {}), run_id=run_id)
 
     @app.get("/runs/{run_id}/artifacts")
     def run_artifacts(run_id: str):
         data = app.state.agent.memory.load_run(run_id)
         if not data:
             raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Run not found"})
-        return {"run_id": run_id, "grouped_artifacts": group_artifacts(data)}
+        return ok("artifacts", group_artifacts(data), run_id=run_id)
 
     @app.get("/runs/{run_id}/planning-context")
     def run_planning_context(run_id: str):
@@ -357,7 +360,7 @@ def create_app() -> FastAPI:
         planning_context = load_artifact_json(data, "planning_context")
         if planning_context is None:
             raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Planning context not found"})
-        return {"run_id": run_id, "planning_context": planning_context}
+        return ok("planning_context", planning_context, run_id=run_id)
 
     @app.get("/runs/{run_id}/resume-context")
     def run_resume_context(run_id: str):
@@ -367,7 +370,14 @@ def create_app() -> FastAPI:
         resume_context = load_artifact_json(data, "resume_context")
         if resume_context is None:
             raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Resume context not found"})
-        return {"run_id": run_id, "resume_context": resume_context}
+        return ok("resume_context", resume_context, run_id=run_id)
+
+    @app.get("/runs/{run_id}/report")
+    def run_report(run_id: str):
+        data = app.state.agent.memory.load_run(run_id)
+        if not data:
+            raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Run not found"})
+        return ok("report", data.get("report", {}), run_id=run_id)
 
     @app.get("/runs/{run_id}/view", response_class=HTMLResponse)
     def run_detail_view(run_id: str):
@@ -378,12 +388,15 @@ def create_app() -> FastAPI:
         planning_context = load_artifact_json(data, "planning_context")
         resume_context = load_artifact_json(data, "resume_context")
         forensics = data.get("forensics") or {}
+        report = data.get("report") or {}
         body = [
             "<html><body style='font-family:Arial,sans-serif;max-width:1100px;margin:24px auto;padding:0 16px'>",
             f"<h1>Run detail: {run_id}</h1>",
             f"<p>Task: <b>{data['task']}</b></p>",
             f"<p>Status: <b>{data['status']}</b></p>",
             f"<p>Created: {data['created_at']}</p>",
+            "<h2>Run report</h2>",
+            f"<p>{report.get('executive_summary') or 'No report summary available.'}</p>",
             "<h2>Run forensics</h2>",
             f"<p>Steps: <b>{forensics.get('step_count', 0)}</b> | Artifacts: <b>{forensics.get('artifact_count', 0)}</b></p>",
             f"<pre>{json.dumps(forensics, ensure_ascii=False, indent=2)[:2500]}</pre>",
@@ -420,11 +433,11 @@ def create_app() -> FastAPI:
 
     @app.get("/runs/{run_id}/approval-history")
     def approval_history(run_id: str):
-        return {"run_id": run_id, "history": app.state.agent.get_approval_history(run_id)}
+        return ok("history", app.state.agent.get_approval_history(run_id), run_id=run_id)
 
     @app.get("/approvals")
     def approvals():
-        return {"pending": app.state.agent.list_pending_approvals()}
+        return ok("pending", app.state.agent.list_pending_approvals())
 
     @app.post("/approvals/{run_id}/{step_id}/approve")
     @limiter.limit("20/minute")
@@ -536,17 +549,17 @@ def create_app() -> FastAPI:
 
         body.append("<h2>Recent runs</h2>")
         body.append("<table border='1' cellpadding='6' cellspacing='0' style='border-collapse:collapse;width:100%'>")
-        body.append("<tr><th>Run ID</th><th>Task</th><th>Status</th><th>Created</th><th>View</th><th>Planning context</th><th>Resume context</th><th>Forensics</th></tr>")
+        body.append("<tr><th>Run ID</th><th>Task</th><th>Status</th><th>Created</th><th>View</th><th>Planning context</th><th>Resume context</th><th>Forensics</th><th>Report</th></tr>")
         for run in recent:
             body.append(
-                f"<tr><td><code>{run['run_id']}</code></td><td>{run['task']}</td><td>{badge(run['status'])}</td><td>{run['created_at']}</td><td><a href='/runs/{run['run_id']}/view'>open</a></td><td><a href='/runs/{run['run_id']}/planning-context'>json</a></td><td><a href='/runs/{run['run_id']}/resume-context'>json</a></td><td><a href='/runs/{run['run_id']}/forensics'>json</a></td></tr>"
+                f"<tr><td><code>{run['run_id']}</code></td><td>{run['task']}</td><td>{badge(run['status'])}</td><td>{run['created_at']}</td><td><a href='/runs/{run['run_id']}/view'>open</a></td><td><a href='/runs/{run['run_id']}/planning-context'>json</a></td><td><a href='/runs/{run['run_id']}/resume-context'>json</a></td><td><a href='/runs/{run['run_id']}/forensics'>json</a></td><td><a href='/runs/{run['run_id']}/report'>json</a></td></tr>"
             )
         body.append("</table>")
 
         body.append("<h2>Last failed run</h2>")
         if last_failed:
             forensic = last_failed.get('forensics') or {}
-            body.append(f"<p><code>{last_failed['run_id']}</code> — {last_failed['task']} — {badge(last_failed['status'])} — <a href='/runs/{last_failed['run_id']}/view'>details</a> — <a href='/runs/{last_failed['run_id']}/forensics'>forensics</a></p>")
+            body.append(f"<p><code>{last_failed['run_id']}</code> — {last_failed['task']} — {badge(last_failed['status'])} — <a href='/runs/{last_failed['run_id']}/view'>details</a> — <a href='/runs/{last_failed['run_id']}/forensics'>forensics</a> — <a href='/runs/{last_failed['run_id']}/report'>report</a></p>")
             body.append(f"<p>Failed step: <b>{(forensic.get('failed_step') or {}).get('title') or 'n/a'}</b> | Artifacts: <b>{forensic.get('artifact_count', 0)}</b></p>")
         else:
             body.append("<p>No failed runs recorded.</p>")


### PR DESCRIPTION
## Summary
This PR hardens read-side API contracts by introducing stable response envelopes for operator-facing endpoints and by exposing a dedicated run report route.

## What is included
- stable `status: ok` envelopes for read/operator endpoints
- `GET /runs/{run_id}/report`
- dashboard links for run reports
- run detail page now shows report summary
- tests for response envelope stability and run report route

## Why
The project already had a broad API surface, but response shapes across read endpoints were still inconsistent. This PR makes client integrations more predictable without changing execution permissions.
