### PR TITLE
Add Dashboard v2 foundation

### DIFF
--- a/tests/test_dashboard_v2_foundation.py
+++ b/tests/test_dashboard_v2_foundation.py
@@ -1,0 +1,157 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from velocity_claw.api.app import install_dashboard_v2
+from velocity_claw.api.dashboard_v2 import render_dashboard_v2
+
+
+class FakeSettings:
+    execution_profile = "safe"
+    safe_mode = True
+    trusted_mode = False
+
+
+class FakeMetrics:
+    def __init__(self):
+        self.values = {}
+
+    def set_value(self, key, value):
+        self.values[key] = value
+
+    def snapshot(self):
+        return dict(self.values)
+
+
+class FakeQueue:
+    max_concurrency = 2
+
+    def list_jobs(self):
+        return [
+            {
+                "job_id": "job-1",
+                "task": "Run tests",
+                "status": "running",
+                "attempts": 1,
+                "terminal_reason": None,
+            }
+        ]
+
+    def active_count(self):
+        return 1
+
+
+class FakeMemory:
+    def list_recent_runs(self, limit=10):
+        return [
+            {
+                "run_id": "run-1",
+                "task": "Analyze repo",
+                "status": "completed",
+                "created_at": "2026-05-11T00:00:00Z",
+            }
+        ]
+
+
+class FakeRouter:
+    def get_router_observability(self):
+        return {
+            "summary": {
+                "route_count": 3,
+                "fallback_successes": 1,
+                "failed_routes": 0,
+            },
+            "recent_route_history": [],
+        }
+
+    def get_provider_health(self):
+        return {
+            "openai": {
+                "requests": 2,
+                "successes": 2,
+                "failures": 0,
+                "in_cooldown": False,
+                "last_error": None,
+            }
+        }
+
+
+class FakeAgent:
+    def __init__(self):
+        self.memory = FakeMemory()
+        self.router = FakeRouter()
+
+    def list_pending_approvals(self):
+        return [
+            {
+                "run_id": "run-2",
+                "step_id": 3,
+                "title": "Apply patch",
+                "reason": "patch requires review",
+            }
+        ]
+
+    def resume_last_failed_run(self):
+        return {
+            "run_id": "run-failed",
+            "task": "Repair tests",
+            "status": "failed",
+        }
+
+
+class FakeRelease:
+    def evaluate(self):
+        return {
+            "readiness": "ready",
+            "score": 5,
+            "total_checks": 5,
+            "blocking_issues": [],
+            "warnings": [],
+        }
+
+
+def make_fake_app():
+    app = FastAPI()
+    app.state.settings = FakeSettings()
+    app.state.metrics = FakeMetrics()
+    app.state.queue = FakeQueue()
+    app.state.agent = FakeAgent()
+    app.state.release = FakeRelease()
+    install_dashboard_v2(app)
+    return app
+
+
+def test_render_dashboard_v2_contains_core_sections_and_escapes_values():
+    html = render_dashboard_v2(
+        execution_profile="safe<script>",
+        safe_mode=True,
+        trusted_mode=False,
+        release_state={"readiness": "ready", "score": 1, "total_checks": 1},
+        console={"queue": {"running": 0, "failed": 0}, "approvals": {"pending": 0}},
+        recent_runs=[{"run_id": "run-1", "task": "Fix <bug>", "status": "completed", "created_at": "now"}],
+        approvals=[],
+        queue_jobs=[],
+        metrics={"tasks_total": 1},
+        provider_observability={"summary": {"failed_routes": 0}},
+        provider_health={},
+        last_failed=None,
+    )
+
+    assert "Velocity Claw Dashboard v2" in html
+    assert "Recent runs" in html
+    assert "Pending approvals" in html
+    assert "Provider health" in html
+    assert "safe&lt;script&gt;" in html
+    assert "Fix &lt;bug&gt;" in html
+
+
+def test_dashboard_v2_endpoint_renders_operational_snapshot():
+    client = TestClient(make_fake_app())
+    response = client.get("/dashboard/v2")
+
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "Velocity Claw Dashboard v2" in response.text
+    assert "Analyze repo" in response.text
+    assert "Apply patch" in response.text
+    assert "Repair tests" in response.text
+    assert "openai" in response.text

--- a/velocity_claw/api/app.py
+++ b/velocity_claw/api/app.py
@@ -1,17 +1,70 @@
 from __future__ import annotations
 
 from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
 
 from velocity_claw.api.auth import install_api_key_auth
+from velocity_claw.api.dashboard_v2 import render_dashboard_v2
 from velocity_claw.api.errors import install_api_error_handlers
 from velocity_claw.api.server import create_app as create_base_app
