### PR TITLE
Changelog release notes automation v2: add release notes generator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,8 +65,14 @@ jobs:
             echo "- docs/DEPLOYMENT.md"
           } > dist/release-summary.md
 
-      - name: Upload release summary artifact
+      - name: Generate release notes
+        run: |
+          python scripts/generate_release_notes.py
+
+      - name: Upload release artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: release-summary
-          path: dist/release-summary.md
+          name: release-artifacts
+          path: |
+            dist/release-summary.md
+            dist/release-notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,14 +65,8 @@ jobs:
             echo "- docs/DEPLOYMENT.md"
           } > dist/release-summary.md
 
-      - name: Generate release notes
-        run: |
-          python scripts/generate_release_notes.py
-
-      - name: Upload release artifacts
+      - name: Upload release summary artifact
         uses: actions/upload-artifact@v4
         with:
-          name: release-artifacts
-          path: |
-            dist/release-summary.md
-            dist/release-notes.md
+          name: release-summary
+          path: dist/release-summary.md

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def generate_release_notes(root: Path = ROOT) -> str:
+    version = (root / "VERSION").read_text(encoding="utf-8").strip()
+    deployment_doc = root / "docs" / "DEPLOYMENT.md"
+    release_doc = root / "docs" / "RELEASE.md"
+    pyproject = root / "pyproject.toml"
+
+    checks = {
+        "deployment_guide": deployment_doc.exists(),
+        "release_guide": release_doc.exists(),
+        "pyproject": pyproject.exists(),
+        "systemd_deployment": (root / "deploy" / "systemd" / "velocity-claw.service").exists(),
+        "docker_compose_deployment": (root / "deploy" / "docker" / "docker-compose.yml").exists(),
+        "production_installer": (root / "deploy" / "install" / "install.sh").exists(),
+        "build_artifact_workflow": (root / ".github" / "workflows" / "build-artifacts.yml").exists(),
+        "release_workflow": (root / ".github" / "workflows" / "release.yml").exists(),
+    }
+
+    checklist = "\n".join(f"- [{'x' if ok else ' '}] {name.replace('_', ' ')}" for name, ok in checks.items())
+    return f"""# Velocity Claw v{version}
+
+## Summary
+
+Velocity Claw v{version} is an advanced self-hosted AI dev-agent release focused on controlled execution, operator workflows, deployment readiness, package metadata, and release automation.
+
+## Included release areas
+
+- Agent runtime, memory, approvals, retry/replay, and reports
+- API, dashboard helpers, operator CLI, and queue/metrics foundations
+- Systemd deployment, Docker Compose deployment, and production installer
+- Version metadata, package validation, release workflow, and build artifact workflow
+
+## Release readiness checklist
+
+{checklist}
+
+## Operator docs
+
+- `README.md`
+- `docs/DEPLOYMENT.md`
+- `docs/RELEASE.md`
+
+## Build artifacts
+
+Python package artifacts are built through the `build-artifacts` workflow and uploaded as GitHub Actions artifacts.
+"""
+
+
+def write_release_notes(root: Path = ROOT, output_path: Path | None = None) -> Path:
+    output = output_path or root / "dist" / "release-notes.md"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(generate_release_notes(root), encoding="utf-8")
+    return output
+
+
+def main() -> int:
+    path = write_release_notes()
+    print(f"release notes written: {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_changelog_release_notes_automation_v2.py
+++ b/tests/test_changelog_release_notes_automation_v2.py
@@ -29,3 +29,4 @@ def test_write_release_notes_creates_output_file(tmp_path):
     assert written == output
     assert output.exists()
     assert "Velocity Claw" in output.read_text(encoding="utf-8")
+    assert output.name == "release-notes.md"

--- a/tests/test_changelog_release_notes_automation_v2.py
+++ b/tests/test_changelog_release_notes_automation_v2.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from scripts.generate_release_notes import generate_release_notes, write_release_notes
+
+
+def test_generate_release_notes_mentions_version_and_release_areas():
+    notes = generate_release_notes(Path.cwd())
+    version = Path("VERSION").read_text(encoding="utf-8").strip()
+    assert f"Velocity Claw v{version}" in notes
+    assert "Release readiness checklist" in notes
+    assert "Systemd deployment" in notes
+    assert "Docker Compose deployment" in notes
+    assert "production installer" in notes
+    assert "build-artifacts" in notes
+
+
+def test_generate_release_notes_checks_core_docs_and_workflows():
+    notes = generate_release_notes(Path.cwd())
+    assert "[x] deployment guide" in notes
+    assert "[x] release guide" in notes
+    assert "[x] pyproject" in notes
+    assert "[x] release workflow" in notes
+    assert "[x] build artifact workflow" in notes
+
+
+def test_write_release_notes_creates_output_file(tmp_path):
+    output = tmp_path / "release-notes.md"
+    written = write_release_notes(Path.cwd(), output)
+    assert written == output
+    assert output.exists()
+    assert "Velocity Claw" in output.read_text(encoding="utf-8")

--- a/tests/test_github_release_automation_v2.py
+++ b/tests/test_github_release_automation_v2.py
@@ -21,12 +21,9 @@ def test_release_workflow_runs_required_validation_gates():
     assert "EXPECTED_TAG=\"v${VERSION_VALUE}\"" in content
 
 
-def test_release_workflow_uploads_release_artifacts():
+def test_release_workflow_uploads_release_summary_artifact():
     content = WORKFLOW.read_text(encoding="utf-8")
     assert "Generate release summary" in content
-    assert "Generate release notes" in content
-    assert "generate_release_notes.py" in content
     assert "dist/release-summary.md" in content
-    assert "dist/release-notes.md" in content
     assert "upload-artifact" in content
-    assert "release-artifacts" in content
+    assert "release-summary" in content

--- a/tests/test_github_release_automation_v2.py
+++ b/tests/test_github_release_automation_v2.py
@@ -21,9 +21,12 @@ def test_release_workflow_runs_required_validation_gates():
     assert "EXPECTED_TAG=\"v${VERSION_VALUE}\"" in content
 
 
-def test_release_workflow_uploads_release_summary_artifact():
+def test_release_workflow_uploads_release_artifacts():
     content = WORKFLOW.read_text(encoding="utf-8")
     assert "Generate release summary" in content
+    assert "Generate release notes" in content
+    assert "generate_release_notes.py" in content
     assert "dist/release-summary.md" in content
-    assert "actions/upload-artifact@v4" in content
-    assert "release-summary" in content
+    assert "dist/release-notes.md" in content
+    assert "upload-artifact" in content
+    assert "release-artifacts" in content


### PR DESCRIPTION
## Summary
This PR adds release notes automation so the release workflow can generate a structured release-notes artifact alongside the release summary.

## What is included
- `scripts/generate_release_notes.py`
- generated `dist/release-notes.md`
- release notes include:
  - version
  - release areas
  - readiness checklist
  - operator docs
  - build artifact note
- release workflow now generates and uploads both summary and release notes
- tests for release notes generation and workflow artifact coverage

## Why
The project now has release validation and build artifacts. This PR adds a repeatable release notes layer so releases are easier to review and publish later.
