### PR TITLE
Add Execution profiles v2 explanations

### DIFF
--- a/tests/test_execution_profiles_v2.py
+++ b/tests/test_execution_profiles_v2.py
@@ -1,0 +1,74 @@
+from velocity_claw.config.settings import Settings
+from velocity_claw.security.access import ExecutionProfileManager
+from velocity_claw.security.profile_explain import classify_tool
+
+
+def make_manager(profile="safe"):
+    return ExecutionProfileManager(Settings(env="test", execution_profile=profile))
+
+
+def test_classify_tool_maps_known_tools_to_category_risk_and_capability():
+    shell = classify_tool("shell.run")
+    assert shell["category"] == "shell"
+    assert shell["risk_level"] == "high"
+    assert shell["capability"] == "shell"
+
+    patch = classify_tool("patch.apply")
+    assert patch["category"] == "patch"
+    assert patch["risk_level"] == "medium"
+    assert patch["capability"] == "patch_engine"
+
+    unknown = classify_tool("custom.tool")
+    assert unknown["category"] == "unknown"
+    assert unknown["risk_level"] == "unknown"
+    assert unknown["capability"] is None
+
+
+def test_safe_profile_explains_blocked_shell_access():
+    explanation = make_manager("safe").explain_tool_access("shell.run")
+
+    assert explanation["profile"] == "safe"
+    assert explanation["tool"] == "shell.run"
+    assert explanation["allowed"] is False
+    assert explanation["category"] == "shell"
+    assert explanation["risk_level"] == "high"
+    assert explanation["required_capability"] == "shell"
+    assert "does not grant" in explanation["reason"]
+    assert explanation["approval_hint"] == "approval_required_or_strongly_recommended"
+    assert explanation["profile_capabilities"]["shell"] is False
+
+
+def test_dev_profile_allows_shell_but_blocks_git_write():
+    manager = make_manager("dev")
+
+    shell = manager.explain_tool_access("shell.run")
+    assert shell["allowed"] is True
+    assert shell["profile_capabilities"]["shell"] is True
+
+    git_write = manager.explain_tool_access("git.run")
+    assert git_write["allowed"] is False
+    assert git_write["category"] == "git_write"
+    assert git_write["required_capability"] == "git_write"
+    assert git_write["risk_level"] == "high"
+
+
+def test_owner_profile_allows_network_and_git_write():
+    manager = make_manager("owner")
+
+    git_write = manager.explain_tool_access("git.run")
+    network = manager.explain_tool_access("http.get")
+
+    assert git_write["allowed"] is True
+    assert git_write["profile_capabilities"]["git_write"] is True
+    assert network["allowed"] is True
+    assert network["category"] == "network"
+    assert network["required_capability"] == "network"
+
+
+def test_git_inspect_remains_low_risk_read_for_safe_profile():
+    explanation = make_manager("safe").explain_tool_access("git.inspect")
+
+    assert explanation["allowed"] is True
+    assert explanation["category"] == "git_read"
+    assert explanation["risk_level"] == "low"
+    assert explanation["required_capability"] is None

--- a/velocity_claw/security/access.py
+++ b/velocity_claw/security/access.py
@@ -4,6 +4,7 @@ from dataclasses import asdict, dataclass
 from typing import Optional
 
 from velocity_claw.config.settings import Settings
+from velocity_claw.security.profile_explain import explain_tool_access as build_tool_access_explanation
 
 
 class AccessControl:
@@ -110,12 +111,7 @@ class ExecutionProfileManager:
     def explain_tool_access(self, tool: str, profile_name: Optional[str] = None) -> dict:
         profile = self.get_profile(profile_name)
         allowed = self.is_tool_allowed(tool, profile.name)
-        return {
-            "profile": profile.name,
-            "tool": tool,
-            "allowed": allowed,
-            "description": profile.description,
-        }
+        return build_tool_access_explanation(profile, tool, allowed)
 
 
 class ApprovalManager:

--- a/velocity_claw/security/profile_explain.py
+++ b/velocity_claw/security/profile_explain.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+TOOL_CATEGORIES = {
+    "fs.read": "filesystem_read",
+    "fs.write": "filesystem_write",
+    "fs.append": "filesystem_write",
+    "fs.replace": "filesystem_write",
+    "patch.preview": "patch",
+    "patch.apply": "patch",
+    "test.run": "test",
+    "shell.run": "shell",
+    "git.inspect": "git_read",
+    "git.run": "git_write",
+    "http.get": "network",
+    "http.post": "network",
+}
+
+RISK_BY_CATEGORY = {
+    "filesystem_read": "low",
+    "filesystem_write": "medium",
+    "patch": "medium",
+    "test": "low",
+    "shell": "high",
+    "git_read": "low",
+    "git_write": "high",
+    "network": "medium",
+    "unknown": "unknown",
+}
+
+CAPABILITY_BY_CATEGORY = {
+    "filesystem_read": None,
+    "filesystem_write": "filesystem_write",
+    "patch": "patch_engine",
+    "test": "test_runner",
+    "shell": "shell",
+    "git_read": None,
+    "git_write": "git_write",
+    "network": "network",
+    "unknown": None,
+}
+
+
+def classify_tool(tool: str) -> dict[str, Any]:
+    category = TOOL_CATEGORIES.get(tool, "unknown")
+    return {
+        "tool": tool,
+        "category": category,
+        "risk_level": RISK_BY_CATEGORY.get(category, "unknown"),
+        "capability": CAPABILITY_BY_CATEGORY.get(category),
+    }
+
+
+def explain_tool_access(profile: Any, tool: str, allowed: bool) -> dict[str, Any]:
+    classification = classify_tool(tool)
+    category = classification["category"]
+    capability = classification["capability"]
+    profile_name = getattr(profile, "name", "unknown")
+
+    if allowed:
+        reason = "Tool is allowed by this execution profile."
+    elif capability:
+        reason = f"Tool requires capability '{capability}', which profile '{profile_name}' does not grant."
+    else:
+        reason = f"Tool category '{category}' is not explicitly granted by profile '{profile_name}'."
+
+    approval_hint = "approval_not_required"
+    if getattr(profile, "approval_workflow", False):
+        if classification["risk_level"] == "high":
+            approval_hint = "approval_required_or_strongly_recommended"
+        elif classification["risk_level"] == "medium":
+            approval_hint = "approval_recommended_for_sensitive_changes"
+
+    return {
+        "profile": profile_name,
+        "description": getattr(profile, "description", ""),
+        "tool": tool,
+        "allowed": allowed,
+        "category": category,
+        "risk_level": classification["risk_level"],
+        "required_capability": capability,
+        "reason": reason,
+        "approval_hint": approval_hint,
+        "profile_capabilities": {
+            "filesystem_write": getattr(profile, "filesystem_write", False),
+            "patch_engine": getattr(profile, "patch_engine", False),
+            "test_runner": getattr(profile, "test_runner", False),
+            "shell": getattr(profile, "shell", False),
+            "git_write": getattr(profile, "git_write", False),
+            "network": getattr(profile, "network", False),
+            "approval_workflow": getattr(profile, "approval_workflow", False),
+        },
+    }


### PR DESCRIPTION
## Summary

Adds richer execution-profile explanations without changing existing profile enforcement.

Changes:
- add `velocity_claw/security/profile_explain.py`
- classify tools by category, risk level, and required capability
- enrich `ExecutionProfileManager.explain_tool_access()` with reason, approval hint, and profile capabilities
- keep existing `/profiles/explain/{tool_name}` endpoint behavior compatible but more informative
- add tests for safe/dev/owner tool access explanations

Validation:
- pytest -q