### PR TITLE
Add Run detail v2 and artifact index

### DIFF
--- a/tests/test_run_detail_v2.py
+++ b/tests/test_run_detail_v2.py
@@ -1,0 +1,126 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from velocity_claw.api.app import install_run_detail_v2
+from velocity_claw.api.run_detail_v2 import build_artifact_index, build_run_detail_v2, build_step_index
+
+
+RUN_ID = "run-detail-1"
+
+
+def make_run():
+    return {
+        "run_id": RUN_ID,
+        "task": "Fix failing tests",
+        "status": "failed",
+        "created_at": "2026-05-16T00:00:00Z",
+        "completed_at": "2026-05-16T00:05:00Z",
+        "steps": [
+            {"id": 1, "title": "Inspect", "tool": "fs.read", "status": "success", "error": None, "started_at": "a", "completed_at": "b"},
+            {"id": 2, "title": "Apply patch", "tool": "patch.apply", "status": "pending_approval", "error": None, "started_at": "b", "completed_at": "c"},
+            {"id": 3, "title": "Run tests", "tool": "test.run", "status": "failed", "error": "pytest failed", "started_at": "c", "completed_at": "d"},
+        ],
+        "artifacts": [
+            {"step_id": None, "name": "run_plan", "artifact_type": "plan", "content": "{}", "created_at": "now"},
+            {"step_id": 2, "name": "approval_step_2", "artifact_type": "approval", "content": "approval payload", "created_at": "now"},
+            {"step_id": 3, "name": "step_3_stdout", "artifact_type": "log", "content": "x" * 500, "created_at": "now"},
+        ],
+        "approval_history": [
+            {"step_id": 2, "decision": "requested", "actor": None, "reason": "patch requires review", "created_at": "now"}
+        ],
+        "report": {"executive_summary": "Run failed after test execution."},
+        "forensics": {
+            "failed_step": {"id": 3, "title": "Run tests", "tool": "test.run", "error": "pytest failed"},
+            "pending_approval_step": {"id": 2, "title": "Apply patch", "tool": "patch.apply"},
+            "last_step": {"id": 3, "title": "Run tests", "tool": "test.run", "status": "failed"},
+            "artifact_counts_by_type": {"plan": 1, "approval": 1, "log": 1},
+        },
+    }
+
+
+class FakeMemory:
+    def __init__(self, run):
+        self.run = run
+
+    def load_run(self, run_id):
+        if run_id == RUN_ID:
+            return self.run
+        return None
+
+
+class FakeAgent:
+    def __init__(self, run):
+        self.memory = FakeMemory(run)
+
+
+def make_client(run):
+    app = FastAPI()
+    app.state.agent = FakeAgent(run)
+    install_run_detail_v2(app)
+    return TestClient(app)
+
+
+def test_build_artifact_index_groups_by_type_and_step_with_previews():
+    index = build_artifact_index(make_run())
+
+    assert index["total"] == 3
+    assert index["counts_by_type"] == {"plan": 1, "approval": 1, "log": 1}
+    assert index["by_step"]["run_level"][0]["name"] == "run_plan"
+    assert index["by_step"]["step_3"][0]["content_size"] == 500
+    assert len(index["by_step"]["step_3"][0]["content_preview"]) == 240
+
+
+def test_build_step_index_exposes_failed_and_pending_steps():
+    index = build_step_index(make_run())
+
+    assert index["total"] == 3
+    assert index["status_counts"]["success"] == 1
+    assert index["status_counts"]["pending_approval"] == 1
+    assert index["status_counts"]["failed"] == 1
+    assert index["failed_steps"][0]["id"] == 3
+    assert index["pending_approval_steps"][0]["approval_detail_url"] == f"/approvals/v2/{RUN_ID}/2"
+
+
+def test_build_run_detail_v2_returns_compact_operational_summary():
+    detail = build_run_detail_v2(make_run())
+
+    assert detail["run_id"] == RUN_ID
+    assert detail["task"] == "Fix failing tests"
+    assert detail["summary"] == "Run failed after test execution."
+    assert detail["approval_events"] == 1
+    assert detail["artifact_index"]["total"] == 3
+    assert detail["forensic_highlights"]["failed_step"]["id"] == 3
+    assert detail["links"]["detail_v2"] == f"/runs/{RUN_ID}/detail/v2"
+
+
+def test_run_detail_v2_endpoint_returns_summary():
+    client = make_client(make_run())
+
+    response = client.get(f"/runs/{RUN_ID}/detail/v2")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["run"]["run_id"] == RUN_ID
+    assert payload["run"]["step_index"]["failed_steps"][0]["error"] == "pytest failed"
+
+
+def test_run_artifacts_v2_endpoint_returns_index():
+    client = make_client(make_run())
+
+    response = client.get(f"/runs/{RUN_ID}/artifacts/v2")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["run_id"] == RUN_ID
+    assert payload["artifacts"]["counts_by_type"]["approval"] == 1
+
+
+def test_run_detail_v2_endpoint_returns_404_for_missing_run():
+    client = make_client(make_run())
+
+    response = client.get("/runs/missing/detail/v2")
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["error"] == "not_found"

