### PR TITLE
Link Dashboard v2 to Run detail v2

### DIFF
--- a/tests/test_dashboard_v2_foundation.py
+++ b/tests/test_dashboard_v2_foundation.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from velocity_claw.api.app import install_dashboard_v2
-from velocity_claw.api.dashboard_v2 import render_dashboard_v2
+from velocity_claw.api.dashboard_v2 import approval_links, render_dashboard_v2, run_links
 
 
 class FakeSettings:
@@ -120,20 +120,37 @@ def make_fake_app():
     return app
 
 
-def test_render_dashboard_v2_contains_core_sections_and_escapes_values():
+def test_run_links_include_v2_and_classic_destinations():
+    html = run_links("run-1")
+
+    assert "/runs/run-1/detail/v2" in html
+    assert "/runs/run-1/artifacts/v2" in html
+    assert "/runs/run-1/forensics" in html
+    assert "/runs/run-1/report" in html
+    assert "/runs/run-1/view" in html
+
+
+def test_approval_links_include_review_and_run_detail():
+    html = approval_links("run-2", 3)
+
+    assert "/approvals/v2/run-2/3" in html
+    assert "/runs/run-2/detail/v2" in html
+
+
+def test_render_dashboard_v2_contains_core_sections_links_and_escapes_values():
     html = render_dashboard_v2(
         execution_profile="safe<script>",
         safe_mode=True,
         trusted_mode=False,
         release_state={"readiness": "ready", "score": 1, "total_checks": 1},
-        console={"queue": {"running": 0, "failed": 0}, "approvals": {"pending": 0}},
+        console={"queue": {"running": 0, "failed": 0}, "approvals": {"pending": 1}},
         recent_runs=[{"run_id": "run-1", "task": "Fix <bug>", "status": "completed", "created_at": "now"}],
-        approvals=[],
+        approvals=[{"run_id": "run-2", "step_id": 3, "title": "Apply patch", "reason": "review"}],
         queue_jobs=[],
         metrics={"tasks_total": 1},
         provider_observability={"summary": {"failed_routes": 0}},
         provider_health={},
-        last_failed=None,
+        last_failed={"run_id": "run-failed", "task": "Repair tests", "status": "failed"},
     )
 
     assert "Velocity Claw Dashboard v2" in html
@@ -142,6 +159,10 @@ def test_render_dashboard_v2_contains_core_sections_and_escapes_values():
     assert "Provider health" in html
     assert "safe&lt;script&gt;" in html
     assert "Fix &lt;bug&gt;" in html
+    assert "/runs/run-1/detail/v2" in html
+    assert "/runs/run-1/artifacts/v2" in html
+    assert "/approvals/v2/run-2/3" in html
+    assert "/runs/run-failed/detail/v2" in html
 
 
 def test_dashboard_v2_endpoint_renders_operational_snapshot():
@@ -155,3 +176,5 @@ def test_dashboard_v2_endpoint_renders_operational_snapshot():
     assert "Apply patch" in response.text
     assert "Repair tests" in response.text
     assert "openai" in response.text
+    assert "/runs/run-1/detail/v2" in response.text
+    assert "/approvals/v2/run-2/3" in response.text

--- a/velocity_claw/api/dashboard_v2.py
+++ b/velocity_claw/api/dashboard_v2.py
@@ -17,6 +17,26 @@ def number_card(label: str, value: Any) -> str:
     return f"<section class='card metric'><div class='label'>{html_escape(label)}</div><div class='value'>{html_escape(value)}</div></section>"
 
 
