### PR TITLE
Operator release command v2: add local release checklist CLI commands

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,10 +1,14 @@
 import argparse
 import asyncio
 import json
+from pathlib import Path
+
 from velocity_claw.config.settings import load_settings
 from velocity_claw.core.agent import VelocityClawAgent
 from velocity_claw.core.release import ReleaseReadinessEvaluator
 from velocity_claw.api.server import create_app
+from scripts.generate_release_notes import write_release_notes
+from scripts.validate_package import validate_package
 
 
 def build_agent():
@@ -57,6 +61,33 @@ def release_readiness_cli(as_json: bool = False):
     _print_payload(result, as_json=as_json)
 
 
+def validate_package_cli(as_json: bool = False):
+    result = validate_package(Path.cwd())
+    _print_payload(result, as_json=as_json)
+
+
+def generate_release_notes_cli(as_json: bool = False):
+    output_path = write_release_notes(Path.cwd())
+    result = {"status": "ok", "path": str(output_path)}
+    _print_payload(result, as_json=as_json)
+
+
+def release_checklist_cli(as_json: bool = False):
+    settings = load_settings()
+    readiness = ReleaseReadinessEvaluator(settings).evaluate()
+    package = validate_package(Path.cwd())
+    notes_path = write_release_notes(Path.cwd())
+    result = {
+        "status": "ok",
+        "version": package["version"],
+        "package_validation": package,
+        "release_readiness": readiness,
+        "release_notes_path": str(notes_path),
+        "ready": readiness.get("readiness") == "ready",
+    }
+    _print_payload(result, as_json=as_json)
+
+
 def list_runs_cli(limit: int, as_json: bool = False):
     agent = build_agent()
     result = {"runs": agent.memory.list_recent_runs(limit=limit)}
@@ -96,6 +127,9 @@ def main():
     parser.add_argument("--telegram", action="store_true", help="Start Telegram bot")
     parser.add_argument("--status", action="store_true", help="Show agent status")
     parser.add_argument("--release-readiness", action="store_true", help="Show release readiness report")
+    parser.add_argument("--validate-package", action="store_true", help="Validate package metadata")
+    parser.add_argument("--generate-release-notes", action="store_true", help="Generate release notes into dist/release-notes.md")
+    parser.add_argument("--release-checklist", action="store_true", help="Run local release checklist summary")
     parser.add_argument("--runs", action="store_true", help="List recent runs")
     parser.add_argument("--runs-limit", type=int, default=10, help="Limit for --runs output")
     parser.add_argument("--last-failed", action="store_true", help="Show last failed run")
@@ -112,6 +146,12 @@ def main():
         asyncio.run(run_task_cli(args.task, as_json=args.json))
     elif args.release_readiness:
         release_readiness_cli(as_json=args.json)
+    elif args.validate_package:
+        validate_package_cli(as_json=args.json)
+    elif args.generate_release_notes:
+        generate_release_notes_cli(as_json=args.json)
+    elif args.release_checklist:
+        release_checklist_cli(as_json=args.json)
     elif args.runs:
         list_runs_cli(limit=args.runs_limit, as_json=args.json)
     elif args.last_failed:

--- a/tests/test_operator_release_command_v2.py
+++ b/tests/test_operator_release_command_v2.py
@@ -1,0 +1,42 @@
+import io
+import json
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+import cli
+from velocity_claw.config.settings import Settings
+
+
+def test_validate_package_cli_json_outputs_package_status():
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        cli.validate_package_cli(as_json=True)
+    payload = json.loads(buffer.getvalue())
+    assert payload["status"] == "ok"
+    assert payload["name"] == "velocity-claw"
+    assert payload["version"] == Path("VERSION").read_text(encoding="utf-8").strip()
+
+
+def test_generate_release_notes_cli_json_outputs_path(tmp_path):
+    with patch("cli.Path.cwd", return_value=Path.cwd()):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            cli.generate_release_notes_cli(as_json=True)
+    payload = json.loads(buffer.getvalue())
+    assert payload["status"] == "ok"
+    assert payload["path"].endswith("dist/release-notes.md")
+    assert Path(payload["path"]).exists()
+
+
+def test_release_checklist_cli_json_combines_package_readiness_and_notes(tmp_path):
+    settings = Settings(workspace_root=str(tmp_path), memory_db_path=str(tmp_path / "memory.db"))
+    with patch("cli.load_settings", return_value=settings):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            cli.release_checklist_cli(as_json=True)
+    payload = json.loads(buffer.getvalue())
+    assert payload["status"] == "ok"
+    assert payload["package_validation"]["status"] == "ok"
+    assert "release_readiness" in payload
+    assert payload["release_notes_path"].endswith("dist/release-notes.md")


### PR DESCRIPTION
## Summary
This PR adds local operator release commands to the CLI so release validation and release notes generation can be run without manually invoking individual scripts.

## What is included
- `--validate-package`
- `--generate-release-notes`
- `--release-checklist`
- JSON output support for release commands
- combined release checklist with package validation, release readiness, and release notes path
- tests for all new operator release commands

## Why
The project now has package validation, release notes, release workflows, and version bump automation. This PR exposes those release operations through the existing operator CLI.