--- a/velocity_claw/api/app.py
+++ b/velocity_claw/api/app.py
@@ -8,6 +8,7 @@ from velocity_claw.api.auth import install_api_key_auth
 from velocity_claw.api.dashboard_v2 import render_dashboard_v2
 from velocity_claw.api.errors import install_api_error_handlers
 from velocity_claw.api.ops_console import build_operations_console
+from velocity_claw.api.run_detail_v2 import build_artifact_index, build_run_detail_v2
 from velocity_claw.api.server import ApprovalDecisionRequest, create_app as create_base_app
 
 
@@ -32,6 +33,22 @@ def install_approval_v2(app: FastAPI) -> None:
         if result.get("status") == "blocked":
             raise HTTPException(status_code=409, detail={"status": "failed", "error": result["reason"], "detail": result})
         return result
+
+
+def install_run_detail_v2(app: FastAPI) -> None:
+    @app.get("/runs/{run_id}/detail/v2")
+    def run_detail_v2(run_id: str):
+        run = app.state.agent.memory.load_run(run_id)
+        if not run:
+            raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Run not found"})
+        return {"status": "ok", "run": build_run_detail_v2(run)}
+
+    @app.get("/runs/{run_id}/artifacts/v2")
+    def run_artifacts_v2(run_id: str):
+        run = app.state.agent.memory.load_run(run_id)
+        if not run:
+            raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Run not found"})
+        return {"status": "ok", "run_id": run_id, "artifacts": build_artifact_index(run)}
 
 
 def install_dashboard_v2(app: FastAPI) -> None:
@@ -84,10 +101,12 @@ def create_app() -> FastAPI:
     app = create_base_app()
     install_api_error_handlers(app)
     install_approval_v2(app)
+    install_run_detail_v2(app)
     install_dashboard_v2(app)
     install_api_key_auth(app)
     app.state.api_error_handlers_installed = True
     app.state.approval_v2_installed = True
+    app.state.run_detail_v2_installed = True
     app.state.dashboard_v2_installed = True
     app.state.api_key_auth_installed = True
     return app

