### PR TITLE
Retry replay API routes v2: add retry context and retry route registration

### DIFF
--- a/tests/test_retry_replay_api_routes_v2.py
+++ b/tests/test_retry_replay_api_routes_v2.py
@@ -1,0 +1,69 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from velocity_claw.api.retry_routes import register_retry_routes
+
+
+def ok(payload_key, payload, **extra):
+    body = {"status": "ok", payload_key: payload}
+    body.update(extra)
+    return body
+
+
+class RetryReplayApiRoutesV2Tests(unittest.TestCase):
+    def make_client(self, agent):
+        app = FastAPI()
+        app.state.agent = agent
+        register_retry_routes(app, ok)
+        return TestClient(app)
+
+    def test_retry_context_route_returns_structured_context(self):
+        agent = SimpleNamespace(
+            build_retry_context=lambda run_id: {
+                "retry": {
+                    "source_run_id": run_id,
+                    "recommended_strategy": {"mode": "inspect_failed_step_first"},
+                }
+            },
+            retry_run=AsyncMock(),
+        )
+        client = self.make_client(agent)
+        response = client.get("/runs/run-1/retry-context")
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["run_id"], "run-1")
+        self.assertEqual(payload["retry_context"]["retry"]["source_run_id"], "run-1")
+        self.assertEqual(payload["retry_context"]["retry"]["recommended_strategy"]["mode"], "inspect_failed_step_first")
+
+    def test_retry_context_route_returns_404_for_missing_run(self):
+        def missing(_run_id):
+            raise ValueError("run_not_found")
+
+        agent = SimpleNamespace(build_retry_context=missing, retry_run=AsyncMock())
+        client = self.make_client(agent)
+        response = client.get("/runs/missing/retry-context")
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["detail"]["error"], "not_found")
+
+    def test_retry_route_returns_retry_result(self):
+        agent = SimpleNamespace(
+            build_retry_context=lambda run_id: {"retry": {"source_run_id": run_id}},
+            retry_run=AsyncMock(return_value={"run_id": "retry-1", "status": "completed"}),
+        )
+        client = self.make_client(agent)
+        response = client.post("/runs/run-1/retry")
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["run_id"], "run-1")
+        self.assertEqual(payload["retry"]["run_id"], "retry-1")
+        self.assertEqual(payload["retry"]["status"], "completed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/velocity_claw/api/retry_routes.py
+++ b/velocity_claw/api/retry_routes.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from fastapi import HTTPException
+
+
+def register_retry_routes(app, ok: Callable[..., dict]) -> None:
+    @app.get("/runs/{run_id}/retry-context")
+    def run_retry_context(run_id: str) -> dict:
+        try:
+            return ok("retry_context", app.state.agent.build_retry_context(run_id), run_id=run_id)
+        except ValueError as exc:
+            if str(exc) == "run_not_found":
+                raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Run not found"})
+            raise
+
+    @app.post("/runs/{run_id}/retry")
+    async def retry_run(run_id: str) -> dict[str, Any]:
+        try:
+            result = await app.state.agent.retry_run(run_id)
+            return ok("retry", result, run_id=run_id)
+        except ValueError as exc:
+            if str(exc) == "run_not_found":
+                raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Run not found"})
+            raise


### PR DESCRIPTION
## Summary
This PR adds a focused retry/replay API route module for exposing retry context and retry execution endpoints.

## What is included
- `velocity_claw/api/retry_routes.py`
- `register_retry_routes(app, ok)` helper
- `GET /runs/{run_id}/retry-context`
- `POST /runs/{run_id}/retry`
- route-level tests with a minimal FastAPI app

## Why
Run retry orchestration now exists in the agent core. This PR adds a small, testable API layer around that behavior without rewriting the large server module in this step.