+def run_links(run_id: Any) -> str:
+    safe_run_id = html_escape(run_id)
+    return (
+        f"<a href='/runs/{safe_run_id}/detail/v2'>detail v2</a> · "
+        f"<a href='/runs/{safe_run_id}/artifacts/v2'>artifacts</a> · "
+        f"<a href='/runs/{safe_run_id}/forensics'>forensics</a> · "
+        f"<a href='/runs/{safe_run_id}/report'>report</a> · "
+        f"<a href='/runs/{safe_run_id}/view'>classic</a>"
+    )
+
+
+def approval_links(run_id: Any, step_id: Any) -> str:
+    safe_run_id = html_escape(run_id)
+    safe_step_id = html_escape(step_id)
+    return (
+        f"<a href='/approvals/v2/{safe_run_id}/{safe_step_id}'>review</a> · "
+        f"<a href='/runs/{safe_run_id}/detail/v2'>run detail</a>"
+    )
+
+
 def render_dashboard_v2(
     *,
     execution_profile: str,
@@ -46,18 +66,21 @@ def render_dashboard_v2(
             f"<td>{html_escape(run.get('task'))}</td>"
             f"<td>{status_badge(str(run.get('status') or 'unknown'))}</td>"
             f"<td>{html_escape(run.get('created_at'))}</td>"
-            f"<td><a href='/runs/{html_escape(run_id)}/view'>open</a></td>"
+            f"<td>{run_links(run_id)}</td>"
             "</tr>"
         )
 
     approval_rows = []
     for item in approvals:
+        run_id = item.get("run_id")
+        step_id = item.get("step_id")
         approval_rows.append(
             "<tr>"
-            f"<td><code>{html_escape(item.get('run_id'))}</code></td>"
-            f"<td>{html_escape(item.get('step_id'))}</td>"
+            f"<td><code>{html_escape(run_id)}</code></td>"
+            f"<td>{html_escape(step_id)}</td>"
             f"<td>{html_escape(item.get('title') or item.get('step_title') or '')}</td>"
             f"<td>{html_escape(item.get('reason') or item.get('approval_reason') or '')}</td>"
+            f"<td>{approval_links(run_id, step_id)}</td>"
             "</tr>"
         )
 
@@ -92,7 +115,7 @@ def render_dashboard_v2(
         last_failed_block = (
             f"<p><code>{html_escape(run_id)}</code> — {html_escape(last_failed.get('task'))} "
             f"{status_badge(str(last_failed.get('status') or 'failed'))} "
-            f"<a href='/runs/{html_escape(run_id)}/view'>open</a></p>"
+            f"{run_links(run_id)}</p>"
         )
 
     return f"""
@@ -166,15 +189,15 @@ def render_dashboard_v2(
 
   <section class='card section'>
     <h2>Recent runs</h2>
-    <table><thead><tr><th>Run ID</th><th>Task</th><th>Status</th><th>Created</th><th>View</th></tr></thead><tbody>
+    <table><thead><tr><th>Run ID</th><th>Task</th><th>Status</th><th>Created</th><th>Links</th></tr></thead><tbody>
       {''.join(run_rows) or "<tr><td colspan='5'>No runs recorded.</td></tr>"}
     </tbody></table>
   </section>
 
   <section class='card section'>
     <h2>Pending approvals</h2>
-    <table><thead><tr><th>Run ID</th><th>Step</th><th>Title</th><th>Reason</th></tr></thead><tbody>
-      {''.join(approval_rows) or "<tr><td colspan='4'>No pending approvals.</td></tr>"}
+    <table><thead><tr><th>Run ID</th><th>Step</th><th>Title</th><th>Reason</th><th>Links</th></tr></thead><tbody>
+      {''.join(approval_rows) or "<tr><td colspan='5'>No pending approvals.</td></tr>"}
     </tbody></table>
   </section>
 


### PR DESCRIPTION
## Summary

Connects Dashboard v2 to the newer operational v2 endpoints.

Changes:
- add reusable dashboard run links
- link recent runs to `/detail/v2`, `/artifacts/v2`, `/forensics`, `/report`, and classic view
- link pending approvals to Approval v2 review and Run detail v2
- link last failed run to Run detail v2 and related diagnostics
- update Dashboard v2 tests for v2 links and HTML escaping

Validation:
- pytest -q