### PR TITLE
Add Diagnostics v2 foundation

### DIFF
--- a/tests/test_diagnostics_v2.py
+++ b/tests/test_diagnostics_v2.py
@@ -1,0 +1,141 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from velocity_claw.api.app import install_diagnostics_v2
+from velocity_claw.api.diagnostics_v2 import build_diagnostics_v2
+
+
+class FakeSettings:
+    env = "production"
+    execution_profile = "safe"
+    safe_mode = True
+    trusted_mode = False
+    shell_enabled = False
+    git_enabled = False
+    dry_run = False
+
+
+class RiskySettings(FakeSettings):
+    trusted_mode = True
+    shell_enabled = True
+    git_enabled = True
+
+
+class FakeRelease:
+    def evaluate(self):
+        return {
+            "readiness": "warning",
+            "score": 4,
+            "total_checks": 5,
+            "blocking_issues": [],
+            "warnings": ["provider fallback active"],
+        }
+
+
+class FakeQueue:
+    max_concurrency = 2
+
+    def list_jobs(self):
+        return [
+            {"job_id": "job-1", "status": "running"},
+            {"job_id": "job-2", "status": "failed"},
+            {"job_id": "job-3", "status": "queued"},
+        ]
+
+    def active_count(self):
+        return 1
+
+
+class FakeRouter:
+    def get_router_observability(self):
+        return {"summary": {"route_count": 2, "failed_routes": 1}}
+
+    def get_provider_health(self):
+        return {
+            "openai": {"requests": 3, "successes": 2, "failures": 1, "in_cooldown": False},
+            "anthropic": {"requests": 1, "successes": 0, "failures": 1, "in_cooldown": True},
+        }
+
+
+class FakeAgent:
+    def __init__(self):
+        self.router = FakeRouter()
+
+    def list_pending_approvals(self):
+        return [{"run_id": "run-1", "step_id": 2, "reason": "patch requires review"}]
+
+    def resume_last_failed_run(self):
+        return {"run_id": "run-failed", "task": "Repair tests", "status": "failed"}
+
+
+class FakeMetrics:
+    def snapshot(self):
+        return {"tasks_total": 2, "tasks_failed": 1, "queue_failed": 1}
+
+
+class FakeAppState:
+    settings = FakeSettings()
+    release = FakeRelease()
+    queue = FakeQueue()
+    agent = FakeAgent()
+    metrics = FakeMetrics()
+
+
+def make_app():
+    app = FastAPI()
+    app.state.settings = FakeSettings()
+    app.state.release = FakeRelease()
+    app.state.queue = FakeQueue()
+    app.state.agent = FakeAgent()
+    app.state.metrics = FakeMetrics()
+    install_diagnostics_v2(app)
+    return app
+
+
+def test_build_diagnostics_v2_summarizes_runtime_state_and_flags():
+    result = build_diagnostics_v2(
+        settings=RiskySettings(),
+        release_state=FakeRelease().evaluate(),
+        queue_jobs=FakeQueue().list_jobs(),
+        approvals=FakeAgent().list_pending_approvals(),
+        provider_observability=FakeRouter().get_router_observability(),
+        provider_health=FakeRouter().get_provider_health(),
+        last_failed=FakeAgent().resume_last_failed_run(),
+        metrics=FakeMetrics().snapshot(),
+        active_workers=1,
+        max_concurrency=2,
+    )
+
+    assert result["status"] == "ok"
+    assert result["summary"]["queue_total"] == 3
+    assert result["summary"]["queue_failed"] == 1
+    assert result["summary"]["approvals_pending"] == 1
+    assert result["summary"]["provider_failures"] == 2
+    assert result["summary"]["provider_cooldowns"] == 1
+    assert result["runtime"]["execution_profile"] == "safe"
+    codes = {flag["code"] for flag in result["risk_flags"]}
+    assert "trusted_mode_enabled" in codes
+    assert "shell_enabled" in codes
+    assert "git_enabled" in codes
+    assert "release_not_ready" in codes
+    assert "queue_failures" in codes
+    assert "pending_approvals" in codes
+    assert "provider_cooldown" in codes
+    assert "last_failed_run" in codes
+
+
+def test_diagnostics_v2_endpoint_returns_operational_snapshot():
+    client = TestClient(make_app())
+
+    response = client.get("/diagnostics/v2")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["summary"]["release_readiness"] == "warning"
+    assert payload["queue"]["running"] == 1
+    assert payload["queue"]["failed"] == 1
+    assert payload["approvals"]["pending"] == 1
+    assert payload["providers"]["summary"]["in_cooldown"] == 1
+    assert payload["last_failed_run"]["run_id"] == "run-failed"
+    assert payload["links"]["dashboard_v2"] == "/dashboard/v2"

