### PR TITLE
Tag version bump automation v2: add synchronized version bump script

### DIFF
--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def validate_version(version: str) -> str:
+    value = version.strip()
+    if not SEMVER_RE.match(value):
+        raise ValueError("version must use semantic x.y.z format")
+    return value
+
+
+def replace_once(content: str, old: str, new: str) -> str:
+    if old not in content:
+        raise ValueError(f"target not found: {old}")
+    return content.replace(old, new, 1)
+
+
+def bump_version(version: str, root: Path = ROOT, dry_run: bool = False) -> dict:
+    new_version = validate_version(version)
+    version_path = root / "VERSION"
+    version_module_path = root / "velocity_claw" / "__version__.py"
+    pyproject_path = root / "pyproject.toml"
+
+    old_version = version_path.read_text(encoding="utf-8").strip()
+    version_module = version_module_path.read_text(encoding="utf-8")
+    pyproject = pyproject_path.read_text(encoding="utf-8")
+
+    updated_version_file = f"{new_version}\n"
+    updated_version_module = replace_once(version_module, f'__version__ = "{old_version}"', f'__version__ = "{new_version}"')
+    updated_pyproject = replace_once(pyproject, f'version = "{old_version}"', f'version = "{new_version}"')
+
+    if not dry_run:
+        version_path.write_text(updated_version_file, encoding="utf-8")
+        version_module_path.write_text(updated_version_module, encoding="utf-8")
+        pyproject_path.write_text(updated_pyproject, encoding="utf-8")
+
+    return {
+        "status": "ok",
+        "old_version": old_version,
+        "new_version": new_version,
+        "dry_run": dry_run,
+        "updated_files": ["VERSION", "velocity_claw/__version__.py", "pyproject.toml"],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Bump Velocity Claw version metadata")
+    parser.add_argument("version", help="New semantic version, for example 0.2.1")
+    parser.add_argument("--dry-run", action="store_true", help="Validate changes without writing files")
+    args = parser.parse_args()
+    result = bump_version(args.version, dry_run=args.dry_run)
+    print(f"version bump {result['old_version']} -> {result['new_version']} dry_run={result['dry_run']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_tag_version_bump_automation_v2.py
+++ b/tests/test_tag_version_bump_automation_v2.py
@@ -1,0 +1,45 @@
+import shutil
+from pathlib import Path
+
+import pytest
+
+from scripts.bump_version import bump_version, validate_version
+from scripts.validate_package import validate_package
+
+
+def copy_repo(tmp_path):
+    root = tmp_path / "repo"
+    shutil.copytree(Path.cwd(), root, ignore=shutil.ignore_patterns(".git", ".venv", "__pycache__", ".pytest_cache", "dist"))
+    return root
+
+
+def test_validate_version_accepts_semver():
+    assert validate_version("1.2.3") == "1.2.3"
+
+
+def test_validate_version_rejects_invalid_values():
+    with pytest.raises(ValueError):
+        validate_version("1.2")
+    with pytest.raises(ValueError):
+        validate_version("v1.2.3")
+
+
+def test_bump_version_dry_run_does_not_write(tmp_path):
+    root = copy_repo(tmp_path)
+    old_version = (root / "VERSION").read_text(encoding="utf-8").strip()
+    result = bump_version("0.3.0", root=root, dry_run=True)
+    assert result["status"] == "ok"
+    assert result["old_version"] == old_version
+    assert result["new_version"] == "0.3.0"
+    assert (root / "VERSION").read_text(encoding="utf-8").strip() == old_version
+
+
+def test_bump_version_updates_all_metadata_files(tmp_path):
+    root = copy_repo(tmp_path)
+    result = bump_version("0.3.0", root=root)
+    assert result["new_version"] == "0.3.0"
+    assert (root / "VERSION").read_text(encoding="utf-8").strip() == "0.3.0"
+    assert '__version__ = "0.3.0"' in (root / "velocity_claw" / "__version__.py").read_text(encoding="utf-8")
+    assert 'version = "0.3.0"' in (root / "pyproject.toml").read_text(encoding="utf-8")
+    validation = validate_package(root)
+    assert validation["version"] == "0.3.0"


### PR DESCRIPTION
## Summary
This PR adds a safe version bump helper that synchronizes project version metadata across the repository.

## What is included
- `scripts/bump_version.py`
- semantic version validation
- dry-run support
- synchronized updates for:
  - `VERSION`
  - `velocity_claw/__version__.py`
  - `pyproject.toml`
- tests for validation, dry-run behavior, real metadata update, and package validation after bump

## Why
The project now has version metadata, package validation, release notes, and release workflows. This PR reduces manual version drift before tagging or publishing releases.
