### PR TITLE
Operator CLI admin commands v2: add release, runs, and retry commands

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,7 +1,9 @@
 import argparse
 import asyncio
+import json
 from velocity_claw.config.settings import load_settings
 from velocity_claw.core.agent import VelocityClawAgent
+from velocity_claw.core.release import ReleaseReadinessEvaluator
 from velocity_claw.api.server import create_app
 
 
@@ -14,9 +16,22 @@ def _append_signature(text: str) -> str:
     return f"{text.rstrip()}\n\nvelocity claw"
 
 
-async def run_task_cli(task: str):
+def _print_payload(payload, as_json: bool = False):
+    if as_json:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return
+    if isinstance(payload, str):
+        print(_append_signature(payload))
+        return
+    print(_append_signature(json.dumps(payload, ensure_ascii=False, indent=2)))
+
+
+async def run_task_cli(task: str, as_json: bool = False):
     agent = build_agent()
     result = await agent.run_task(task)
+    if as_json:
+        _print_payload(result, as_json=True)
+        return
     if isinstance(result, dict):
         output = [f"Задача: {result.get('task')}", f"Статус: {result.get('status')}" ]
         summary = result.get('summary', '')
@@ -28,6 +43,36 @@ async def run_task_cli(task: str):
         print(_append_signature("\n".join(output)))
     else:
         print(_append_signature(str(result)))
+
+
+async def retry_run_cli(run_id: str, as_json: bool = False):
+    agent = build_agent()
+    result = await agent.retry_run(run_id)
+    _print_payload(result, as_json=as_json)
+
+
+def release_readiness_cli(as_json: bool = False):
+    settings = load_settings()
+    result = ReleaseReadinessEvaluator(settings).evaluate()
+    _print_payload(result, as_json=as_json)
+
+
+def list_runs_cli(limit: int, as_json: bool = False):
+    agent = build_agent()
+    result = {"runs": agent.memory.list_recent_runs(limit=limit)}
+    _print_payload(result, as_json=as_json)
+
+
+def last_failed_cli(as_json: bool = False):
+    agent = build_agent()
+    result = agent.resume_last_failed_run() or {"status": "not_found", "detail": "No failed runs recorded"}
+    _print_payload(result, as_json=as_json)
+
+
+def retry_context_cli(run_id: str, as_json: bool = False):
+    agent = build_agent()
+    result = agent.build_retry_context(run_id)
+    _print_payload(result, as_json=as_json)
 
 
 def run_server():
@@ -50,6 +95,13 @@ def main():
     parser.add_argument("--server", action="store_true", help="Start FastAPI server")
     parser.add_argument("--telegram", action="store_true", help="Start Telegram bot")
     parser.add_argument("--status", action="store_true", help="Show agent status")
+    parser.add_argument("--release-readiness", action="store_true", help="Show release readiness report")
+    parser.add_argument("--runs", action="store_true", help="List recent runs")
+    parser.add_argument("--runs-limit", type=int, default=10, help="Limit for --runs output")
+    parser.add_argument("--last-failed", action="store_true", help="Show last failed run")
+    parser.add_argument("--retry-context", type=str, help="Build retry context for a run id")
+    parser.add_argument("--retry-run", type=str, help="Retry a previous run id with retry context")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON")
     args = parser.parse_args()
 
     if args.server:
@@ -57,9 +109,20 @@ def main():
     elif args.telegram:
         run_bot()
     elif args.task:
-        asyncio.run(run_task_cli(args.task))
+        asyncio.run(run_task_cli(args.task, as_json=args.json))
+    elif args.release_readiness:
+        release_readiness_cli(as_json=args.json)
+    elif args.runs:
+        list_runs_cli(limit=args.runs_limit, as_json=args.json)
+    elif args.last_failed:
+        last_failed_cli(as_json=args.json)
+    elif args.retry_context:
+        retry_context_cli(args.retry_context, as_json=args.json)
+    elif args.retry_run:
+        asyncio.run(retry_run_cli(args.retry_run, as_json=args.json))
     elif args.status:
-        print(_append_signature("Velocity Claw ready. Use --task, --server or --telegram."))
+        agent = build_agent()
+        _print_payload(agent.get_status(), as_json=args.json)
     else:
         parser.print_help()
 

--- a/tests/test_operator_cli_admin_commands_v2.py
+++ b/tests/test_operator_cli_admin_commands_v2.py
@@ -1,0 +1,77 @@
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+import cli
+from velocity_claw.config.settings import Settings
+from velocity_claw.core.agent import VelocityClawAgent
+
+
+class OperatorCliAdminCommandsV2Tests(unittest.TestCase):
+    def make_settings(self):
+        workspace = tempfile.mkdtemp()
+        db_path = str(Path(workspace) / "memory.db")
+        return Settings(workspace_root=workspace, memory_db_path=db_path)
+
+    def test_print_payload_json(self):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            cli._print_payload({"status": "ok"}, as_json=True)
+        payload = json.loads(buffer.getvalue())
+        self.assertEqual(payload["status"], "ok")
+
+    def test_status_cli_json(self):
+        settings = self.make_settings()
+        with patch("cli.load_settings", return_value=settings):
+            buffer = io.StringIO()
+            with redirect_stdout(buffer):
+                cli.main_args = None
+                agent = cli.build_agent()
+                cli._print_payload(agent.get_status(), as_json=True)
+        payload = json.loads(buffer.getvalue())
+        self.assertEqual(payload["status"], "ready")
+        self.assertIn("available_modes", payload)
+
+    def test_list_runs_cli_json(self):
+        settings = self.make_settings()
+        agent = VelocityClawAgent(settings)
+        agent.memory.create_run("demo task")
+        with patch("cli.build_agent", return_value=agent):
+            buffer = io.StringIO()
+            with redirect_stdout(buffer):
+                cli.list_runs_cli(limit=5, as_json=True)
+        payload = json.loads(buffer.getvalue())
+        self.assertEqual(len(payload["runs"]), 1)
+        self.assertEqual(payload["runs"][0]["task"], "demo task")
+
+    def test_retry_context_cli_json(self):
+        settings = self.make_settings()
+        agent = VelocityClawAgent(settings)
+        run_id = agent.memory.create_run("fix tests")
+        agent.memory.save_step(run_id, {
+            "id": 1,
+            "title": "run tests",
+            "tool": "test.run",
+            "args": {},
+            "status": "failed",
+            "result": None,
+            "error": "boom",
+            "started_at": "2026-04-26T00:00:00",
+            "completed_at": "2026-04-26T00:00:01",
+        })
+        agent.memory.update_run_status(run_id, "failed")
+        with patch("cli.build_agent", return_value=agent):
+            buffer = io.StringIO()
+            with redirect_stdout(buffer):
+                cli.retry_context_cli(run_id, as_json=True)
+        payload = json.loads(buffer.getvalue())
+        self.assertEqual(payload["retry"]["source_run_id"], run_id)
+        self.assertEqual(payload["retry"]["recommended_strategy"]["mode"], "inspect_failed_step_first")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR expands the CLI into a more useful operator/admin interface for local server operations.

## What is included
- `--release-readiness`
- `--runs`
- `--runs-limit`
- `--last-failed`
- `--retry-context RUN_ID`
- `--retry-run RUN_ID`
- `--json` output mode
- tests for CLI JSON output, runs listing, and retry context

## Why
The project already has strong API and memory layers, but operators also need quick local commands on the server. This PR makes common admin workflows accessible without manually calling the API.
