### PR TITLE
Dashboard retry controls v2: add retry control helper module

### DIFF
--- a/tests/test_dashboard_retry_controls_v2.py
+++ b/tests/test_dashboard_retry_controls_v2.py
@@ -1,0 +1,37 @@
+import unittest
+
+from velocity_claw.api.dashboard_retry_controls import build_retry_controls
+
+
+class DashboardRetryControlsV2Tests(unittest.TestCase):
+    def test_failed_run_has_retry_controls(self):
+        controls = build_retry_controls({
+            "run_id": "run-1",
+            "task": "fix tests",
+            "status": "failed",
+        })
+        self.assertTrue(controls["available"])
+        self.assertEqual(controls["reason"], "retryable")
+        self.assertEqual(controls["links"]["retry_context"], "/runs/run-1/retry-context")
+        self.assertEqual(controls["links"]["retry_post"], "/runs/run-1/retry")
+        self.assertIn("Retry controls", controls["html"])
+        self.assertIn("POST /runs/run-1/retry", controls["html"])
+
+    def test_completed_run_is_not_retryable(self):
+        controls = build_retry_controls({
+            "run_id": "run-2",
+            "task": "done",
+            "status": "completed",
+        })
+        self.assertFalse(controls["available"])
+        self.assertEqual(controls["reason"], "status_not_retryable")
+        self.assertIn("not retryable", controls["html"])
+
+    def test_missing_run_has_no_controls(self):
+        controls = build_retry_controls(None)
+        self.assertFalse(controls["available"])
+        self.assertEqual(controls["reason"], "no_run")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/velocity_claw/api/dashboard_retry_controls.py
+++ b/velocity_claw/api/dashboard_retry_controls.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from html import escape
+from typing import Any, Optional
+
+
+def build_retry_controls(run: Optional[dict[str, Any]]) -> dict[str, Any]:
+    if not run:
+        return {
+            "available": False,
+            "reason": "no_run",
+            "links": {},
+            "html": "<p>No retry controls available.</p>",
+        }
+
+    run_id = str(run.get("run_id") or "")
+    status = run.get("status")
+    retryable = status in {"failed", "rejected", "awaiting_approval", "approved_waiting_manual_resume"}
+    links = {
+        "detail": f"/runs/{run_id}/view",
+        "forensics": f"/runs/{run_id}/forensics",
+        "report": f"/runs/{run_id}/report",
+        "retry_context": f"/runs/{run_id}/retry-context",
+        "retry_post": f"/runs/{run_id}/retry",
+    }
+    html = build_retry_controls_html(run, retryable=retryable, links=links)
+    return {
+        "available": retryable,
+        "reason": "retryable" if retryable else "status_not_retryable",
+        "run_id": run_id,
+        "status": status,
+        "task": run.get("task"),
+        "links": links,
+        "html": html,
+    }
+
+
+def build_retry_controls_html(run: dict[str, Any], *, retryable: bool, links: dict[str, str]) -> str:
+    run_id = escape(str(run.get("run_id") or ""))
+    task = escape(str(run.get("task") or ""))
+    status = escape(str(run.get("status") or ""))
+    if not retryable:
+        return f"<p>Run <code>{run_id}</code> is not retryable because status is <b>{status}</b>.</p>"
+    return "".join([
+        "<section>",
+        "<h2>Retry controls</h2>",
+        f"<p>Run: <code>{run_id}</code> — {task} — <b>{status}</b></p>",
+        "<ul>",
+        f"<li><a href='{escape(links['detail'])}'>Open run detail</a></li>",
+        f"<li><a href='{escape(links['forensics'])}'>Open forensics</a></li>",
+        f"<li><a href='{escape(links['report'])}'>Open report</a></li>",
+        f"<li><a href='{escape(links['retry_context'])}'>Open retry context</a></li>",
+        f"<li>Retry action endpoint: <code>POST {escape(links['retry_post'])}</code></li>",
+        "</ul>",
+        "</section>",
+    ])


### PR DESCRIPTION
## Summary
This PR adds a small dashboard retry controls helper module that can render retry links and retry endpoint hints for failed or paused runs.

## What is included
- `velocity_claw/api/dashboard_retry_controls.py`
- `build_retry_controls(...)`
- retry links for:
  - run detail
  - forensics
  - report
  - retry context
  - retry POST endpoint hint
- tests for retryable, non-retryable, and missing run states

## Why
The project already has retry/replay core and API routes. This PR adds a safe, isolated dashboard-ready helper without rewriting the large dashboard server file in one risky patch.
