### PR TITLE
Add API guide for v2 endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ It is designed for self-hosted development automation where auditability and own
 ### Operations layer
 
 - FastAPI server
-- HTML dashboard foundation
+- Dashboard v2 and classic dashboard
 - operations console snapshot
 - queue foundation
 - metrics and diagnostics
@@ -145,6 +145,10 @@ VELOCITY_CLAW_API_KEY="change-this-long-random-key"
 
 If no API key is configured, protected routes return `503 api_key_not_configured` instead of running open.
 
+Full API guide:
+
+- `docs/API.md`
+
 ---
 
 ## API highlights
@@ -157,18 +161,23 @@ Start the server with `python cli.py --server`, then use:
 | `GET /metrics` | runtime metrics |
 | `GET /diagnostics` | diagnostics snapshot |
 | `GET /ops/console` | operations console data |
-| `GET /dashboard` | dashboard HTML |
+| `GET /dashboard` | classic dashboard HTML |
+| `GET /dashboard/v2` | Dashboard v2 HTML |
 | `POST /task` | run a task |
 | `POST /modes/run` | run a high-level mode |
 | `POST /queue/submit` | enqueue a task |
 | `GET /runs` | list recent runs |
-| `GET /runs/{run_id}` | inspect a run |
+| `GET /runs/{run_id}` | inspect raw run payload |
+| `GET /runs/{run_id}/detail/v2` | compact run detail and links |
+| `GET /runs/{run_id}/artifacts/v2` | structured artifact index |
 | `GET /runs/{run_id}/forensics` | inspect run forensics |
 | `GET /runs/{run_id}/report` | inspect run report |
 | `GET /runs/{run_id}/retry-context` | inspect retry context |
 | `POST /runs/{run_id}/retry` | retry a previous run |
 | `GET /approvals` | list pending approvals |
-| `POST /approvals/explain` | explain approval requirement |
+| `GET /approvals/v2/{run_id}/{step_id}` | inspect approval before deciding |
+| `POST /approvals/v2/{run_id}/{step_id}/approve` | guarded Approval v2 approve |
+| `POST /approvals/v2/{run_id}/{step_id}/reject` | guarded Approval v2 reject |
 | `GET /release/readiness` | release readiness |
 | `GET /providers/observability` | provider/router observability |
 | `GET /git/summary` | safe repo summary |
@@ -211,6 +220,10 @@ Main guide:
 
 - `docs/DEPLOYMENT.md`
 
+API guide:
+
+- `docs/API.md`
+
 Release guide:
 
 - `docs/RELEASE.md`
