### PR TITLE
Dependency audit workflow v2: add package dependency audit gate

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,46 @@
+name: dependency-audit
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "requirements.txt"
+      - "pyproject.toml"
+      - ".github/workflows/dependency-audit.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install audit tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install pip-audit
+
+      - name: Validate package metadata
+        run: |
+          python scripts/validate_package.py
+
+      - name: Run dependency audit
+        run: |
+          mkdir -p dist
+          pip-audit -r requirements.txt --format json --output dist/dependency-audit.json
+
+      - name: Upload dependency audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-audit-report
+          path: dist/dependency-audit.json

--- a/tests/test_dependency_audit_workflow_v2.py
+++ b/tests/test_dependency_audit_workflow_v2.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+WORKFLOW = Path(".github/workflows/dependency-audit.yml")
+
+
+def test_dependency_audit_workflow_has_manual_and_pr_triggers():
+    content = WORKFLOW.read_text(encoding="utf-8")
+    assert "workflow_dispatch:" in content
+    assert "pull_request:" in content
+    assert "requirements.txt" in content
+    assert "pyproject.toml" in content
+
+
+def test_dependency_audit_workflow_validates_package_metadata_and_runs_audit():
+    content = WORKFLOW.read_text(encoding="utf-8")
+    assert "Validate package metadata" in content
+    assert "python scripts/validate_package.py" in content
+    assert "Install audit tooling" in content
+    assert "pip install pip-audit" in content
+    assert "Run dependency audit" in content
+    assert "pip-audit -r requirements.txt" in content
+
+
+def test_dependency_audit_workflow_uploads_report_artifact():
+    content = WORKFLOW.read_text(encoding="utf-8")
+    assert "dist/dependency-audit.json" in content
+    assert "actions/upload-artifact@v4" in content
+    assert "dependency-audit-report" in content


### PR DESCRIPTION
## Summary
This PR adds a dependency audit workflow for package dependency changes.

## What is included
- `.github/workflows/dependency-audit.yml`
- manual `workflow_dispatch`
- PR path filters for dependency metadata files
- package metadata validation before audit
- `pip-audit` against `requirements.txt`
- dependency audit report artifact upload
- tests that keep the audit workflow gates in place

## Why
The project now has package metadata, build artifacts, and release publishing. This PR adds a separate dependency audit gate so dependency risk can be reviewed before releases or dependency changes.