--- a/velocity_claw/api/run_detail_v2.py
+++ b/velocity_claw/api/run_detail_v2.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from typing import Any
+
+
+def _preview(content: Any, limit: int = 240) -> str:
+    text = "" if content is None else str(content)
+    return text[:limit]
+
+
+def build_artifact_index(run: dict[str, Any]) -> dict[str, Any]:
+    artifacts = run.get("artifacts", [])
+    by_type: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    by_step: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    counts = Counter()
+
+    for index, artifact in enumerate(artifacts):
+        artifact_type = artifact.get("artifact_type") or "text"
+        step_id = artifact.get("step_id")
+        key = "run_level" if step_id is None else f"step_{step_id}"
+        item = {
+            "index": index,
+            "name": artifact.get("name"),
+            "artifact_type": artifact_type,
+            "step_id": step_id,
+            "created_at": artifact.get("created_at"),
+            "content_preview": _preview(artifact.get("content")),
+            "content_size": len(str(artifact.get("content") or "")),
+        }
+        counts[artifact_type] += 1
+        by_type[artifact_type].append(item)
+        by_step[key].append(item)
+
+    return {
+        "total": len(artifacts),
+        "counts_by_type": dict(counts),
+        "by_type": dict(by_type),
+        "by_step": dict(by_step),
+    }
+
+
+def build_step_index(run: dict[str, Any]) -> dict[str, Any]:
+    steps = run.get("steps", [])
+    status_counts = Counter(step.get("status") or "unknown" for step in steps)
+    failed_steps = [step for step in steps if step.get("status") == "failed"]
+    pending_approval_steps = [step for step in steps if step.get("status") == "pending_approval"]
+    return {
+        "total": len(steps),
+        "status_counts": dict(status_counts),
+        "failed_steps": [
+            {
+                "id": step.get("id"),
+                "title": step.get("title"),
+                "tool": step.get("tool"),
+                "error": step.get("error"),
+            }
+            for step in failed_steps
+        ],
+        "pending_approval_steps": [
+            {
+                "id": step.get("id"),
+                "title": step.get("title"),
+                "tool": step.get("tool"),
+                "approval_detail_url": f"/approvals/v2/{run.get('run_id')}/{step.get('id')}",
+            }
+            for step in pending_approval_steps
+        ],
+        "items": [
+            {
+                "id": step.get("id"),
+                "title": step.get("title"),
+                "tool": step.get("tool"),
+                "status": step.get("status"),
+                "started_at": step.get("started_at"),
+                "completed_at": step.get("completed_at"),
+                "has_error": bool(step.get("error")),
+            }
+            for step in steps
+        ],
+    }
+
+
+def build_run_detail_v2(run: dict[str, Any]) -> dict[str, Any]:
+    step_index = build_step_index(run)
+    artifact_index = build_artifact_index(run)
+    report = run.get("report") or {}
+    forensics = run.get("forensics") or {}
+    approval_history = run.get("approval_history") or []
+    return {
+        "run_id": run.get("run_id"),
+        "task": run.get("task"),
+        "status": run.get("status"),
+        "created_at": run.get("created_at"),
+        "completed_at": run.get("completed_at"),
+        "summary": report.get("executive_summary"),
+        "step_index": step_index,
+        "artifact_index": artifact_index,
+        "approval_history": approval_history,
+        "approval_events": len(approval_history),
+        "forensic_highlights": {
+            "failed_step": forensics.get("failed_step"),
+            "pending_approval_step": forensics.get("pending_approval_step"),
+            "last_step": forensics.get("last_step"),
+            "artifact_counts_by_type": forensics.get("artifact_counts_by_type", {}),
+        },
+        "links": {
+            "raw": f"/runs/{run.get('run_id')}",
+            "html": f"/runs/{run.get('run_id')}/view",
+            "report": f"/runs/{run.get('run_id')}/report",
+            "forensics": f"/runs/{run.get('run_id')}/forensics",
+            "artifacts_v2": f"/runs/{run.get('run_id')}/artifacts/v2",
+            "detail_v2": f"/runs/{run.get('run_id')}/detail/v2",
+        },
+    }


### PR DESCRIPTION
## Summary

Adds structured Run detail v2 and artifact index endpoints without replacing existing run endpoints.

Changes:
- add `velocity_claw/api/run_detail_v2.py`
- build compact run detail summaries with step index, artifact index, approval history, forensic highlights, and links
- add `/runs/{run_id}/detail/v2`
- add `/runs/{run_id}/artifacts/v2`
- keep existing `/runs/{run_id}`, `/runs/{run_id}/view`, and `/runs/{run_id}/artifacts` untouched
- add tests for grouping, previews, failed/pending step indexes, endpoint responses, and missing run handling

Validation:
- pytest -q