### PR TITLE
CI package validation integration v2: run package validator in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Validate package metadata
+        run: |
+          python scripts/validate_package.py
+
       - name: Run tests
         run: |
           pytest -q

--- a/tests/test_ci_package_validation_integration_v2.py
+++ b/tests/test_ci_package_validation_integration_v2.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_ci_runs_package_metadata_validator_before_tests():
+    content = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+    assert "Validate package metadata" in content
+    assert "python scripts/validate_package.py" in content
+    assert content.index("Validate package metadata") < content.index("Run tests")


### PR DESCRIPTION
## Summary
This PR integrates the package metadata validator into CI so packaging/versioning issues fail early on every PR.

## What is included
- CI step: `Validate package metadata`
- runs `python scripts/validate_package.py` before tests
- test to keep the CI validator step present and ordered before `Run tests`

## Why
The project now has package metadata and a package validator. This PR wires that validator into CI so pyproject/version drift is caught automatically.
