### PR TITLE
Release notes workflow integration v3: upload release notes artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,8 +65,14 @@ jobs:
             echo "- docs/DEPLOYMENT.md"
           } > dist/release-summary.md
 
-      - name: Upload release summary artifact
+      - name: Generate release notes
+        run: |
+          python scripts/generate_release_notes.py
+
+      - name: Upload release artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: release-summary
-          path: dist/release-summary.md
+          name: release-artifacts
+          path: |
+            dist/release-summary.md
+            dist/release-notes.md

--- a/tests/test_github_release_automation_v2.py
+++ b/tests/test_github_release_automation_v2.py
@@ -21,9 +21,12 @@ def test_release_workflow_runs_required_validation_gates():
     assert "EXPECTED_TAG=\"v${VERSION_VALUE}\"" in content
 
 
-def test_release_workflow_uploads_release_summary_artifact():
+def test_release_workflow_uploads_release_artifacts():
     content = WORKFLOW.read_text(encoding="utf-8")
     assert "Generate release summary" in content
+    assert "Generate release notes" in content
+    assert "python scripts/generate_release_notes.py" in content
     assert "dist/release-summary.md" in content
+    assert "dist/release-notes.md" in content
     assert "upload-artifact" in content
-    assert "release-summary" in content
+    assert "release-artifacts" in content


### PR DESCRIPTION
## Summary
This PR integrates the existing release notes generator into the manual release workflow.

## What is included
- release workflow step: `Generate release notes`
- runs `python scripts/generate_release_notes.py`
- uploads both:
  - `dist/release-summary.md`
  - `dist/release-notes.md`
- artifact name changed to `release-artifacts`
- tests updated for release notes workflow integration

## Why
The release notes generator is already in the repository. This PR wires it into the manual release validation workflow in a small isolated change.
