### PR TITLE
Add version API surface

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -27,13 +27,14 @@ After starting a deployed API service, run:
 VELOCITY_CLAW_API_KEY=<key> python scripts/smoke_api.py --base-url http://127.0.0.1:8000
 ```
 
-The smoke script checks public health, protected-route auth behavior, authenticated status/metrics/diagnostics/runs/approvals/profile endpoints, release readiness, and Dashboard v2.
+The smoke script checks public health, protected-route auth behavior, authenticated version/status/metrics/diagnostics/runs/approvals/profile endpoints, release readiness, and Dashboard v2.
 
 ## Health and runtime status
 
 | Method | Endpoint | Purpose |
 | --- | --- | --- |
 | GET | `/health` | Public service health and metrics snapshot |
+| GET | `/version` | Product version, release stage, and runtime mode |
 | GET | `/status` | Agent runtime status |
 | GET | `/metrics` | Metrics counters |
 | GET | `/diagnostics` | Classic diagnostics snapshot |
@@ -46,6 +47,7 @@ Example:
 
 ```bash
 curl http://127.0.0.1:8000/health
+curl -H "X-API-Key: $VELOCITY_CLAW_API_KEY" http://127.0.0.1:8000/version
 curl -H "X-API-Key: $VELOCITY_CLAW_API_KEY" http://127.0.0.1:8000/dashboard/v2
 curl -H "X-API-Key: $VELOCITY_CLAW_API_KEY" http://127.0.0.1:8000/diagnostics/v2
 ```
@@ -194,13 +196,14 @@ The profile explanation includes:
 
 Recommended operator flow:
 
-1. Open `/dashboard/v2`.
-2. Review recent runs and pending approvals.
-3. Open `/diagnostics/v2` when troubleshooting runtime state.
-4. Open `/runs/{run_id}/detail/v2` for compact run context.
-5. Open `/runs/{run_id}/artifacts/v2` for artifact grouping and previews.
-6. Open `/approvals/v2/{run_id}/{step_id}` before approving or rejecting.
-7. Use the guarded Approval v2 decision endpoints.
+1. Open `/version` to verify the deployed version.
+2. Open `/dashboard/v2`.
+3. Review recent runs and pending approvals.
+4. Open `/diagnostics/v2` when troubleshooting runtime state.
+5. Open `/runs/{run_id}/detail/v2` for compact run context.
+6. Open `/runs/{run_id}/artifacts/v2` for artifact grouping and previews.
+7. Open `/approvals/v2/{run_id}/{step_id}` before approving or rejecting.
+8. Use the guarded Approval v2 decision endpoints.
 
 ## Error behavior
 

--- a/scripts/smoke_api.py
+++ b/scripts/smoke_api.py
@@ -71,6 +71,7 @@ def run_smoke_checks(base_url: str, api_key: str) -> list[CheckResult]:
     checks = [
         request_json(base_url, "/health", expected_status=200),
         request_json(base_url, "/status", expected_status=401),
+        request_json(base_url, "/version", api_key=api_key, expected_status=200),
         request_json(base_url, "/status", api_key=api_key, expected_status=200),
         request_json(base_url, "/metrics", api_key=api_key, expected_status=200),
         request_json(base_url, "/diagnostics/v2", api_key=api_key, expected_status=200),

--- a/tests/test_api_docs_v2.py
+++ b/tests/test_api_docs_v2.py
@@ -10,6 +10,7 @@ def test_api_doc_lists_v2_operator_endpoints():
     content = API_DOC.read_text(encoding="utf-8")
 
     required = [
+        "/version",
         "/dashboard/v2",
         "/diagnostics/v2",
         "/runs/{run_id}/detail/v2",

--- a/tests/test_smoke_api_script.py
+++ b/tests/test_smoke_api_script.py
@@ -44,6 +44,7 @@ def test_smoke_api_checks_expected_auth_and_operator_endpoints(monkeypatch):
     assert all(result.ok for result in results)
     assert ("json", "/health", None, 200) in calls
     assert ("json", "/status", None, 401) in calls
+    assert ("json", "/version", "secret", 200) in calls
     assert ("json", "/status", "secret", 200) in calls
     assert ("json", "/diagnostics/v2", "secret", 200) in calls
     assert ("html", "/dashboard/v2", "secret", 200) in calls

--- a/tests/test_version_api.py
+++ b/tests/test_version_api.py
@@ -1,0 +1,42 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from velocity_claw.api.app import install_version_endpoint
+from velocity_claw.api.version import build_version_payload
+from velocity_claw.__version__ import __product_name__, __release_stage__, __version__
+
+
+class FakeSettings:
+    env = "production"
+    execution_profile = "safe"
+    safe_mode = True
+    trusted_mode = False
+
+
+def test_build_version_payload_uses_package_metadata_and_runtime_settings():
+    payload = build_version_payload(FakeSettings())
+
+    assert payload["status"] == "ok"
+    assert payload["product"] == __product_name__
+    assert payload["version"] == __version__
+    assert payload["release_stage"] == __release_stage__
+    assert payload["runtime"]["env"] == "production"
+    assert payload["runtime"]["execution_profile"] == "safe"
+    assert payload["runtime"]["safe_mode"] is True
+    assert payload["runtime"]["trusted_mode"] is False
+
+
+def test_version_endpoint_returns_version_payload():
+    app = FastAPI()
+    app.state.settings = FakeSettings()
+    install_version_endpoint(app)
+    client = TestClient(app)
+
+    response = client.get("/version")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["product"] == __product_name__
+    assert payload["version"] == __version__
+    assert payload["runtime"]["execution_profile"] == "safe"

--- a/velocity_claw/api/app.py
+++ b/velocity_claw/api/app.py
@@ -11,6 +11,13 @@ from velocity_claw.api.errors import install_api_error_handlers
 from velocity_claw.api.ops_console import build_operations_console
 from velocity_claw.api.run_detail_v2 import build_artifact_index, build_run_detail_v2
 from velocity_claw.api.server import ApprovalDecisionRequest, create_app as create_base_app
+from velocity_claw.api.version import build_version_payload
+
+
+def install_version_endpoint(app: FastAPI) -> None:
+    @app.get("/version")
+    def version():
+        return build_version_payload(app.state.settings)
 
 
 def install_approval_v2(app: FastAPI) -> None:
@@ -125,12 +132,14 @@ def create_app() -> FastAPI:
     """Create the production API app with shared hardening installed."""
     app = create_base_app()
     install_api_error_handlers(app)
+    install_version_endpoint(app)
     install_approval_v2(app)
     install_run_detail_v2(app)
     install_diagnostics_v2(app)
     install_dashboard_v2(app)
     install_api_key_auth(app)
     app.state.api_error_handlers_installed = True
+    app.state.version_endpoint_installed = True
     app.state.approval_v2_installed = True
     app.state.run_detail_v2_installed = True
     app.state.diagnostics_v2_installed = True

--- a/velocity_claw/api/version.py
+++ b/velocity_claw/api/version.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any
+
+from velocity_claw.__version__ import __product_name__, __release_stage__, __version__
+
+
+def build_version_payload(settings: Any) -> dict[str, Any]:
+    return {
+        "status": "ok",
+        "product": __product_name__,
+        "version": __version__,
+        "release_stage": __release_stage__,
+        "runtime": {
+            "env": getattr(settings, "env", None),
+            "execution_profile": getattr(settings, "execution_profile", None),
+            "safe_mode": getattr(settings, "safe_mode", None),
+            "trusted_mode": getattr(settings, "trusted_mode", None),
+        },
+    }


### PR DESCRIPTION
## Summary

Adds a protected version endpoint so operators can verify the deployed service version and runtime mode.

Changes:
- add `velocity_claw/api/version.py`
- add `/version` endpoint to the production app wrapper
- include package version, product name, release stage, env, execution profile, safe mode, and trusted mode
- include `/version` in API smoke checks
- document `/version` in `docs/API.md`
- require `/version` in API docs coverage tests
- add unit/endpoint tests for version payload

Validation:
- pytest -q