### PR TITLE
Build artifact workflow v2: add Python package artifact build workflow

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,0 +1,51 @@
+name: build-artifacts
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "pyproject.toml"
+      - "VERSION"
+      - "velocity_claw/**"
+      - "scripts/validate_package.py"
+      - ".github/workflows/build-artifacts.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-artifacts:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install build
+
+      - name: Validate package metadata
+        run: |
+          python scripts/validate_package.py
+
+      - name: Run tests
+        run: |
+          pytest -q
+
+      - name: Build Python artifacts
+        run: |
+          python -m build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-artifacts
+          path: dist/*

--- a/tests/test_build_artifact_workflow_v2.py
+++ b/tests/test_build_artifact_workflow_v2.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+
+WORKFLOW = Path(".github/workflows/build-artifacts.yml")
+
+
+def test_build_artifact_workflow_has_manual_dispatch_and_pr_paths():
+    content = WORKFLOW.read_text(encoding="utf-8")
+    assert "workflow_dispatch:" in content
+    assert "pull_request:" in content
+    assert "pyproject.toml" in content
+    assert "scripts/validate_package.py" in content
+
+
+def test_build_artifact_workflow_validates_before_building():
+    content = WORKFLOW.read_text(encoding="utf-8")
+    assert "Validate package metadata" in content
+    assert "python scripts/validate_package.py" in content
+    assert "Run tests" in content
+    assert "pytest -q" in content
+    assert "Build Python artifacts" in content
+    assert "python -m build" in content
+    assert content.index("Validate package metadata") < content.index("Build Python artifacts")
+    assert content.index("Run tests") < content.index("Build Python artifacts")
+
+
+def test_build_artifact_workflow_uploads_dist_artifacts():
+    content = WORKFLOW.read_text(encoding="utf-8")
+    assert "actions/upload-artifact@v4" in content
+    assert "python-package-artifacts" in content
+    assert "path: dist/*" in content


### PR DESCRIPTION
## Summary
This PR adds a manual and path-filtered build artifact workflow for Python package artifacts.

## What is included
- `.github/workflows/build-artifacts.yml`
- manual `workflow_dispatch`
- PR path filters for packaging-related files
- package metadata validation
- test execution
- `python -m build`
- upload of `dist/*` as `python-package-artifacts`
- tests to keep workflow gates and artifact upload in place

## Why
The project now has pyproject metadata, package validation, CI integration, and release automation. This PR adds a controlled build artifact workflow without automatically publishing packages.
