### PR TITLE
Production install script v2: add Linux systemd installer

### DIFF
--- a/deploy/install/README.md
+++ b/deploy/install/README.md
@@ -1,0 +1,27 @@
+# Velocity Claw production installer
+
+This directory contains a production-oriented Linux installer for Velocity Claw.
+
+## Installer
+
+`install.sh` prepares a Linux host for running Velocity Claw with systemd.
+
+It creates or updates:
+
+- dedicated service user: `velocityclaw`
+- application directory: `/opt/velocityclaw`
+- configuration directory: `/etc/velocity-claw`
+- state directory: `/var/lib/velocity-claw`
+- log directory: `/var/log/velocity-claw`
+- Python virtual environment under `/opt/velocityclaw/.venv`
+- systemd service and tmpfiles configuration
+
+## Safety model
+
+The installer uses the systemd deployment template from `deploy/systemd` and preserves the safe production defaults from `velocity-claw.env.example`.
+
+The service starts in safe mode with the safe execution profile and shell execution disabled by default.
+
+## Usage notes
+
+Run the installer from the repository root on the target Linux host. Review `/etc/velocity-claw/velocity-claw.env` before starting the service.

--- a/deploy/install/install.sh
+++ b/deploy/install/install.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_USER="${APP_USER:-velocityclaw}"
+APP_GROUP="${APP_GROUP:-velocityclaw}"
+APP_DIR="${APP_DIR:-/opt/velocityclaw}"
+CONFIG_DIR="${CONFIG_DIR:-/etc/velocity-claw}"
+STATE_DIR="${STATE_DIR:-/var/lib/velocity-claw}"
+LOG_DIR="${LOG_DIR:-/var/log/velocity-claw}"
+SERVICE_NAME="${SERVICE_NAME:-velocity-claw}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+require_root() {
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "This installer must run as root." >&2
+    exit 1
+  fi
+}
+
+require_file() {
+  if [ ! -f "$1" ]; then
+    echo "Missing required file: $1" >&2
+    exit 1
+  fi
+}
+
+create_user() {
+  if ! id "$APP_USER" >/dev/null 2>&1; then
+    useradd --system --home "$STATE_DIR" --shell /usr/sbin/nologin "$APP_USER"
+  fi
+}
+
+create_directories() {
+  mkdir -p "$APP_DIR" "$CONFIG_DIR" "$STATE_DIR/workspace" "$LOG_DIR"
+  chown -R "$APP_USER:$APP_GROUP" "$STATE_DIR" "$LOG_DIR"
+  chmod 0750 "$CONFIG_DIR" "$STATE_DIR" "$STATE_DIR/workspace" "$LOG_DIR"
+}
+
+install_project_files() {
+  rsync -a --delete --exclude .git --exclude .venv ./ "$APP_DIR/"
+  chown -R "$APP_USER:$APP_GROUP" "$APP_DIR"
+}
+
+install_python_env() {
+  cd "$APP_DIR"
+  sudo -u "$APP_USER" "$PYTHON_BIN" -m venv .venv
+  sudo -u "$APP_USER" .venv/bin/python -m pip install --upgrade pip
+  if [ -f requirements.txt ]; then
+    sudo -u "$APP_USER" .venv/bin/python -m pip install -r requirements.txt
+  fi
+}
+
+install_config() {
+  require_file "$APP_DIR/deploy/systemd/velocity-claw.env.example"
+  if [ ! -f "$CONFIG_DIR/velocity-claw.env" ]; then
+    cp "$APP_DIR/deploy/systemd/velocity-claw.env.example" "$CONFIG_DIR/velocity-claw.env"
+  fi
+  chown root:"$APP_GROUP" "$CONFIG_DIR/velocity-claw.env"
+  chmod 0640 "$CONFIG_DIR/velocity-claw.env"
+}
+
+install_systemd() {
+  require_file "$APP_DIR/deploy/systemd/velocity-claw.service"
+  require_file "$APP_DIR/deploy/systemd/velocity-claw.tmpfiles.conf"
+  cp "$APP_DIR/deploy/systemd/velocity-claw.service" "/etc/systemd/system/$SERVICE_NAME.service"
+  cp "$APP_DIR/deploy/systemd/velocity-claw.tmpfiles.conf" "/etc/tmpfiles.d/$SERVICE_NAME.conf"
+  systemd-tmpfiles --create "/etc/tmpfiles.d/$SERVICE_NAME.conf"
+  systemctl daemon-reload
+  systemctl enable "$SERVICE_NAME"
+}
+
+print_summary() {
+  cat <<EOF
+Velocity Claw installation finished.
+
+Service: $SERVICE_NAME
+App dir: $APP_DIR
+Config: $CONFIG_DIR/velocity-claw.env
+State: $STATE_DIR
+Logs: $LOG_DIR
+
+Next steps:
+1. Review $CONFIG_DIR/velocity-claw.env
+2. Start the service with: systemctl start $SERVICE_NAME
+3. Check status with: systemctl status $SERVICE_NAME --no-pager
+EOF
+}
+
+main() {
+  require_root
+  create_user
+  create_directories
+  install_project_files
+  install_python_env
+  install_config
+  install_systemd
+  print_summary
+}
+
+main "$@"

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_USER="${APP_USER:-velocityclaw}"
+APP_GROUP="${APP_GROUP:-velocityclaw}"
+APP_DIR="${APP_DIR:-/opt/velocityclaw}"
+CONFIG_DIR="${CONFIG_DIR:-/etc/velocity-claw}"
+DATA_DIR="${DATA_DIR:-/var/lib/velocity-claw}"
+LOG_DIR="${LOG_DIR:-/var/log/velocity-claw}"
+SERVICE_NAME="${SERVICE_NAME:-velocity-claw}"
+
+require_root() {
+  if [[ "${EUID}" -ne 0 ]]; then
+    echo "This installer must be run as root." >&2
+    exit 1
+  fi
+}
+
+copy_repo() {
+  local source_dir
+  source_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  mkdir -p "${APP_DIR}"
+  rsync -a --delete \
+    --exclude='.git' \
+    --exclude='.venv' \
+    --exclude='__pycache__' \
+    "${source_dir}/" "${APP_DIR}/"
+}
+
+ensure_user() {
+  if ! id "${APP_USER}" >/dev/null 2>&1; then
+    useradd --system --home "${DATA_DIR}" --shell /usr/sbin/nologin "${APP_USER}"
+  fi
+}
+
+install_files() {
+  mkdir -p "${CONFIG_DIR}" "${DATA_DIR}/workspace" "${LOG_DIR}"
+  cp "${APP_DIR}/deploy/systemd/velocity-claw.service" "/etc/systemd/system/${SERVICE_NAME}.service"
+  cp "${APP_DIR}/deploy/systemd/velocity-claw.tmpfiles.conf" "/etc/tmpfiles.d/${SERVICE_NAME}.conf"
+  if [[ ! -f "${CONFIG_DIR}/velocity-claw.env" ]]; then
+    cp "${APP_DIR}/deploy/systemd/velocity-claw.env.example" "${CONFIG_DIR}/velocity-claw.env"
+  fi
+  chown -R "${APP_USER}:${APP_GROUP}" "${DATA_DIR}" "${LOG_DIR}" "${APP_DIR}"
+  chown root:"${APP_GROUP}" "${CONFIG_DIR}" "${CONFIG_DIR}/velocity-claw.env"
+  chmod 0750 "${CONFIG_DIR}"
+  chmod 0640 "${CONFIG_DIR}/velocity-claw.env"
+}
+
+install_python() {
+  python3 -m venv "${APP_DIR}/.venv"
+  "${APP_DIR}/.venv/bin/python" -m pip install --upgrade pip
+  if [[ -f "${APP_DIR}/requirements.txt" ]]; then
+    "${APP_DIR}/.venv/bin/pip" install -r "${APP_DIR}/requirements.txt"
+  fi
+}
+
+start_service() {
+  systemd-tmpfiles --create "/etc/tmpfiles.d/${SERVICE_NAME}.conf"
+  systemctl daemon-reload
+  systemctl enable "${SERVICE_NAME}"
+  systemctl restart "${SERVICE_NAME}"
+}
+
+main() {
+  require_root
+  ensure_user
+  copy_repo
+  install_files
+  install_python
+  start_service
+  echo "Velocity Claw installed."
+  echo "Status: sudo systemctl status ${SERVICE_NAME} --no-pager"
+  echo "Logs:   sudo journalctl -u ${SERVICE_NAME} -f"
+}
+
+main "$@"

