### PR TITLE
Deployment systemd hardening v2: add hardened service templates

### DIFF
--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,35 @@
+# Velocity Claw systemd deployment
+
+This directory contains a hardened Linux systemd deployment template for running Velocity Claw as a long-lived API service.
+
+## Files
+
+- `velocity-claw.service` — systemd unit for the API service.
+- `velocity-claw.env.example` — environment template for `/etc/velocity-claw/velocity-claw.env`.
+- `velocity-claw.tmpfiles.conf` — tmpfiles config for runtime directories.
+
+## Install
+
+```bash
+sudo useradd --system --home /var/lib/velocity-claw --shell /usr/sbin/nologin velocityclaw || true
+sudo mkdir -p /opt/velocityclaw /etc/velocity-claw
+sudo cp deploy/systemd/velocity-claw.service /etc/systemd/system/velocity-claw.service
+sudo cp deploy/systemd/velocity-claw.tmpfiles.conf /etc/tmpfiles.d/velocity-claw.conf
+sudo cp deploy/systemd/velocity-claw.env.example /etc/velocity-claw/velocity-claw.env
+sudo systemd-tmpfiles --create /etc/tmpfiles.d/velocity-claw.conf
+sudo systemctl daemon-reload
+sudo systemctl enable velocity-claw
+sudo systemctl start velocity-claw
+```
+
+## Operate
+
+```bash
+sudo systemctl status velocity-claw --no-pager
+sudo journalctl -u velocity-claw -f
+sudo systemctl restart velocity-claw
+```
+
+## Security notes
+
+The unit starts with the `safe` execution profile, disables shell by default, runs as a dedicated unprivileged user, and uses systemd hardening directives such as `NoNewPrivileges`, `PrivateTmp`, `ProtectSystem`, `ProtectHome`, `CapabilityBoundingSet`, and syscall architecture restrictions.

--- a/deploy/systemd/velocity-claw.env.example
+++ b/deploy/systemd/velocity-claw.env.example
@@ -1,0 +1,11 @@
+# Copy to /etc/velocity-claw/velocity-claw.env and adjust values.
+VELOCITY_CLAW_ENV=production
+VELOCITY_CLAW_SAFE_MODE=true
+VELOCITY_CLAW_TRUSTED_MODE=false
+VELOCITY_CLAW_WORKSPACE_ROOT=/var/lib/velocity-claw/workspace
+VELOCITY_CLAW_MEMORY_ENABLED=true
+VELOCITY_CLAW_MEMORY_DB_PATH=/var/lib/velocity-claw/memory.db
+VELOCITY_CLAW_EXECUTION_PROFILE=safe
+VELOCITY_CLAW_API_PORT=8000
+VELOCITY_CLAW_SHELL_ENABLED=false
+VELOCITY_CLAW_GIT_ENABLED=true

--- a/deploy/systemd/velocity-claw.service
+++ b/deploy/systemd/velocity-claw.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=Velocity Claw API service
+Documentation=https://github.com/govor2026-design/VelocityClaw
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=velocityclaw
+Group=velocityclaw
+WorkingDirectory=/opt/velocityclaw
+EnvironmentFile=/etc/velocity-claw/velocity-claw.env
+ExecStart=/opt/velocityclaw/.venv/bin/python cli.py --server
+Restart=on-failure
+RestartSec=5s
+TimeoutStartSec=30s
+TimeoutStopSec=30s
+KillSignal=SIGINT
+
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+ReadWritePaths=/var/lib/velocity-claw /var/log/velocity-claw /opt/velocityclaw
+CapabilityBoundingSet=
+AmbientCapabilities=
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/velocity-claw.tmpfiles.conf
+++ b/deploy/systemd/velocity-claw.tmpfiles.conf
@@ -1,0 +1,4 @@
+d /var/lib/velocity-claw 0750 velocityclaw velocityclaw -
+d /var/lib/velocity-claw/workspace 0750 velocityclaw velocityclaw -
+d /var/log/velocity-claw 0750 velocityclaw velocityclaw -
+d /etc/velocity-claw 0750 root velocityclaw -

--- a/tests/test_deployment_systemd_hardening_v2.py
+++ b/tests/test_deployment_systemd_hardening_v2.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+
+def test_systemd_service_has_hardening_directives():
+    content = Path("deploy/systemd/velocity-claw.service").read_text(encoding="utf-8")
+    assert "User=velocityclaw" in content
+    assert "EnvironmentFile=/etc/velocity-claw/velocity-claw.env" in content
+    assert "ExecStart=/opt/velocityclaw/.venv/bin/python cli.py --server" in content
+    assert "Restart=on-failure" in content
+    assert "NoNewPrivileges=true" in content
+    assert "PrivateTmp=true" in content
+    assert "ProtectSystem=full" in content
+    assert "ProtectHome=true" in content
+    assert "CapabilityBoundingSet=" in content
+    assert "SystemCallArchitectures=native" in content
+
+
+def test_systemd_env_example_defaults_to_safe_profile():
+    content = Path("deploy/systemd/velocity-claw.env.example").read_text(encoding="utf-8")
+    assert "VELOCITY_CLAW_ENV=production" in content
+    assert "VELOCITY_CLAW_SAFE_MODE=true" in content
+    assert "VELOCITY_CLAW_TRUSTED_MODE=false" in content
+    assert "VELOCITY_CLAW_EXECUTION_PROFILE=safe" in content
+    assert "VELOCITY_CLAW_SHELL_ENABLED=false" in content
+
+
+def test_systemd_tmpfiles_declares_runtime_directories():
+    content = Path("deploy/systemd/velocity-claw.tmpfiles.conf").read_text(encoding="utf-8")
+    assert "/var/lib/velocity-claw" in content
+    assert "/var/lib/velocity-claw/workspace" in content
+    assert "/var/log/velocity-claw" in content
+    assert "/etc/velocity-claw" in content


### PR DESCRIPTION
## Summary
This PR adds a hardened Linux systemd deployment template for running Velocity Claw as a long-lived API service.

## What is included
- `deploy/systemd/velocity-claw.service`
- `deploy/systemd/velocity-claw.env.example`
- `deploy/systemd/velocity-claw.tmpfiles.conf`
- `deploy/systemd/README.md`
- tests for systemd hardening directives, safe env defaults, and runtime directories

## Why
The project already has API, dashboard, CLI, and retry layers. This PR adds a production-oriented Linux service template with safer defaults and repeatable deployment commands.
