### PR TITLE
Centralized logging v2: add rotating file logging helper

### DIFF
--- a/tests/test_centralized_logging_v2.py
+++ b/tests/test_centralized_logging_v2.py
@@ -1,5 +1,4 @@
 import logging
-from pathlib import Path
 
 from velocity_claw.logs.logger import configure_logging, get_logger, reset_logging_for_tests
 
@@ -35,6 +34,18 @@ def test_get_logger_writes_to_rotating_file(tmp_path, monkeypatch):
     content = (tmp_path / "velocity_claw.log").read_text(encoding="utf-8")
     assert "centralized logging smoke test" in content
     assert "velocity_claw.test" in content
+
+
+def test_get_logger_writes_errors_to_error_log(tmp_path, monkeypatch):
+    reset_logging_for_tests()
+    monkeypatch.setenv("LOG_DIR", str(tmp_path))
+    logger = get_logger("velocity_claw.error_test")
+    logger.error("centralized logging error test")
+    for handler in logging.getLogger().handlers:
+        handler.flush()
+    content = (tmp_path / "velocity_claw_errors.log").read_text(encoding="utf-8")
+    assert "centralized logging error test" in content
+    assert "velocity_claw.error_test" in content
 
 
 def test_invalid_log_level_falls_back_to_info(tmp_path):

--- a/tests/test_centralized_logging_v2.py
+++ b/tests/test_centralized_logging_v2.py
@@ -1,0 +1,43 @@
+import logging
+from pathlib import Path
+
+from velocity_claw.logs.logger import configure_logging, get_logger, reset_logging_for_tests
+
+
+def teardown_function():
+    reset_logging_for_tests()
+
+
+def test_configure_logging_adds_stream_app_and_error_handlers(tmp_path):
+    reset_logging_for_tests()
+    root = configure_logging(log_dir=tmp_path, enable_file=True, max_bytes=1024, backup_count=1)
+    assert len(root.handlers) == 3
+    assert (tmp_path / "velocity_claw.log").exists()
+    assert (tmp_path / "velocity_claw_errors.log").exists()
+
+
+def test_configure_logging_is_idempotent(tmp_path):
+    reset_logging_for_tests()
+    root = configure_logging(log_dir=tmp_path, enable_file=True)
+    first_handler_ids = [id(handler) for handler in root.handlers]
+    root = configure_logging(log_dir=tmp_path, enable_file=True)
+    second_handler_ids = [id(handler) for handler in root.handlers]
+    assert first_handler_ids == second_handler_ids
+
+
+def test_get_logger_writes_to_rotating_file(tmp_path, monkeypatch):
+    reset_logging_for_tests()
+    monkeypatch.setenv("LOG_DIR", str(tmp_path))
+    logger = get_logger("velocity_claw.test")
+    logger.info("centralized logging smoke test")
+    for handler in logging.getLogger().handlers:
+        handler.flush()
+    content = (tmp_path / "velocity_claw.log").read_text(encoding="utf-8")
+    assert "centralized logging smoke test" in content
+    assert "velocity_claw.test" in content
+
+
+def test_invalid_log_level_falls_back_to_info(tmp_path):
+    reset_logging_for_tests()
+    root = configure_logging(level_name="NOPE", log_dir=tmp_path, enable_file=False)
+    assert root.level == logging.INFO

--- a/velocity_claw/logs/logger.py
+++ b/velocity_claw/logs/logger.py
@@ -1,54 +1,113 @@
 """
-Logging layer for VelocityClaw.
+Centralized logging layer for VelocityClaw.
 
-Provides get_logger(name) — a thin wrapper around the standard library
-logging module that:
-- reads LOG_LEVEL from settings/env (default INFO)
-- attaches a StreamHandler only once (no duplicate handlers)
-- is safe to call multiple times with the same name
-- works in CLI, API, and test contexts
+The helper is intentionally stdlib-only and safe to import from CLI, API,
+Telegram bot, runtime boundaries, tests, and deployment scripts.
 """
+
+from __future__ import annotations
 
 import logging
 import os
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
 
-_HANDLER_ATTACHED: set[str] = set()
+_CONFIGURED = False
 
-_LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+_LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s:%(lineno)d %(message)s"
 _DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
