### PR TITLE
GitHub release automation v2: add manual release validation workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag, for example v0.2.0"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Validate package metadata
+        run: |
+          python scripts/validate_package.py
+
+      - name: Run tests
+        run: |
+          pytest -q
+
+      - name: Validate release tag matches VERSION
+        run: |
+          VERSION_VALUE="$(cat VERSION | tr -d '[:space:]')"
+          EXPECTED_TAG="v${VERSION_VALUE}"
+          if [ "${{ inputs.tag }}" != "$EXPECTED_TAG" ]; then
+            echo "Release tag ${{ inputs.tag }} does not match VERSION $EXPECTED_TAG" >&2
+            exit 1
+          fi
+
+      - name: Generate release summary
+        run: |
+          VERSION_VALUE="$(cat VERSION | tr -d '[:space:]')"
+          mkdir -p dist
+          {
+            echo "# Velocity Claw ${VERSION_VALUE}"
+            echo
+            echo "## Validation"
+            echo
+            echo "- Package metadata validated"
+            echo "- Tests passed"
+            echo "- Release tag matched VERSION"
+            echo
+            echo "## Release docs"
+            echo
+            echo "- docs/RELEASE.md"
+            echo "- docs/DEPLOYMENT.md"
+          } > dist/release-summary.md
+
+      - name: Upload release summary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-summary
+          path: dist/release-summary.md

--- a/tests/test_github_release_automation_v2.py
+++ b/tests/test_github_release_automation_v2.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+WORKFLOW = Path(".github/workflows/release.yml")
+
+
+def test_release_workflow_has_manual_dispatch_and_tag_input():
+    content = WORKFLOW.read_text(encoding="utf-8")
+    assert "workflow_dispatch:" in content
+    assert "tag:" in content
+    assert "Release tag" in content
+
+
+def test_release_workflow_runs_required_validation_gates():
+    content = WORKFLOW.read_text(encoding="utf-8")
+    assert "Validate package metadata" in content
+    assert "python scripts/validate_package.py" in content
+    assert "Run tests" in content
+    assert "pytest -q" in content
+    assert "Validate release tag matches VERSION" in content
+    assert "EXPECTED_TAG=\"v${VERSION_VALUE}\"" in content
+
+
+def test_release_workflow_uploads_release_summary_artifact():
+    content = WORKFLOW.read_text(encoding="utf-8")
+    assert "Generate release summary" in content
+    assert "dist/release-summary.md" in content
+    assert "actions/upload-artifact@v4" in content
+    assert "release-summary" in content


### PR DESCRIPTION
## Summary
This PR adds a manual GitHub Actions release workflow that validates package metadata, runs tests, checks the requested release tag against VERSION, and uploads a release summary artifact.

## What is included
- `.github/workflows/release.yml`
- manual `workflow_dispatch` input for release tag
- package metadata validation
- test suite execution
- tag/version consistency check
- generated `dist/release-summary.md`
- artifact upload
- tests that keep the release workflow gates in place

## Why
The project now has version metadata, release docs, and package validation. This PR adds a safe manual release automation layer without automatically publishing artifacts or creating releases yet.
