### PR TITLE
Release preflight workflow v2: add all-in-one release validation gate

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -1,0 +1,82 @@
+name: release-preflight
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to validate, for example v0.2.0"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  release-preflight:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies and tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install build pip-audit
+
+      - name: Validate package metadata
+        run: |
+          python scripts/validate_package.py
+
+      - name: Run tests
+        run: |
+          pytest -q
+
+      - name: Validate release tag matches VERSION
+        run: |
+          VERSION_VALUE="$(cat VERSION | tr -d '[:space:]')"
+          EXPECTED_TAG="v${VERSION_VALUE}"
+          if [ "${{ inputs.tag }}" != "$EXPECTED_TAG" ]; then
+            echo "Release tag ${{ inputs.tag }} does not match VERSION $EXPECTED_TAG" >&2
+            exit 1
+          fi
+
+      - name: Run dependency audit
+        run: |
+          mkdir -p dist
+          pip-audit -r requirements.txt --format json --output dist/dependency-audit.json
+
+      - name: Build Python artifacts
+        run: |
+          python -m build
+
+      - name: Generate release notes
+        run: |
+          python scripts/generate_release_notes.py
+
+      - name: Generate preflight summary
+        run: |
+          VERSION_VALUE="$(cat VERSION | tr -d '[:space:]')"
+          {
+            echo "# Velocity Claw release preflight ${VERSION_VALUE}"
+            echo
+            echo "- Package metadata validated"
+            echo "- Tests passed"
+            echo "- Dependency audit completed"
+            echo "- Python artifacts built"
+            echo "- Release notes generated"
+          } > dist/release-preflight-summary.md
+
+      - name: Upload preflight artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-preflight-artifacts
+          path: |
+            dist/*

--- a/tests/test_release_preflight_workflow_v2.py
+++ b/tests/test_release_preflight_workflow_v2.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+
+WORKFLOW = Path(".github/workflows/release-preflight.yml")
+
+
+def test_release_preflight_workflow_is_manual_with_tag_input():
+    content = WORKFLOW.read_text(encoding="utf-8")
+    assert "workflow_dispatch:" in content
+    assert "tag:" in content
+    assert "Release tag to validate" in content
+
+
+def test_release_preflight_workflow_runs_all_validation_gates():
+    content = WORKFLOW.read_text(encoding="utf-8")
+    assert "Validate package metadata" in content
+    assert "python scripts/validate_package.py" in content
+    assert "Run tests" in content
+    assert "pytest -q" in content
+    assert "Validate release tag matches VERSION" in content
+    assert "Run dependency audit" in content
+    assert "pip-audit -r requirements.txt" in content
+    assert "Build Python artifacts" in content
+    assert "python -m build" in content
+    assert "Generate release notes" in content
+    assert "python scripts/generate_release_notes.py" in content
+
+
+def test_release_preflight_workflow_uploads_artifacts():
+    content = WORKFLOW.read_text(encoding="utf-8")
+    assert "Generate preflight summary" in content
+    assert "dist/release-preflight-summary.md" in content
+    assert "actions/upload-artifact@v4" in content
+    assert "release-preflight-artifacts" in content
+    assert "path: |" in content
+    assert "dist/*" in content


### PR DESCRIPTION
## Summary
This PR adds a manual all-in-one release preflight workflow for validating a release before publishing.

## What is included
- `.github/workflows/release-preflight.yml`
- manual `workflow_dispatch` with release tag input
- package metadata validation
- test suite execution
- release tag vs VERSION validation
- dependency audit
- Python package artifact build
- release notes generation
- preflight summary generation
- upload of all `dist/*` preflight artifacts
- tests that keep the preflight gates in place

## Why
The project now has separate CI, dependency audit, build artifact, release validation, and publish workflows. This PR adds a single operator-controlled preflight workflow that runs the release-critical checks together before publishing.
