### PR TITLE
Fix API smoke auth status expectation

### DIFF
--- a/scripts/smoke_api.py
+++ b/scripts/smoke_api.py
@@ -70,7 +70,7 @@ def request_html(base_url: str, path: str, api_key: str | None = None, expected_
 def run_smoke_checks(base_url: str, api_key: str) -> list[CheckResult]:
     checks = [
         request_json(base_url, "/health", expected_status=200),
-        request_json(base_url, "/status", expected_status=503),
+        request_json(base_url, "/status", expected_status=401),
         request_json(base_url, "/status", api_key=api_key, expected_status=200),
         request_json(base_url, "/metrics", api_key=api_key, expected_status=200),
         request_json(base_url, "/diagnostics/v2", api_key=api_key, expected_status=200),

--- a/tests/test_smoke_api_script.py
+++ b/tests/test_smoke_api_script.py
@@ -1,4 +1,5 @@
-from scripts.smoke_api import CheckResult, main, print_results
+from scripts import smoke_api
+from scripts.smoke_api import CheckResult, main, print_results, run_smoke_checks
 
 
 def test_smoke_api_main_requires_api_key(monkeypatch):
@@ -22,3 +23,27 @@ def test_smoke_api_print_results_reports_pass_and_fail(capsys):
     assert "FAIL /status" in output
     assert "status=200" in output
     assert "status=401" in output
+
+
+def test_smoke_api_checks_expected_auth_and_operator_endpoints(monkeypatch):
+    calls = []
+
+    def fake_json(base_url, path, api_key=None, expected_status=200):
+        calls.append(("json", path, api_key, expected_status))
+        return CheckResult(path, True, expected_status, "ok")
+
+    def fake_html(base_url, path, api_key=None, expected_status=200):
+        calls.append(("html", path, api_key, expected_status))
+        return CheckResult(path, True, expected_status, "ok")
+
+    monkeypatch.setattr(smoke_api, "request_json", fake_json)
+    monkeypatch.setattr(smoke_api, "request_html", fake_html)
+
+    results = run_smoke_checks("http://127.0.0.1:8000", "secret")
+
+    assert all(result.ok for result in results)
+    assert ("json", "/health", None, 200) in calls
+    assert ("json", "/status", None, 401) in calls
+    assert ("json", "/status", "secret", 200) in calls
+    assert ("json", "/diagnostics/v2", "secret", 200) in calls
+    assert ("html", "/dashboard/v2", "secret", 200) in calls


### PR DESCRIPTION
## Summary

Fixes the deployed API smoke check for authenticated deployments.

Changes:
- expect `401` for protected `/status` without a key when the server has an API key configured
- keep authenticated `/status` check at `200`
- keep `/health` public at `200`
- add tests that lock the smoke-check endpoint list and expected auth statuses

Validation:
- pytest -q