### PR TITLE
Run replay and retry orchestration v2: add retry context and replan flow

### DIFF
--- a/tests/test_run_replay_retry_orchestration_v2.py
+++ b/tests/test_run_replay_retry_orchestration_v2.py
@@ -1,0 +1,55 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.core.agent import VelocityClawAgent
+
+
+class RunReplayRetryOrchestrationV2Tests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.workspace = tempfile.mkdtemp()
+        self.db_path = str(Path(self.workspace) / "memory.db")
+        self.agent = VelocityClawAgent(Settings(workspace_root=self.workspace, memory_db_path=self.db_path))
+
+    def _create_failed_run(self):
+        run_id = self.agent.memory.create_run("fix broken tests")
+        self.agent.memory.save_step(run_id, {
+            "id": 1,
+            "title": "run failing tests",
+            "tool": "test.run",
+            "args": {"runner": "pytest"},
+            "status": "failed",
+            "result": None,
+            "error": "AssertionError",
+            "started_at": "2026-04-25T00:00:00",
+            "completed_at": "2026-04-25T00:00:01",
+        })
+        self.agent.memory.save_artifact(run_id, "step_1_stdout", "failure log", step_id=1, artifact_type="log")
+        self.agent.memory.update_run_status(run_id, "failed")
+        return run_id
+
+    def test_build_retry_context_uses_run_report_and_forensics(self):
+        run_id = self._create_failed_run()
+        context = self.agent.build_retry_context(run_id)
+        retry = context["retry"]
+        self.assertEqual(retry["source_run_id"], run_id)
+        self.assertEqual(retry["source_task"], "fix broken tests")
+        self.assertEqual(retry["source_status"], "failed")
+        self.assertIn("executive_summary", retry)
+        self.assertEqual(retry["failed_step"]["tool"], "test.run")
+        self.assertEqual(retry["recommended_strategy"]["mode"], "inspect_failed_step_first")
+
+    async def test_retry_run_replans_with_retry_context(self):
+        run_id = self._create_failed_run()
+        with patch.object(self.agent, "run_task", new=AsyncMock(return_value={"status": "completed", "run_id": "retry-run"})) as run_task:
+            result = await self.agent.retry_run(run_id)
+        self.assertEqual(result["status"], "completed")
+        called_task, called_context = run_task.call_args.args
+        self.assertIn(run_id, called_task)
+        self.assertEqual(called_context["retry"]["source_run_id"], run_id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_replay_retry_orchestration_v2.py
+++ b/tests/test_run_replay_retry_orchestration_v2.py
@@ -38,8 +38,15 @@ class RunReplayRetryOrchestrationV2Tests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(retry["source_task"], "fix broken tests")
         self.assertEqual(retry["source_status"], "failed")
         self.assertIn("executive_summary", retry)
+        self.assertIn("artifact_overview", retry)
+        self.assertIn("step_overview", retry)
         self.assertEqual(retry["failed_step"]["tool"], "test.run")
         self.assertEqual(retry["recommended_strategy"]["mode"], "inspect_failed_step_first")
+        self.assertIn("run failing tests", retry["recommended_strategy"]["hint"])
+
+    def test_build_retry_context_missing_run_raises(self):
+        with self.assertRaises(ValueError):
+            self.agent.build_retry_context("missing-run")
 
     async def test_retry_run_replans_with_retry_context(self):
         run_id = self._create_failed_run()
@@ -49,6 +56,7 @@ class RunReplayRetryOrchestrationV2Tests(unittest.IsolatedAsyncioTestCase):
         called_task, called_context = run_task.call_args.args
         self.assertIn(run_id, called_task)
         self.assertEqual(called_context["retry"]["source_run_id"], run_id)
+        self.assertEqual(called_context["retry"]["recommended_strategy"]["mode"], "inspect_failed_step_first")
 
 
 if __name__ == "__main__":

--- a/tests/test_run_retry_v2.py
+++ b/tests/test_run_retry_v2.py
@@ -1,0 +1,55 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.core.agent import VelocityClawAgent
+
+
+class RunRetryV2Tests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.workspace = tempfile.mkdtemp()
+        self.db_path = str(Path(self.workspace) / "memory.db")
+        self.agent = VelocityClawAgent(Settings(workspace_root=self.workspace, memory_db_path=self.db_path))
+
+    def _create_failed_run(self):
+        run_id = self.agent.memory.create_run("fix broken tests")
+        self.agent.memory.save_step(run_id, {
+            "id": 1,
+            "title": "run failing tests",
+            "tool": "test.run",
+            "args": {"runner": "pytest"},
+            "status": "failed",
+            "result": None,
+            "error": "AssertionError",
+            "started_at": "2026-04-25T00:00:00",
+            "completed_at": "2026-04-25T00:00:01",
+        })
+        self.agent.memory.save_artifact(run_id, "step_1_stdout", "failure log", step_id=1, artifact_type="log")
+        self.agent.memory.update_run_status(run_id, "failed")
+        return run_id
+
+    def test_build_retry_context_uses_run_report_and_forensics(self):
+        run_id = self._create_failed_run()
+        context = self.agent.build_retry_context(run_id)
+        retry = context["retry"]
+        self.assertEqual(retry["source_run_id"], run_id)
+        self.assertEqual(retry["source_task"], "fix broken tests")
+        self.assertEqual(retry["source_status"], "failed")
+        self.assertIn("executive_summary", retry)
+        self.assertEqual(retry["failed_step"]["tool"], "test.run")
+        self.assertEqual(retry["recommended_strategy"]["mode"], "inspect_failed_step_first")
+
+    async def test_retry_run_replans_with_retry_context(self):
+        run_id = self._create_failed_run()
+        with patch.object(self.agent, "run_task", new=AsyncMock(return_value={"status": "completed", "run_id": "retry-run"})) as run_task:
+            result = await self.agent.retry_run(run_id)
+        self.assertEqual(result["status"], "completed")
+        called_task, called_context = run_task.call_args.args
+        self.assertIn(run_id, called_task)
+        self.assertEqual(called_context["retry"]["source_run_id"], run_id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/velocity_claw/core/agent.py
+++ b/velocity_claw/core/agent.py
@@ -65,6 +65,54 @@ class VelocityClawAgent:
         merged["planning_context"] = planning_context
         return merged
 
+    def build_retry_context(self, run_id: str) -> Dict:
+        run = self.memory.load_run(run_id)
+        if not run:
+            raise ValueError("run_not_found")
+        forensics = run.get("forensics") or {}
+        report = run.get("report") or {}
+        failed_step = forensics.get("failed_step")
+        last_step = forensics.get("last_step")
+        return {
+            "retry": {
+                "source_run_id": run_id,
+                "source_task": run.get("task"),
+                "source_status": run.get("status"),
+                "executive_summary": report.get("executive_summary"),
+                "failed_step": failed_step,
+                "last_step": last_step,
+                "artifact_overview": report.get("artifact_overview"),
+                "step_overview": report.get("step_overview"),
+                "recommended_strategy": self._build_retry_strategy(run),
+            }
+        }
+
+    async def retry_run(self, run_id: str) -> Dict:
+        run = self.memory.load_run(run_id)
+        if not run:
+            raise ValueError("run_not_found")
+        retry_context = self.build_retry_context(run_id)
+        retry_task = f"Retry run {run_id}: {run.get('task')}"
+        return await self.run_task(retry_task, retry_context)
+
+    def _build_retry_strategy(self, run: Dict) -> dict:
+        forensics = run.get("forensics") or {}
+        failed_step = forensics.get("failed_step") or {}
+        if failed_step:
+            return {
+                "mode": "inspect_failed_step_first",
+                "hint": f"Start by inspecting failed step '{failed_step.get('title')}' using tool {failed_step.get('tool')} before editing.",
+            }
+        if run.get("status") == "awaiting_approval":
+            return {
+                "mode": "resolve_approval_first",
+                "hint": "Run is awaiting approval. Inspect approval history and pending approval payload before retrying.",
+            }
+        return {
+            "mode": "replan_from_report",
+            "hint": "Use previous report and forensics to replan conservatively before executing changes.",
+        }
+
     async def run_mode(self, mode: str, task: str, context: Optional[Dict] = None) -> Dict:
         return await self.run_task(build_mode_task(mode, task), context)
 


### PR DESCRIPTION
## Summary
This PR adds a safer retry/replay orchestration layer for previous runs. Instead of blindly replaying old steps, it builds a retry context from prior run report and forensics, then replans conservatively.

## What is included
- `build_retry_context(run_id)` in `VelocityClawAgent`
- `retry_run(run_id)` in `VelocityClawAgent`
- retry context includes:
  - source run id/task/status
  - executive summary
  - failed step
  - last step
  - artifact and step overview
  - recommended retry strategy
- tests for retry context and retry run orchestration

## Why
The project already had run forensics and reports, but there was no structured way to retry a failed run using that information. This PR makes retry behavior safer and more memory-aware without changing execution permissions.