--- a/velocity_claw/api/app.py
+++ b/velocity_claw/api/app.py
@@ -6,6 +6,7 @@ from fastapi.responses import HTMLResponse
 from velocity_claw.api.approval_v2 import approve_with_guard, build_approval_detail, reject_with_guard
 from velocity_claw.api.auth import install_api_key_auth
 from velocity_claw.api.dashboard_v2 import render_dashboard_v2
+from velocity_claw.api.diagnostics_v2 import build_diagnostics_v2
 from velocity_claw.api.errors import install_api_error_handlers
 from velocity_claw.api.ops_console import build_operations_console
 from velocity_claw.api.run_detail_v2 import build_artifact_index, build_run_detail_v2
@@ -49,6 +50,30 @@ def install_run_detail_v2(app: FastAPI) -> None:
         if not run:
             raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Run not found"})
         return {"status": "ok", "run_id": run_id, "artifacts": build_artifact_index(run)}
+
+
+def install_diagnostics_v2(app: FastAPI) -> None:
+    @app.get("/diagnostics/v2")
+    def diagnostics_v2():
+        release_state = app.state.release.evaluate()
+        queue_jobs = app.state.queue.list_jobs()
+        approvals = app.state.agent.list_pending_approvals()
+        provider_observability = app.state.agent.router.get_router_observability()
+        provider_health = app.state.agent.router.get_provider_health()
+        last_failed = app.state.agent.resume_last_failed_run()
+        metrics = app.state.metrics.snapshot()
+        return build_diagnostics_v2(
+            settings=app.state.settings,
+            release_state=release_state,
+            queue_jobs=queue_jobs,
+            approvals=approvals,
+            provider_observability=provider_observability,
+            provider_health=provider_health,
+            last_failed=last_failed,
+            metrics=metrics,
+            active_workers=app.state.queue.active_count(),
+            max_concurrency=app.state.queue.max_concurrency,
+        )
 
 
 def install_dashboard_v2(app: FastAPI) -> None:
@@ -102,11 +127,13 @@ def create_app() -> FastAPI:
     install_api_error_handlers(app)
     install_approval_v2(app)
     install_run_detail_v2(app)
+    install_diagnostics_v2(app)
     install_dashboard_v2(app)
     install_api_key_auth(app)
     app.state.api_error_handlers_installed = True
     app.state.approval_v2_installed = True
     app.state.run_detail_v2_installed = True
+    app.state.diagnostics_v2_installed = True
     app.state.dashboard_v2_installed = True
     app.state.api_key_auth_installed = True
     return app

