### PR TITLE
GitHub release publish v3: add manual release publishing workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,71 @@
+name: publish-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag, for example v0.2.0"
+        required: true
+        type: string
+      prerelease:
+        description: "Mark release as prerelease"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install build
+
+      - name: Validate package metadata
+        run: |
+          python scripts/validate_package.py
+
+      - name: Run tests
+        run: |
+          pytest -q
+
+      - name: Validate release tag matches VERSION
+        run: |
+          VERSION_VALUE="$(cat VERSION | tr -d '[:space:]')"
+          EXPECTED_TAG="v${VERSION_VALUE}"
+          if [ "${{ inputs.tag }}" != "$EXPECTED_TAG" ]; then
+            echo "Release tag ${{ inputs.tag }} does not match VERSION $EXPECTED_TAG" >&2
+            exit 1
+          fi
+
+      - name: Build Python artifacts
+        run: |
+          python -m build
+
+      - name: Generate release notes
+        run: |
+          python scripts/generate_release_notes.py
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          name: Velocity Claw ${{ inputs.tag }}
+          body_path: dist/release-notes.md
+          prerelease: ${{ inputs.prerelease }}
+          files: |
+            dist/*

--- a/tests/test_github_release_publish_v3.py
+++ b/tests/test_github_release_publish_v3.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+
+WORKFLOW = Path(".github/workflows/publish-release.yml")
+
+
+def test_publish_release_workflow_is_manual_and_has_write_permission():
+    content = WORKFLOW.read_text(encoding="utf-8")
+    assert "workflow_dispatch:" in content
+    assert "tag:" in content
+    assert "prerelease:" in content
+    assert "contents: write" in content
+
+
+def test_publish_release_workflow_runs_validation_before_publish():
+    content = WORKFLOW.read_text(encoding="utf-8")
+    assert "Validate package metadata" in content
+    assert "python scripts/validate_package.py" in content
+    assert "Run tests" in content
+    assert "pytest -q" in content
+    assert "Validate release tag matches VERSION" in content
+    assert "Build Python artifacts" in content
+    assert "python -m build" in content
+    assert "Generate release notes" in content
+    assert "python scripts/generate_release_notes.py" in content
+    assert content.index("Validate package metadata") < content.index("Create GitHub Release")
+    assert content.index("Run tests") < content.index("Create GitHub Release")
+    assert content.index("Build Python artifacts") < content.index("Create GitHub Release")
+
+
+def test_publish_release_workflow_creates_github_release_with_artifacts():
+    content = WORKFLOW.read_text(encoding="utf-8")
+    assert "softprops/action-gh-release@v2" in content
+    assert "tag_name: ${{ inputs.tag }}" in content
+    assert "body_path: dist/release-notes.md" in content
+    assert "files: |" in content
+    assert "dist/*" in content


### PR DESCRIPTION
## Summary
This PR adds a guarded manual GitHub Release publishing workflow.

## What is included
- `.github/workflows/publish-release.yml`
- manual `workflow_dispatch`
- required release tag input
- prerelease input
- package metadata validation
- test suite execution
- release tag vs VERSION validation
- Python package artifact build
- release notes generation
- GitHub Release creation with `softprops/action-gh-release@v2`
- tests that keep release gates and artifact publishing in place

## Why
The project now has version bump automation, package validation, release notes, release workflow, and build artifact workflow. This PR adds the final manual publish workflow while keeping publishing explicit and operator-controlled.