@@ -241,7 +254,7 @@ Both files are tested for consistency.
 
 ```text
 velocity_claw/
-  api/            FastAPI server, auth, retry routes, dashboard helpers
+  api/            FastAPI server, auth, v2 endpoints, dashboard helpers
   config/         settings and env loading
   core/           agent, queue, modes, metrics, auto_fix, release
   executor/       tool dispatch
@@ -260,6 +273,7 @@ deploy/
   systemd/        hardened systemd deployment
 
 docs/
+  API.md          API endpoint guide
   DEPLOYMENT.md   unified deployment guide
   RELEASE.md      release checklist and versioning guide
 ```

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,201 @@
+# Velocity Claw API guide
+
+This guide lists the operational API endpoints exposed by Velocity Claw.
+
+All routes except `GET /health` require API authentication when the production app wrapper is used.
+
+Supported authentication headers:
+
+```text
+X-API-Key: <key>
+Authorization: Bearer <key>
+```
+
+Configure one of these variables before exposing the API:
+
+```bash
+VELOCITY_CLAW_API_KEY=change-this-long-random-key
+# or
+API_KEY=change-this-long-random-key
+```
+
+## Health and runtime status
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| GET | `/health` | Public service health and metrics snapshot |
+| GET | `/status` | Agent runtime status |
+| GET | `/metrics` | Metrics counters |
+| GET | `/diagnostics` | Diagnostics snapshot |
+| GET | `/ops/console` | Compact operations console snapshot |
+| GET | `/dashboard` | Classic HTML dashboard |
+| GET | `/dashboard/v2` | Dashboard v2 HTML overview |
+
+Example:
+
+```bash
+curl http://127.0.0.1:8000/health
+curl -H "X-API-Key: $VELOCITY_CLAW_API_KEY" http://127.0.0.1:8000/dashboard/v2
+```
+
+## Task execution
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| POST | `/task` | Run a task immediately |
+| POST | `/modes/run` | Run a task through a named mode |
+| GET | `/modes` | List available modes |
+| POST | `/auto-fix` | Run auto-fix loop for a target test |
+
+Example:
+
+```bash
+curl -X POST http://127.0.0.1:8000/task \
+  -H "X-API-Key: $VELOCITY_CLAW_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"task":"Analyze repository structure"}'
+```
+
+## Queue
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| POST | `/queue/submit` | Submit a queued task |
+| GET | `/queue` | List queued jobs |
+| GET | `/queue/{job_id}` | Get one queued job |
+| POST | `/queue/{job_id}/cancel` | Cancel a queued job |
+| POST | `/queue/{job_id}/requeue` | Requeue a job |
+
+## Runs and artifacts
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| GET | `/runs` | List recent runs |
+| GET | `/runs/{run_id}` | Raw run payload |
+| GET | `/runs/{run_id}/view` | Classic HTML run view |
+| GET | `/runs/{run_id}/detail/v2` | Structured compact run summary |
+| GET | `/runs/{run_id}/artifacts` | Legacy artifact grouping |
+| GET | `/runs/{run_id}/artifacts/v2` | Structured artifact index |
+| GET | `/runs/{run_id}/forensics` | Run forensics |
+| GET | `/runs/{run_id}/report` | Run report |
+| GET | `/runs/{run_id}/planning-context` | Planning context artifact |
+| GET | `/runs/{run_id}/resume-context` | Resume context artifact |
+| GET | `/runs/{run_id}/approval-history` | Approval history for a run |
+
+Run detail v2 returns:
+
+- compact run metadata
+- step index
+- failed steps
+- pending approval steps
+- artifact counts by type
+- artifact grouping by type and step
+- artifact previews
+- approval history count
+- forensic highlights
+- links to related views
+
+Example:
+
+```bash
+curl -H "X-API-Key: $VELOCITY_CLAW_API_KEY" \
+  http://127.0.0.1:8000/runs/<run_id>/detail/v2
+```
+
+## Approvals
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| GET | `/approvals` | List pending approvals |
+| POST | `/approvals/explain` | Explain whether a step requires approval |
+| POST | `/approvals/{run_id}/{step_id}/approve` | Legacy approve endpoint |
+| POST | `/approvals/{run_id}/{step_id}/reject` | Legacy reject endpoint |
+| GET | `/approvals/v2/{run_id}/{step_id}` | Approval v2 detail before decision |
+| POST | `/approvals/v2/{run_id}/{step_id}/approve` | Guarded Approval v2 approve |
+| POST | `/approvals/v2/{run_id}/{step_id}/reject` | Guarded Approval v2 reject |
+
+Approval v2 detail returns:
+
+- run id
+- run task
+- step payload
+- current step status
+- `can_decide`
+- approval history for that step
+- step artifacts
+- approve/reject links
+
+Approval v2 blocks duplicate decisions. If a step is already approved or rejected, the v2 decision endpoints return `409`.
+
+Example:
+
+```bash
+curl -H "X-API-Key: $VELOCITY_CLAW_API_KEY" \
+  http://127.0.0.1:8000/approvals/v2/<run_id>/<step_id>
+
+curl -X POST http://127.0.0.1:8000/approvals/v2/<run_id>/<step_id>/approve \
+  -H "X-API-Key: $VELOCITY_CLAW_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"actor":"owner","reason":"reviewed and approved"}'
+```
+
+## Execution profiles and security explanation
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| GET | `/profiles` | List profiles |
+| GET | `/profiles/active` | Active profile capability matrix |
+| GET | `/profiles/explain/{tool_name}` | Explain tool access under the active profile |
+| POST | `/approvals/explain` | Explain approval requirement for a step |
+
+For tools with dots, replace `.` with `__` in the URL path.
+
+Example:
+
+```bash
+curl -H "X-API-Key: $VELOCITY_CLAW_API_KEY" \
+  http://127.0.0.1:8000/profiles/explain/shell__run
+```
+
+The profile explanation includes:
+
+- allowed/blocked state
+- tool category
+- risk level
+- required capability
+- reason
+- approval hint
+- active profile capabilities
+
+## Providers and repository context
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| GET | `/providers/health` | Provider health state |
+| GET | `/providers/observability` | Provider routing observability |
+| GET | `/git/summary` | Safe git repository summary |
+| GET | `/memory/context` | Repository memory context |
+| GET | `/memory/resume?task=...` | Resume context for a task |
+| GET | `/release/readiness` | Release readiness report |
+
+## Dashboard workflow
+
+Recommended operator flow:
+
+1. Open `/dashboard/v2`.
+2. Review recent runs and pending approvals.
+3. Open `/runs/{run_id}/detail/v2` for compact run context.
+4. Open `/runs/{run_id}/artifacts/v2` for artifact grouping and previews.
+5. Open `/approvals/v2/{run_id}/{step_id}` before approving or rejecting.
+6. Use the guarded Approval v2 decision endpoints.
+
+## Error behavior
+
+Common response patterns:
+
+| Status | Meaning |
+| --- | --- |
+| 401 | Missing or wrong API key |
+| 404 | Requested run/job/approval was not found |
+| 409 | Approval decision blocked because the step is no longer pending |
+| 503 | API key is not configured on protected routes |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -44,6 +44,10 @@ Authorization: Bearer <key>
 
 If no API key is configured, protected routes fail closed instead of running open.
 