+
+
+def install_dashboard_v2(app: FastAPI) -> None:
+    @app.get("/dashboard/v2", response_class=HTMLResponse)
+    def dashboard_v2():
+        if hasattr(app.state, "metrics"):
+            app.state.metrics.set_value("approvals_pending", len(app.state.agent.list_pending_approvals()))
+            queue_jobs_for_metrics = app.state.queue.list_jobs()
+            app.state.metrics.set_value("queue_total", len(queue_jobs_for_metrics))
+            app.state.metrics.set_value("queue_running", sum(1 for job in queue_jobs_for_metrics if job["status"] == "running"))
+            app.state.metrics.set_value("queue_failed", sum(1 for job in queue_jobs_for_metrics if job["status"] == "failed"))
+            app.state.metrics.set_value("queue_cancelled", sum(1 for job in queue_jobs_for_metrics if job["status"] == "cancelled"))
+
+        release_state = app.state.release.evaluate()
+        queue_jobs = app.state.queue.list_jobs()
+        approvals = app.state.agent.list_pending_approvals()
+        provider_observability = app.state.agent.router.get_router_observability()
+        provider_health = app.state.agent.router.get_provider_health()
+        last_failed = app.state.agent.resume_last_failed_run()
+        metrics = app.state.metrics.snapshot()
+        console = app.routes[1].endpoint.__globals__.get("build_operations_console") if False else None
+
+        from velocity_claw.api.ops_console import build_operations_console
+
+        console_snapshot = build_operations_console(
+            release_state=release_state,
+            queue_jobs=queue_jobs,
+            approvals=approvals,
+            provider_observability=provider_observability,
+            last_failed=last_failed,
+            metrics=metrics,
+            active_workers=app.state.queue.active_count(),
+            max_concurrency=app.state.queue.max_concurrency,
+        )
+
+        return render_dashboard_v2(
+            execution_profile=app.state.settings.execution_profile,
+            safe_mode=app.state.settings.safe_mode,
+            trusted_mode=app.state.settings.trusted_mode,
+            release_state=release_state,
+            console=console_snapshot,
+            recent_runs=app.state.agent.memory.list_recent_runs(limit=10),
+            approvals=approvals,
+            queue_jobs=queue_jobs[:10],
+            metrics=metrics,
+            provider_observability=provider_observability,
+            provider_health=provider_health,
+            last_failed=last_failed,
+        )
 
 
 def create_app() -> FastAPI:
     """Create the production API app with shared hardening installed."""
     app = create_base_app()
     install_api_error_handlers(app)
+    install_dashboard_v2(app)
     install_api_key_auth(app)
     app.state.api_error_handlers_installed = True
+    app.state.dashboard_v2_installed = True
     app.state.api_key_auth_installed = True
     return app

--- a/velocity_claw/api/app.py
+++ b/velocity_claw/api/app.py
@@ -6,6 +6,7 @@ from fastapi.responses import HTMLResponse
 from velocity_claw.api.auth import install_api_key_auth
 from velocity_claw.api.dashboard_v2 import render_dashboard_v2
 from velocity_claw.api.errors import install_api_error_handlers
+from velocity_claw.api.ops_console import build_operations_console
 from velocity_claw.api.server import create_app as create_base_app
 
 
@@ -27,10 +28,6 @@ def install_dashboard_v2(app: FastAPI) -> None:
         provider_health = app.state.agent.router.get_provider_health()
         last_failed = app.state.agent.resume_last_failed_run()
         metrics = app.state.metrics.snapshot()