--- a/velocity_claw/api/diagnostics_v2.py
+++ b/velocity_claw/api/diagnostics_v2.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def _queue_summary(queue_jobs: list[dict[str, Any]], active_workers: int, max_concurrency: int) -> dict[str, Any]:
+    return {
+        "total": len(queue_jobs),
+        "running": sum(1 for job in queue_jobs if job.get("status") == "running"),
+        "queued": sum(1 for job in queue_jobs if job.get("status") == "queued"),
+        "completed": sum(1 for job in queue_jobs if job.get("status") == "completed"),
+        "failed": sum(1 for job in queue_jobs if job.get("status") == "failed"),
+        "cancelled": sum(1 for job in queue_jobs if job.get("status") == "cancelled"),
+        "active_workers": active_workers,
+        "max_concurrency": max_concurrency,
+    }
+
+
+def _provider_summary(provider_health: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    total = len(provider_health)
+    in_cooldown = [name for name, state in provider_health.items() if state.get("in_cooldown")]
+    failed = [name for name, state in provider_health.items() if state.get("failures", 0) > 0]
+    return {
+        "total": total,
+        "in_cooldown": len(in_cooldown),
+        "failed": len(failed),
+        "cooldown_providers": in_cooldown,
+        "providers_with_failures": failed,
+    }
+
+
+def _risk_flags(*, settings: Any, release_state: dict[str, Any], queue: dict[str, Any], approvals: list[dict[str, Any]], provider_summary: dict[str, Any], last_failed: dict[str, Any] | None) -> list[dict[str, str]]:
+    flags: list[dict[str, str]] = []
+    if getattr(settings, "trusted_mode", False):
+        flags.append({"level": "high", "code": "trusted_mode_enabled", "message": "Trusted mode is enabled."})
+    if getattr(settings, "shell_enabled", False):
+        flags.append({"level": "medium", "code": "shell_enabled", "message": "Shell execution is enabled."})
+    if getattr(settings, "git_enabled", False):
+        flags.append({"level": "medium", "code": "git_enabled", "message": "Git execution is enabled."})
+    if release_state.get("readiness") not in {"ready", "ok"}:
+        flags.append({"level": "medium", "code": "release_not_ready", "message": "Release readiness is not green."})
+    if queue.get("failed", 0) > 0:
+        flags.append({"level": "medium", "code": "queue_failures", "message": "Queue has failed jobs."})
+    if approvals:
+        flags.append({"level": "info", "code": "pending_approvals", "message": "There are pending approvals."})
+    if provider_summary.get("in_cooldown", 0) > 0:
+        flags.append({"level": "medium", "code": "provider_cooldown", "message": "One or more providers are in cooldown."})
+    if last_failed:
+        flags.append({"level": "info", "code": "last_failed_run", "message": "A failed run is available for inspection."})
+    return flags
+
+
+def build_diagnostics_v2(*, settings: Any, release_state: dict[str, Any], queue_jobs: list[dict[str, Any]], approvals: list[dict[str, Any]], provider_observability: dict[str, Any], provider_health: dict[str, dict[str, Any]], last_failed: dict[str, Any] | None, metrics: dict[str, Any], active_workers: int, max_concurrency: int) -> dict[str, Any]:
+    queue = _queue_summary(queue_jobs, active_workers, max_concurrency)
+    providers = _provider_summary(provider_health)
+    flags = _risk_flags(
+        settings=settings,
+        release_state=release_state,
+        queue=queue,
+        approvals=approvals,
+        provider_summary=providers,
+        last_failed=last_failed,
+    )
+    return {
+        "status": "ok",
+        "summary": {
+            "release_readiness": release_state.get("readiness"),
+            "release_score": release_state.get("score"),
+            "release_total_checks": release_state.get("total_checks"),
+            "queue_total": queue["total"],
+            "queue_running": queue["running"],
+            "queue_failed": queue["failed"],
+            "approvals_pending": len(approvals),
+            "provider_failures": providers["failed"],
+            "provider_cooldowns": providers["in_cooldown"],
+            "risk_flags": len(flags),
+        },
+        "runtime": {
+            "env": getattr(settings, "env", None),
+            "execution_profile": getattr(settings, "execution_profile", None),
+            "safe_mode": getattr(settings, "safe_mode", None),
+            "trusted_mode": getattr(settings, "trusted_mode", None),
+            "shell_enabled": getattr(settings, "shell_enabled", None),
+            "git_enabled": getattr(settings, "git_enabled", None),
+            "dry_run": getattr(settings, "dry_run", None),
+        },
+        "release": {
+            "readiness": release_state.get("readiness"),
+            "score": release_state.get("score"),
+            "total_checks": release_state.get("total_checks"),
+            "blocking_issues": release_state.get("blocking_issues", []),
+            "warnings": release_state.get("warnings", []),
+        },
+        "queue": queue,
+        "approvals": {
+            "pending": len(approvals),
+            "items": approvals[:10],
+        },
+        "providers": {
+            "summary": providers,
+            "router": provider_observability.get("summary", {}) if isinstance(provider_observability, dict) else {},
+            "health": provider_health,
+        },
+        "last_failed_run": last_failed,
+        "metrics": metrics,
+        "risk_flags": flags,
+        "links": {
+            "dashboard_v2": "/dashboard/v2",
+            "ops_console": "/ops/console",
+            "runs": "/runs",
+            "approvals": "/approvals",
+            "providers": "/providers/observability",
+            "release_readiness": "/release/readiness",
+        },
+    }


### PR DESCRIPTION
## Summary

Adds a richer Diagnostics v2 endpoint for operational troubleshooting.

Changes:
- add `velocity_claw/api/diagnostics_v2.py`
- add `/diagnostics/v2`
- summarize release readiness, queue, approvals, providers, runtime settings, metrics, and last failed run
- add risk flags for trusted mode, shell/git enabled, release warnings, queue failures, pending approvals, provider cooldown, and last failed run
- add links to Dashboard v2, ops console, runs, approvals, providers, and release readiness
- add tests for summary, risk flags, and endpoint output

Validation:
- pytest -q