+DEFAULT_LOG_DIR = "logs"
+DEFAULT_LOG_FILE = "velocity_claw.log"
+DEFAULT_ERROR_LOG_FILE = "velocity_claw_errors.log"
 
 
-def _resolve_level() -> int:
-    """Read LOG_LEVEL from environment, fall back to INFO."""
-    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
-    level = logging.getLevelName(level_name)
-    # getLevelName returns the string itself if unknown; fall back to INFO
-    if not isinstance(level, int):
-        level = logging.INFO
-    return level
+def _resolve_level(level_name: str | None = None) -> int:
+    value = (level_name or os.getenv("LOG_LEVEL", "INFO")).upper()
+    level = logging.getLevelName(value)
+    return level if isinstance(level, int) else logging.INFO
+
+
+def _resolve_int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _build_formatter() -> logging.Formatter:
+    return logging.Formatter(_LOG_FORMAT, datefmt=_DATE_FORMAT)
+
+
+def configure_logging(
+    *,
+    level_name: str | None = None,
+    log_dir: str | Path | None = None,
+    enable_file: bool | None = None,
+    max_bytes: int | None = None,
+    backup_count: int | None = None,
+) -> logging.Logger:
+    """Configure root logging once and return the root logger."""
+    global _CONFIGURED
+    root = logging.getLogger()
+    level = _resolve_level(level_name)
+    root.setLevel(level)
+
+    if _CONFIGURED:
+        for handler in root.handlers:
+            handler.setLevel(level)
+        return root
+
+    formatter = _build_formatter()
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(level)
+    stream_handler.setFormatter(formatter)
+    root.addHandler(stream_handler)
+
+    file_logging_enabled = enable_file if enable_file is not None else os.getenv("LOG_TO_FILE", "true").lower() not in {"0", "false", "no", "off"}
+    if file_logging_enabled:
+        resolved_log_dir = Path(log_dir or os.getenv("LOG_DIR", DEFAULT_LOG_DIR))
+        resolved_log_dir.mkdir(parents=True, exist_ok=True)
+        resolved_max_bytes = max_bytes or _resolve_int_env("LOG_FILE_MAX_BYTES", 10 * 1024 * 1024)
+        resolved_backup_count = backup_count or _resolve_int_env("LOG_FILE_BACKUP_COUNT", 5)
+
+        app_handler = RotatingFileHandler(
+            resolved_log_dir / DEFAULT_LOG_FILE,
+            maxBytes=resolved_max_bytes,
+            backupCount=resolved_backup_count,
+            encoding="utf-8",
+        )
+        app_handler.setLevel(level)
+        app_handler.setFormatter(formatter)
+        root.addHandler(app_handler)
+
+        error_handler = RotatingFileHandler(
+            resolved_log_dir / DEFAULT_ERROR_LOG_FILE,
+            maxBytes=resolved_max_bytes,
+            backupCount=resolved_backup_count,
+            encoding="utf-8",
+        )
+        error_handler.setLevel(logging.ERROR)
+        error_handler.setFormatter(formatter)
+        root.addHandler(error_handler)
+
+    _CONFIGURED = True
+    return root
 
 
 def get_logger(name: str) -> logging.Logger:
-    """
-    Return a configured logger for *name*.
+    """Return a logger after ensuring centralized logging is configured."""
+    configure_logging()
+    return logging.getLogger(name)
 
-    A StreamHandler is added to the root logger the first time this function
-    is called, and never added again — so importing this module from multiple
-    files does not produce duplicate log lines.
-    """
+
+def reset_logging_for_tests() -> None:
+    """Reset root handlers so tests can assert logging setup deterministically."""
+    global _CONFIGURED
     root = logging.getLogger()
-
-    if "root" not in _HANDLER_ATTACHED:
-        level = _resolve_level()
-        root.setLevel(level)
-
-        handler = logging.StreamHandler()
-        handler.setLevel(level)
-        formatter = logging.Formatter(_LOG_FORMAT, datefmt=_DATE_FORMAT)
-        handler.setFormatter(formatter)
-        root.addHandler(handler)
-
-        _HANDLER_ATTACHED.add("root")
-
-    logger = logging.getLogger(name)
-    return logger
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+        handler.close()
+    _CONFIGURED = False


### PR DESCRIPTION
## Summary
This PR strengthens centralized logging for CLI/API/bot/runtime usage.

## What is included
- centralized `configure_logging(...)`
- idempotent logging setup without duplicate handlers
- stdout stream handler
- rotating app log file: `logs/velocity_claw.log`
- rotating error log file: `logs/velocity_claw_errors.log`
- env controls:
  - `LOG_TO_FILE`
  - `LOG_DIR`
  - `LOG_FILE_MAX_BYTES`
  - `LOG_FILE_BACKUP_COUNT`
- `get_logger(...)` backed by centralized setup
- test reset helper
- tests for file logging, idempotency, logger output, and invalid log-level fallback

## Why
The uploaded audit called out insufficient centralized logging. The project already had a thin stdout logger, but this PR adds production-grade rotating file logs and regression tests.