-        console = app.routes[1].endpoint.__globals__.get("build_operations_console") if False else None
-
-        from velocity_claw.api.ops_console import build_operations_console
-
         console_snapshot = build_operations_console(
             release_state=release_state,
             queue_jobs=queue_jobs,

--- a/velocity_claw/api/dashboard_v2.py
+++ b/velocity_claw/api/dashboard_v2.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from html import escape
+from typing import Any
+
+
+def html_escape(value: Any) -> str:
+    return escape(str(value if value is not None else ""), quote=True)
+
+
+def status_badge(status: str) -> str:
+    normalized = (status or "unknown").lower()
+    return f"<span class='badge badge-{html_escape(normalized)}'>{html_escape(status or 'unknown')}</span>"
+
+
+def number_card(label: str, value: Any) -> str:
+    return f"<section class='card metric'><div class='label'>{html_escape(label)}</div><div class='value'>{html_escape(value)}</div></section>"
+
+
+def render_dashboard_v2(
+    *,
+    execution_profile: str,
+    safe_mode: bool,
+    trusted_mode: bool,
+    release_state: dict[str, Any],
+    console: dict[str, Any],
+    recent_runs: list[dict[str, Any]],
+    approvals: list[dict[str, Any]],
+    queue_jobs: list[dict[str, Any]],
+    metrics: dict[str, Any],
+    provider_observability: dict[str, Any],
+    provider_health: dict[str, Any],
+    last_failed: dict[str, Any] | None,
+) -> str:
+    release_score = f"{release_state.get('score', 0)}/{release_state.get('total_checks', 0)}"
+    provider_summary = provider_observability.get("summary", {}) if isinstance(provider_observability, dict) else {}
+    queue_summary = console.get("queue", {}) if isinstance(console, dict) else {}
+    approval_summary = console.get("approvals", {}) if isinstance(console, dict) else {}
+
+    run_rows = []
+    for run in recent_runs:
+        run_id = run.get("run_id", "")
+        run_rows.append(
+            "<tr>"
+            f"<td><code>{html_escape(run_id)}</code></td>"
+            f"<td>{html_escape(run.get('task'))}</td>"
+            f"<td>{status_badge(str(run.get('status') or 'unknown'))}</td>"
+            f"<td>{html_escape(run.get('created_at'))}</td>"
+            f"<td><a href='/runs/{html_escape(run_id)}/view'>open</a></td>"
+            "</tr>"
+        )
+
+    approval_rows = []
+    for item in approvals:
+        approval_rows.append(
+            "<tr>"
+            f"<td><code>{html_escape(item.get('run_id'))}</code></td>"
+            f"<td>{html_escape(item.get('step_id'))}</td>"
+            f"<td>{html_escape(item.get('title') or item.get('step_title') or '')}</td>"
+            f"<td>{html_escape(item.get('reason') or item.get('approval_reason') or '')}</td>"
+            "</tr>"
+        )
+
+    queue_rows = []
+    for job in queue_jobs:
+        queue_rows.append(
+            "<tr>"
+            f"<td><code>{html_escape(job.get('job_id'))}</code></td>"
+            f"<td>{html_escape(job.get('task'))}</td>"
+            f"<td>{status_badge(str(job.get('status') or 'unknown'))}</td>"
+            f"<td>{html_escape(job.get('attempts'))}</td>"
+            f"<td>{html_escape(job.get('terminal_reason') or '')}</td>"
+            "</tr>"
+        )
+
+    provider_rows = []
+    for provider, state in provider_health.items():
+        provider_rows.append(
+            "<tr>"
+            f"<td>{html_escape(provider)}</td>"
+            f"<td>{html_escape(state.get('requests', 0))}</td>"
+            f"<td>{html_escape(state.get('successes', 0))}</td>"
+            f"<td>{html_escape(state.get('failures', 0))}</td>"
+            f"<td>{status_badge('cooldown' if state.get('in_cooldown') else 'ready')}</td>"
+            f"<td>{html_escape(state.get('last_error') or '')}</td>"
+            "</tr>"
+        )
+
+    last_failed_block = "<p>No failed runs recorded.</p>"
+    if last_failed:
+        run_id = last_failed.get("run_id", "")
+        last_failed_block = (
+            f"<p><code>{html_escape(run_id)}</code> — {html_escape(last_failed.get('task'))} "
+            f"{status_badge(str(last_failed.get('status') or 'failed'))} "
+            f"<a href='/runs/{html_escape(run_id)}/view'>open</a></p>"
+        )
+
+    return f"""
+<!doctype html>
+<html lang='en'>
+<head>
+  <meta charset='utf-8'>
+  <meta name='viewport' content='width=device-width, initial-scale=1'>
+  <title>Velocity Claw Dashboard v2</title>
+  <style>
+    :root {{ color-scheme: dark; --bg:#0f172a; --panel:#111827; --muted:#94a3b8; --text:#e5e7eb; --line:#263244; --accent:#38bdf8; }}
+    body {{ margin:0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Arial, sans-serif; background:var(--bg); color:var(--text); }}
+    main {{ max-width:1280px; margin:0 auto; padding:28px; }}
+    header {{ display:flex; justify-content:space-between; gap:18px; align-items:flex-start; margin-bottom:24px; }}
+    h1 {{ margin:0; font-size:32px; }}
+    h2 {{ margin:0 0 12px; font-size:20px; }}
+    a {{ color:var(--accent); text-decoration:none; }}
+    .muted {{ color:var(--muted); }}
+    .grid {{ display:grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap:14px; margin:18px 0; }}
+    .card {{ background:var(--panel); border:1px solid var(--line); border-radius:16px; padding:16px; box-shadow:0 8px 24px rgba(0,0,0,.18); }}
+    .metric .label {{ color:var(--muted); font-size:13px; }}
+    .metric .value {{ font-size:26px; font-weight:700; margin-top:6px; }}
+    .section {{ margin-top:18px; }}
+    table {{ width:100%; border-collapse:collapse; overflow:hidden; border-radius:12px; }}
+    th, td {{ border-bottom:1px solid var(--line); padding:10px; text-align:left; vertical-align:top; }}
+    th {{ color:var(--muted); font-size:13px; font-weight:600; }}
+    code {{ background:#020617; border:1px solid var(--line); border-radius:8px; padding:2px 6px; }}
+    .badge {{ display:inline-block; border:1px solid var(--line); border-radius:999px; padding:2px 8px; font-size:12px; }}
+    .badge-completed, .badge-ok, .badge-ready {{ border-color:#22c55e; color:#86efac; }}
+    .badge-failed, .badge-error {{ border-color:#ef4444; color:#fca5a5; }}
+    .badge-running, .badge-pending, .badge-cooldown {{ border-color:#f59e0b; color:#fcd34d; }}
+    .nav {{ display:flex; flex-wrap:wrap; gap:10px; margin-top:10px; }}
+    .nav a {{ background:#020617; border:1px solid var(--line); border-radius:999px; padding:8px 10px; }}
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <div>
+      <h1>Velocity Claw Dashboard v2</h1>
+      <p class='muted'>Operational overview for runs, approvals, queue, providers, and release readiness.</p>
+      <div class='nav'>
+        <a href='/dashboard'>classic dashboard</a>
+        <a href='/ops/console'>ops console</a>
+        <a href='/runs'>runs json</a>
+        <a href='/approvals'>approvals json</a>
+        <a href='/queue'>queue json</a>
+        <a href='/metrics'>metrics json</a>
+      </div>
+    </div>
+    <section class='card'>
+      <div>Profile: <b>{html_escape(execution_profile)}</b></div>
+      <div>Safe mode: <b>{html_escape(safe_mode)}</b></div>
+      <div>Trusted mode: <b>{html_escape(trusted_mode)}</b></div>
+    </section>
+  </header>
+
+  <div class='grid'>
+    {number_card('Release readiness', release_state.get('readiness', 'unknown'))}
+    {number_card('Release score', release_score)}
+    {number_card('Queue running', queue_summary.get('running', 0))}
+    {number_card('Queue failed', queue_summary.get('failed', 0))}
+    {number_card('Approvals pending', approval_summary.get('pending', len(approvals)))}
+    {number_card('Provider failed routes', provider_summary.get('failed_routes', 0))}
+  </div>
+
+  <section class='card section'>
+    <h2>Last failed run</h2>
+    {last_failed_block}
+  </section>
+
+  <section class='card section'>
+    <h2>Recent runs</h2>
+    <table><thead><tr><th>Run ID</th><th>Task</th><th>Status</th><th>Created</th><th>View</th></tr></thead><tbody>
+      {''.join(run_rows) or "<tr><td colspan='5'>No runs recorded.</td></tr>"}
+    </tbody></table>
+  </section>
+
+  <section class='card section'>
+    <h2>Pending approvals</h2>
+    <table><thead><tr><th>Run ID</th><th>Step</th><th>Title</th><th>Reason</th></tr></thead><tbody>
+      {''.join(approval_rows) or "<tr><td colspan='4'>No pending approvals.</td></tr>"}
+    </tbody></table>
+  </section>
+
+  <section class='card section'>
+    <h2>Queue</h2>
+    <table><thead><tr><th>Job ID</th><th>Task</th><th>Status</th><th>Attempts</th><th>Terminal reason</th></tr></thead><tbody>
+      {''.join(queue_rows) or "<tr><td colspan='5'>No queued jobs.</td></tr>"}
+    </tbody></table>
+  </section>
+
+  <section class='card section'>
+    <h2>Provider health</h2>
+    <table><thead><tr><th>Provider</th><th>Requests</th><th>Successes</th><th>Failures</th><th>State</th><th>Last error</th></tr></thead><tbody>
+      {''.join(provider_rows) or "<tr><td colspan='6'>No provider health data.</td></tr>"}
+    </tbody></table>
+  </section>
+
+  <section class='card section'>
+    <h2>Raw metric counters</h2>
+    <pre>{html_escape(metrics)}</pre>
+  </section>
+</main>
+</body>
+</html>
+""".strip()


### PR DESCRIPTION
## Summary

Adds a safer Dashboard v2 foundation without replacing the existing dashboard.

Changes:
- add `velocity_claw/api/dashboard_v2.py` renderer
- add `/dashboard/v2` endpoint through the production app wrapper
- keep existing `/dashboard` untouched
- add operational sections for release readiness, queue, approvals, runs, provider health, metrics, and last failed run
- HTML-escape dynamic values
- add tests for renderer output, escaping, and endpoint behavior

Validation:
- pytest -q