--- a/tests/test_production_install_script_v2.py
+++ b/tests/test_production_install_script_v2.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+
+INSTALLER = Path("deploy/install/install.sh")
+README = Path("deploy/install/README.md")
+
+
+def test_install_script_is_fail_fast_and_root_guarded():
+    content = INSTALLER.read_text(encoding="utf-8")
+    assert "set -euo pipefail" in content
+    assert "require_root" in content
+    assert "id -u" in content
+    assert "This installer must run as root" in content
+
+
+def test_install_script_uses_expected_production_paths():
+    content = INSTALLER.read_text(encoding="utf-8")
+    assert "APP_DIR=\"${APP_DIR:-/opt/velocityclaw}\"" in content
+    assert "CONFIG_DIR=\"${CONFIG_DIR:-/etc/velocity-claw}\"" in content
+    assert "STATE_DIR=\"${STATE_DIR:-/var/lib/velocity-claw}\"" in content
+    assert "LOG_DIR=\"${LOG_DIR:-/var/log/velocity-claw}\"" in content
+
+
+def test_install_script_installs_systemd_assets_and_config_permissions():
+    content = INSTALLER.read_text(encoding="utf-8")
+    assert "deploy/systemd/velocity-claw.service" in content
+    assert "deploy/systemd/velocity-claw.tmpfiles.conf" in content
+    assert "systemctl daemon-reload" in content
+    assert "systemctl enable" in content
+    assert "chmod 0640" in content
+    assert "chown root:\"$APP_GROUP\"" in content
+
+
+def test_install_readme_documents_safe_defaults():
+    content = README.read_text(encoding="utf-8")
+    assert "safe execution profile" in content
+    assert "shell execution disabled" in content
+    assert "/etc/velocity-claw/velocity-claw.env" in content


### PR DESCRIPTION
## Summary
This PR adds a production-oriented Linux installer that prepares Velocity Claw for systemd-based operation.

## What is included
- `deploy/install/install.sh`
- `deploy/install/README.md`
- installer flow for:
  - service user
  - app/config/state/log directories
  - Python virtual environment
  - env file setup
  - systemd unit/tmpfiles installation
- tests for fail-fast behavior, production paths, systemd flow, and safe defaults documentation

## Why
The project already has systemd and Docker Compose deployment templates. This PR adds a repeatable install path for Linux hosts while preserving safe production defaults.
