### PR TITLE
Add Approval workflow v2 foundation

### DIFF
--- a/tests/test_approval_workflow_v2.py
+++ b/tests/test_approval_workflow_v2.py
@@ -1,0 +1,172 @@
+import asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from velocity_claw.api.app import install_approval_v2
+from velocity_claw.api.approval_v2 import build_approval_detail, evaluate_approval_decision
+
+
+RUN_ID = "run-approval"
+
+
+def make_run(step_status="pending_approval"):
+    return {
+        "run_id": RUN_ID,
+        "task": "Apply guarded patch",
+        "status": "awaiting_approval",
+        "steps": [
+            {
+                "id": 7,
+                "title": "Apply patch",
+                "tool": "patch.apply",
+                "args": {"path": "demo.py"},
+                "status": step_status,
+                "result": {"reason": "patch requires review"},
+                "error": None,
+            }
+        ],
+        "artifacts": [
+            {
+                "step_id": 7,
+                "name": "approval_step_7",
+                "artifact_type": "approval",
+                "content": "{}",
+            }
+        ],
+        "approval_history": [
+            {
+                "step_id": 7,
+                "decision": "requested",
+                "actor": None,
+                "reason": "patch requires review",
+                "payload": {"reason": "patch requires review"},
+                "created_at": "2026-05-11T00:00:00Z",
+            }
+        ],
+    }
+
+
+class FakeMemory:
+    def __init__(self, run):
+        self.run = run
+
+    def load_run(self, run_id):
+        if run_id != RUN_ID:
+            return None
+        return self.run
+
+    def update_step_status(self, run_id, step_id, status, result=None, error=None):
+        self.run["steps"][0]["status"] = status
+        self.run["steps"][0]["result"] = result
+        self.run["steps"][0]["error"] = error
+
+    def save_approval_decision(self, run_id, step_id, decision, actor=None, reason=None, payload=None):
+        self.run["approval_history"].append(
+            {
+                "step_id": step_id,
+                "decision": decision,
+                "actor": actor,
+                "reason": reason,
+                "payload": payload,
+                "created_at": "now",
+            }
+        )
+
+    def save_artifact(self, run_id, name, content, step_id=None, artifact_type="text"):
+        self.run["artifacts"].append(
+            {
+                "step_id": step_id,
+                "name": name,
+                "artifact_type": artifact_type,
+                "content": content,
+            }
+        )
+
+    def save_project_note(self, note_type, content):
+        pass
+
+    def update_run_status(self, run_id, status):
+        self.run["status"] = status
+
+
+class FakeAgent:
+    def __init__(self, run):
+        self.memory = FakeMemory(run)
+
+    async def approve_step(self, run_id, step_id, actor="owner", reason=None):
+        self.memory.update_step_status(run_id, step_id, "approved", result={"decision": "approved", "actor": actor, "reason": reason})
+        self.memory.save_approval_decision(run_id, step_id, "approved", actor=actor, reason=reason, payload={"decision": "approved"})
+        return {"decision": "approved", "actor": actor, "reason": reason, "resume": {"status": "completed"}}
+
+    def reject_step(self, run_id, step_id, actor="owner", reason=None):
+        self.memory.update_step_status(run_id, step_id, "rejected", result={"decision": "rejected", "actor": actor, "reason": reason}, error="Rejected by reviewer")
+        self.memory.save_approval_decision(run_id, step_id, "rejected", actor=actor, reason=reason, payload={"decision": "rejected"})
+        self.memory.update_run_status(run_id, "rejected")
+        return {"decision": "rejected", "actor": actor, "reason": reason}
+
+
+def make_client(run):
+    app = FastAPI()
+    app.state.agent = FakeAgent(run)
+    install_approval_v2(app)
+    return TestClient(app)
+
+
+def test_build_approval_detail_exposes_step_history_artifacts_and_links():
+    detail = build_approval_detail(make_run(), 7)
+
+    assert detail["status"] == "ok"
+    assert detail["can_decide"] is True
+    assert detail["step"]["title"] == "Apply patch"
+    assert len(detail["history"]) == 1
+    assert len(detail["artifacts"]) == 1
+    assert detail["links"]["approve"].endswith("/approvals/v2/run-approval/7/approve")
+
+
+def test_evaluate_approval_decision_blocks_non_pending_steps():
+    guard = evaluate_approval_decision(make_run(step_status="approved"), 7)
+
+    assert guard.allowed is False
+    assert guard.reason == "already_approved"
+    assert guard.current_status == "approved"
+
+
+def test_approval_detail_v2_endpoint_returns_context():
+    client = make_client(make_run())
+
+    response = client.get(f"/approvals/v2/{RUN_ID}/7")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["approval"]["can_decide"] is True
+    assert payload["approval"]["history"][0]["decision"] == "requested"
+
+
+def test_approval_v2_reject_changes_status_and_blocks_second_decision():
+    run = make_run()
+    client = make_client(run)
+
+    first = client.post(f"/approvals/v2/{RUN_ID}/7/reject", json={"actor": "owner", "reason": "not safe"})
+    assert first.status_code == 200
+    assert first.json()["status"] == "ok"
+    assert run["steps"][0]["status"] == "rejected"
+    assert run["status"] == "rejected"
+
+    second = client.post(f"/approvals/v2/{RUN_ID}/7/approve", json={"actor": "owner", "reason": "changed mind"})
+    assert second.status_code == 409
+    assert second.json()["detail"]["error"] == "already_rejected"
+
+
+def test_approval_v2_approve_returns_resume_payload():
+    run = make_run()
+    client = make_client(run)
+
+    response = client.post(f"/approvals/v2/{RUN_ID}/7/approve", json={"actor": "owner", "reason": "approved"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["decision"]["decision"] == "approved"
+    assert payload["decision"]["resume"]["status"] == "completed"
+    assert run["steps"][0]["status"] == "approved"

--- a/velocity_claw/api/app.py
+++ b/velocity_claw/api/app.py
@@ -1,13 +1,37 @@
 from __future__ import annotations
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
 
+from velocity_claw.api.approval_v2 import approve_with_guard, build_approval_detail, reject_with_guard
 from velocity_claw.api.auth import install_api_key_auth
 from velocity_claw.api.dashboard_v2 import render_dashboard_v2
 from velocity_claw.api.errors import install_api_error_handlers
 from velocity_claw.api.ops_console import build_operations_console
-from velocity_claw.api.server import create_app as create_base_app
+from velocity_claw.api.server import ApprovalDecisionRequest, create_app as create_base_app
+
+
+def install_approval_v2(app: FastAPI) -> None:
+    @app.get("/approvals/v2/{run_id}/{step_id}")
+    def approval_detail_v2(run_id: str, step_id: int):
+        detail = build_approval_detail(app.state.agent.memory.load_run(run_id), step_id)
+        if detail["status"] == "not_found":
+            raise HTTPException(status_code=404, detail={"status": "failed", "error": detail["reason"], "detail": detail})
+        return {"status": "ok", "approval": detail}
+
+    @app.post("/approvals/v2/{run_id}/{step_id}/approve")
+    async def approve_v2(run_id: str, step_id: int, payload: ApprovalDecisionRequest):
+        result = await approve_with_guard(app.state.agent, run_id, step_id, actor=payload.actor, reason=payload.reason)
+        if result.get("status") == "blocked":
+            raise HTTPException(status_code=409, detail={"status": "failed", "error": result["reason"], "detail": result})
+        return result
+
+    @app.post("/approvals/v2/{run_id}/{step_id}/reject")
+    def reject_v2(run_id: str, step_id: int, payload: ApprovalDecisionRequest):
+        result = reject_with_guard(app.state.agent, run_id, step_id, actor=payload.actor, reason=payload.reason)
+        if result.get("status") == "blocked":
+            raise HTTPException(status_code=409, detail={"status": "failed", "error": result["reason"], "detail": result})
+        return result
 
 
 def install_dashboard_v2(app: FastAPI) -> None:
@@ -59,9 +83,11 @@ def create_app() -> FastAPI:
     """Create the production API app with shared hardening installed."""
     app = create_base_app()
     install_api_error_handlers(app)
+    install_approval_v2(app)
     install_dashboard_v2(app)
     install_api_key_auth(app)
     app.state.api_error_handlers_installed = True
+    app.state.approval_v2_installed = True
     app.state.dashboard_v2_installed = True
     app.state.api_key_auth_installed = True
     return app

--- a/velocity_claw/api/approval_v2.py
+++ b/velocity_claw/api/approval_v2.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+TERMINAL_APPROVAL_STATUSES = {"approved", "rejected"}
+PENDING_APPROVAL_STATUS = "pending_approval"
+
+
+@dataclass(frozen=True)
+class ApprovalDecisionGuard:
+    allowed: bool
+    reason: str
+    current_status: str | None
+
+
+def _find_step(run: dict[str, Any], step_id: int) -> dict[str, Any] | None:
+    for step in run.get("steps", []):
+        if step.get("id") == step_id:
+            return step
+    return None
+
+
+def _step_artifacts(run: dict[str, Any], step_id: int) -> list[dict[str, Any]]:
+    return [artifact for artifact in run.get("artifacts", []) if artifact.get("step_id") == step_id]
+
+
+def _step_history(run: dict[str, Any], step_id: int) -> list[dict[str, Any]]:
+    return [event for event in run.get("approval_history", []) if event.get("step_id") == step_id]
+
+
+def evaluate_approval_decision(run: dict[str, Any] | None, step_id: int) -> ApprovalDecisionGuard:
+    if not run:
+        return ApprovalDecisionGuard(False, "run_not_found", None)
+    step = _find_step(run, step_id)
+    if not step:
+        return ApprovalDecisionGuard(False, "step_not_found", None)
+    status = step.get("status")
+    if status != PENDING_APPROVAL_STATUS:
+        if status in TERMINAL_APPROVAL_STATUSES:
+            return ApprovalDecisionGuard(False, f"already_{status}", status)
+        return ApprovalDecisionGuard(False, "step_not_pending_approval", status)
+    return ApprovalDecisionGuard(True, "pending_approval", status)
+
+
+def build_approval_detail(run: dict[str, Any] | None, step_id: int) -> dict[str, Any]:
+    guard = evaluate_approval_decision(run, step_id)
+    if not run:
+        return {
+            "status": "not_found",
+            "reason": guard.reason,
+            "run_id": None,
+            "step_id": step_id,
+            "can_decide": False,
+        }
+
+    step = _find_step(run, step_id)
+    return {
+        "status": "ok" if step else "not_found",
+        "reason": guard.reason,
+        "run_id": run.get("run_id"),
+        "run_status": run.get("status"),
+        "task": run.get("task"),
+        "step_id": step_id,
+        "step": step,
+        "current_status": guard.current_status,
+        "can_decide": guard.allowed,
+        "history": _step_history(run, step_id),
+        "artifacts": _step_artifacts(run, step_id),
+        "links": {
+            "approve": f"/approvals/v2/{run.get('run_id')}/{step_id}/approve",
+            "reject": f"/approvals/v2/{run.get('run_id')}/{step_id}/reject",
+            "run": f"/runs/{run.get('run_id')}",
+            "run_view": f"/runs/{run.get('run_id')}/view",
+        },
+    }
+
+
+async def approve_with_guard(agent: Any, run_id: str, step_id: int, actor: str, reason: str | None) -> dict[str, Any]:
+    run = agent.memory.load_run(run_id)
+    guard = evaluate_approval_decision(run, step_id)
+    if not guard.allowed:
+        return {
+            "status": "blocked",
+            "decision": "approve",
+            "reason": guard.reason,
+            "current_status": guard.current_status,
+            "run_id": run_id,
+            "step_id": step_id,
+        }
+    decision = await agent.approve_step(run_id, step_id, actor=actor, reason=reason)
+    return {
+        "status": "ok",
+        "decision": decision,
+        "approval": build_approval_detail(agent.memory.load_run(run_id), step_id),
+    }
+
+
+def reject_with_guard(agent: Any, run_id: str, step_id: int, actor: str, reason: str | None) -> dict[str, Any]:
+    run = agent.memory.load_run(run_id)
+    guard = evaluate_approval_decision(run, step_id)
+    if not guard.allowed:
+        return {
+            "status": "blocked",
+            "decision": "reject",
+            "reason": guard.reason,
+            "current_status": guard.current_status,
+            "run_id": run_id,
+            "step_id": step_id,
+        }
+    decision = agent.reject_step(run_id, step_id, actor=actor, reason=reason)
+    return {
+        "status": "ok",
+        "decision": decision,
+        "approval": build_approval_detail(agent.memory.load_run(run_id), step_id),
+    }


### PR DESCRIPTION
## Summary

Adds Approval workflow v2 foundation without replacing the existing approval endpoints.

Changes:
- add approval detail builder with step, history, artifacts, and action links
- add decision guard that blocks duplicate approve/reject attempts
- add `/approvals/v2/{run_id}/{step_id}` detail endpoint
- add guarded `/approve` and `/reject` v2 endpoints
- keep existing approval endpoints untouched
- add tests for detail output, decision guards, endpoint behavior, reject flow, and approve resume payload

Validation:
- pytest -q