+Full endpoint reference:
+
+- `docs/API.md`
+
 ## Manual systemd deployment
 
 Use manual systemd deployment when you want to copy and adjust unit files yourself.
@@ -106,6 +110,10 @@ For a healthy deployment, verify:
 - the API service starts successfully
 - `/health` responds through the configured API port
 - protected API routes require `X-API-Key` or Bearer authentication
+- `/dashboard/v2` loads with authentication
+- `/runs` returns recent runs with authentication
+- `/approvals` returns pending approvals with authentication
+- `docs/API.md` matches the deployed API surface
 - logs are being written or available through the process manager
 - the memory database path is writable by the service user
 - the workspace directory exists and is writable by the service user

--- a/tests/test_api_docs_v2.py
+++ b/tests/test_api_docs_v2.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+
+API_DOC = Path("docs/API.md")
+README = Path("README.md")
+DEPLOYMENT = Path("docs/DEPLOYMENT.md")
+
+
+def test_api_doc_lists_v2_operator_endpoints():
+    content = API_DOC.read_text(encoding="utf-8")
+
+    required = [
+        "/dashboard/v2",
+        "/runs/{run_id}/detail/v2",
+        "/runs/{run_id}/artifacts/v2",
+        "/approvals/v2/{run_id}/{step_id}",
+        "/approvals/v2/{run_id}/{step_id}/approve",
+        "/approvals/v2/{run_id}/{step_id}/reject",
+        "/profiles/explain/{tool_name}",
+    ]
+    for endpoint in required:
+        assert endpoint in content
+
+
+def test_api_doc_documents_auth_headers_and_error_behavior():
+    content = API_DOC.read_text(encoding="utf-8")
+
+    assert "X-API-Key" in content
+    assert "Authorization: Bearer" in content
+    assert "401" in content
+    assert "409" in content
+    assert "503" in content
+
+
+def test_primary_docs_link_to_api_guide():
+    assert "docs/API.md" in README.read_text(encoding="utf-8")
+    assert "docs/API.md" in DEPLOYMENT.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Adds an API guide for the current operator API surface.

Changes:
- add `docs/API.md`
- document API auth headers and error behavior
- document Dashboard v2, Run detail v2, Artifact index v2, Approval v2, profiles, queue, providers, and memory endpoints
- link API guide from README
- link API guide from deployment docs
- add tests that ensure key v2 endpoints stay documented

Validation:
- pytest -q