### PR TITLE
Show version in Dashboard v2

### DIFF
--- a/tests/test_dashboard_v2_foundation.py
+++ b/tests/test_dashboard_v2_foundation.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from velocity_claw.__version__ import __release_stage__, __version__
 from velocity_claw.api.app import install_dashboard_v2
 from velocity_claw.api.dashboard_v2 import approval_links, dashboard_risk_flags, render_dashboard_v2, run_links
 
@@ -156,7 +157,7 @@ def test_dashboard_risk_flags_detect_runtime_risks():
     assert "last_failed_run" in codes
 
 
-def test_render_dashboard_v2_contains_core_sections_diagnostics_links_and_escapes_values():
+def test_render_dashboard_v2_contains_core_sections_version_diagnostics_links_and_escapes_values():
     html = render_dashboard_v2(
         execution_profile="safe<script>",
         safe_mode=True,
@@ -178,6 +179,10 @@ def test_render_dashboard_v2_contains_core_sections_diagnostics_links_and_escape
     assert "Provider health" in html
     assert "Diagnostics" in html
     assert "Risk flags" in html
+    assert "Version" in html
+    assert __version__ in html
+    assert __release_stage__ in html
+    assert "/version" in html
     assert "/diagnostics/v2" in html
     assert "safe&lt;script&gt;" in html
     assert "Fix &lt;bug&gt;" in html
@@ -201,4 +206,6 @@ def test_dashboard_v2_endpoint_renders_operational_snapshot():
     assert "/runs/run-1/detail/v2" in response.text
     assert "/approvals/v2/run-2/3" in response.text
     assert "/diagnostics/v2" in response.text
+    assert "/version" in response.text
+    assert __version__ in response.text
     assert "Risk flags" in response.text

--- a/velocity_claw/api/dashboard_v2.py
+++ b/velocity_claw/api/dashboard_v2.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from html import escape
 from typing import Any
 
+from velocity_claw.__version__ import __release_stage__, __version__
+
 
 def html_escape(value: Any) -> str:
     return escape(str(value if value is not None else ""), quote=True)
@@ -199,6 +201,7 @@ def render_dashboard_v2(
       <h1>Velocity Claw Dashboard v2</h1>
       <p class='muted'>Operational overview for runs, approvals, queue, providers, and release readiness.</p>
       <div class='nav'>
+        <a href='/version'>version</a>
         <a href='/dashboard'>classic dashboard</a>
         <a href='/diagnostics/v2'>diagnostics v2</a>
         <a href='/ops/console'>ops console</a>
@@ -209,6 +212,7 @@ def render_dashboard_v2(
       </div>
     </div>
     <section class='card'>
+      <div>Version: <b>{html_escape(__version__)}</b> <span class='muted'>({html_escape(__release_stage__)})</span></div>
       <div>Profile: <b>{html_escape(execution_profile)}</b></div>
       <div>Safe mode: <b>{html_escape(safe_mode)}</b></div>
       <div>Trusted mode: <b>{html_escape(trusted_mode)}</b></div>
@@ -216,6 +220,7 @@ def render_dashboard_v2(
   </header>
 
   <div class='grid'>
+    {number_card('Version', __version__)}
     {number_card('Release readiness', release_state.get('readiness', 'unknown'))}
     {number_card('Release score', release_score)}
     {number_card('Queue running', queue_summary.get('running', 0))}


### PR DESCRIPTION
## Summary

Shows deployed package version information directly in Dashboard v2.

Changes:
- import package version metadata in Dashboard v2 renderer
- add `/version` link to Dashboard v2 navigation
- show version and release stage in the header card
- add a Version metric card
- update Dashboard v2 tests for version rendering and `/version` link

Validation:
- pytest -q