### PR TITLE
API error handling hardening v2: add reusable error response helpers

### DIFF
--- a/tests/test_api_error_handling_hardening_v2.py
+++ b/tests/test_api_error_handling_hardening_v2.py
@@ -1,0 +1,73 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+from velocity_claw.api.errors import REQUEST_ID_HEADER, install_api_error_handlers
+
+
+class Payload(BaseModel):
+    name: str
+
+
+def build_app():
+    app = FastAPI()
+    install_api_error_handlers(app)
+
+    @app.get("/ok")
+    def ok():
+        return {"status": "ok"}
+
+    @app.get("/not-found")
+    def not_found():
+        raise HTTPException(status_code=404, detail={"error": "not_found", "detail": "Missing"})
+
+    @app.post("/payload")
+    def payload(item: Payload):
+        return item
+
+    @app.get("/boom")
+    def boom():
+        raise RuntimeError("secret traceback detail")
+
+    return app
+
+
+def test_request_id_header_is_added_and_preserved():
+    client = TestClient(build_app(), raise_server_exceptions=False)
+    response = client.get("/ok", headers={REQUEST_ID_HEADER: "req-test-1"})
+    assert response.status_code == 200
+    assert response.headers[REQUEST_ID_HEADER] == "req-test-1"
+
+
+def test_http_exception_uses_consistent_error_shape():
+    client = TestClient(build_app(), raise_server_exceptions=False)
+    response = client.get("/not-found", headers={REQUEST_ID_HEADER: "req-test-2"})
+    assert response.status_code == 404
+    payload = response.json()
+    assert payload["status"] == "error"
+    assert payload["request_id"] == "req-test-2"
+    assert payload["error"]["code"] == "not_found"
+    assert payload["error"]["message"] == "Missing"
+
+
+def test_validation_error_uses_consistent_error_shape():
+    client = TestClient(build_app(), raise_server_exceptions=False)
+    response = client.post("/payload", json={}, headers={REQUEST_ID_HEADER: "req-test-3"})
+    assert response.status_code == 422
+    payload = response.json()
+    assert payload["status"] == "error"
+    assert payload["request_id"] == "req-test-3"
+    assert payload["error"]["code"] == "validation_error"
+    assert "details" in payload["error"]
+
+
+def test_unhandled_exception_returns_safe_500_without_traceback_leak():
+    client = TestClient(build_app(), raise_server_exceptions=False)
+    response = client.get("/boom", headers={REQUEST_ID_HEADER: "req-test-4"})
+    assert response.status_code == 500
+    payload = response.json()
+    assert payload["status"] == "error"
+    assert payload["request_id"] == "req-test-4"
+    assert payload["error"]["code"] == "internal_error"
+    assert payload["error"]["message"] == "Internal server error"
+    assert "secret traceback detail" not in response.text

--- a/velocity_claw/api/errors.py
+++ b/velocity_claw/api/errors.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request, status
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from velocity_claw.logs.logger import get_logger
+
+LOGGER = get_logger("velocity_claw.api.errors")
+REQUEST_ID_HEADER = "X-Request-ID"
+
+
+def error_payload(*, code: str, message: str, request_id: str | None = None, details: Any = None) -> dict:
+    payload = {
+        "status": "error",
+        "error": {
+            "code": code,
+            "message": message,
+        },
+    }
+    if request_id:
+        payload["request_id"] = request_id
+    if details is not None:
+        payload["error"]["details"] = details
+    return payload
+
+
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid.uuid4())
+        request.state.request_id = request_id
+        response = await call_next(request)
+        response.headers[REQUEST_ID_HEADER] = request_id
+        return response
+
+
+def get_request_id(request: Request) -> str | None:
+    return getattr(request.state, "request_id", None)
+
+
+async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    request_id = get_request_id(request)
+    detail = exc.detail
+    if isinstance(detail, dict):
+        code = str(detail.get("error") or detail.get("code") or "http_error")
+        message = str(detail.get("detail") or detail.get("message") or "HTTP error")
+        details = detail if detail else None
+    else:
+        code = "http_error"
+        message = str(detail or "HTTP error")
+        details = None
+    LOGGER.warning("HTTP error request_id=%s status=%s code=%s message=%s", request_id, exc.status_code, code, message)
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=error_payload(code=code, message=message, request_id=request_id, details=details),
+        headers=exc.headers,
+    )
+
+
+async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+    request_id = get_request_id(request)
+    LOGGER.warning("Validation error request_id=%s errors=%s", request_id, exc.errors())
+    return JSONResponse(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        content=error_payload(
+            code="validation_error",
+            message="Request validation failed",
+            request_id=request_id,
+            details=exc.errors(),
+        ),
+    )
+
+
+async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    request_id = get_request_id(request)
+    LOGGER.exception("Unhandled API exception request_id=%s", request_id)
+    return JSONResponse(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        content=error_payload(
+            code="internal_error",
+            message="Internal server error",
+            request_id=request_id,
+        ),
+    )
+
+
+def install_api_error_handlers(app: FastAPI) -> FastAPI:
+    app.add_middleware(RequestIdMiddleware)
+    app.add_exception_handler(HTTPException, http_exception_handler)
+    app.add_exception_handler(RequestValidationError, validation_exception_handler)
+    app.add_exception_handler(Exception, unhandled_exception_handler)
+    return app


### PR DESCRIPTION
## Summary
This PR adds reusable FastAPI error handling helpers for consistent production-safe API errors.

## What is included
- `velocity_claw/api/errors.py`
- request id middleware with `X-Request-ID`
- consistent error payload shape
- HTTPException handler
- RequestValidationError handler
- unhandled exception handler with safe 500 response
- logging via centralized logger
- tests for request ids, validation errors, HTTP errors, and safe 500 output

## Notes
`server.py` is currently very large, so this PR introduces the reusable helper and test coverage first. Wiring it into `create_app()` can be done as a small follow-up patch to avoid unsafe full-file rewrites.
