### PR TITLE
Packaging metadata pyproject v2: add installable Python package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "velocity-claw"
+version = "0.2.0"
+description = "Self-hosted AI dev-agent for controlled repo automation, approvals, retry/replay, and operator deployment."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Proprietary" }
+authors = [
+  { name = "Velocity Claw maintainers" }
+]
+keywords = ["ai-agent", "dev-agent", "automation", "fastapi", "self-hosted"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Framework :: FastAPI",
+  "Topic :: Software Development",
+]
+dependencies = [
+  "fastapi>=0.110.0",
+  "uvicorn[standard]>=0.23.0",
+  "requests>=2.31.0",
+  "aiohttp>=3.9.0",
+  "python-dotenv>=1.0.0",
+  "python-telegram-bot>=20.6",
+  "PyYAML>=6.0",
+  "pydantic>=2.0.0",
+  "slowapi>=0.1.9",
+  "limits>=3.13.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0.0",
+]
+
+[project.scripts]
+velocity-claw = "cli:main"
+
+[tool.setuptools.packages.find]
+include = ["velocity_claw*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/test_packaging_metadata_pyproject_v2.py
+++ b/tests/test_packaging_metadata_pyproject_v2.py
@@ -1,0 +1,36 @@
+import sys
+import tomllib
+from pathlib import Path
+
+from velocity_claw.__version__ import __version__
+
+
+def load_pyproject():
+    return tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+
+
+def test_pyproject_version_matches_version_files():
+    pyproject = load_pyproject()
+    version_file = Path("VERSION").read_text(encoding="utf-8").strip()
+    assert pyproject["project"]["version"] == version_file
+    assert pyproject["project"]["version"] == __version__
+
+
+def test_pyproject_declares_console_entrypoint():
+    pyproject = load_pyproject()
+    assert pyproject["project"]["scripts"]["velocity-claw"] == "cli:main"
+
+
+def test_pyproject_runtime_and_dev_dependencies_are_separated():
+    pyproject = load_pyproject()
+    dependencies = pyproject["project"]["dependencies"]
+    dev_dependencies = pyproject["project"]["optional-dependencies"]["dev"]
+    assert any(item.startswith("fastapi") for item in dependencies)
+    assert any(item.startswith("uvicorn") for item in dependencies)
+    assert not any(item.startswith("pytest") for item in dependencies)
+    assert any(item.startswith("pytest") for item in dev_dependencies)
+
+
+def test_pyproject_package_discovery_includes_velocity_claw():
+    pyproject = load_pyproject()
+    assert "velocity_claw*" in pyproject["tool"]["setuptools"]["packages"]["find"]["include"]


### PR DESCRIPTION
## Summary
This PR adds Python packaging metadata so Velocity Claw has a proper installable package definition in addition to requirements.txt.

## What is included
- `pyproject.toml`
- package metadata for version `0.2.0`
- runtime dependencies
- dev optional dependencies
- console script entrypoint: `velocity-claw = cli:main`
- pytest configuration
- tests for version consistency, entrypoint, dependency separation, and package discovery

## Why
The project now has release/versioning docs and deployment flows. This PR adds the missing Python packaging metadata needed for cleaner installs and future release automation.
