### PR TITLE
Document version surface for 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,17 @@ All notable changes to Velocity Claw are tracked here.
 - Added Execution profiles v2 tool-access explanations.
 - Added Run detail v2 and Artifact index v2 endpoints.
 - Added Diagnostics v2 endpoint with runtime summary, risk flags, queue state, approval state, provider state, release readiness, metrics, and troubleshooting links.
+- Added `/version` endpoint for deployed service version and runtime-mode verification.
 - Added API guide for current v2 endpoints.
 - Added deployed API smoke-check script.
 
 ### Changed
 
-- Dashboard v2 now links to Run detail v2, Artifact index v2, Approval v2, forensics, reports, classic run views, and Diagnostics v2.
-- Dashboard v2 now surfaces compact risk flags and a Diagnostics section.
-- API smoke checks now include Diagnostics v2.
+- Dashboard v2 now links to Run detail v2, Artifact index v2, Approval v2, forensics, reports, classic run views, Diagnostics v2, and `/version`.
+- Dashboard v2 now surfaces package version, release stage, compact risk flags, and a Diagnostics section.
+- API smoke checks now include Diagnostics v2 and `/version`.
 - API smoke auth check now expects `401` for protected routes without an API key when the server is configured with an API key.
-- README and deployment docs now point operators to the API guide.
+- README and deployment docs now point operators to the API guide and version verification flow.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ It is designed for self-hosted development automation where auditability and own
 
 - FastAPI server
 - Dashboard v2 and classic dashboard
+- `/version` endpoint for deployed version verification
 - operations console snapshot
 - queue foundation
 - metrics and diagnostics
@@ -87,9 +88,10 @@ Run the API:
 API_KEY="change-this-long-random-key" python cli.py --server
 ```
 
-Call a protected API endpoint:
+Call protected API endpoints:
 
 ```bash
+curl -H "X-API-Key: change-this-long-random-key" http://127.0.0.1:8000/version
 curl -H "X-API-Key: change-this-long-random-key" http://127.0.0.1:8000/status
 ```
 
@@ -158,8 +160,10 @@ Start the server with `python cli.py --server`, then use:
 | Endpoint | Purpose |
 | --- | --- |
 | `GET /health` | public service health |
+| `GET /version` | deployed version and runtime mode |
 | `GET /metrics` | runtime metrics |
 | `GET /diagnostics` | diagnostics snapshot |
+| `GET /diagnostics/v2` | diagnostics v2 runtime summary and risk flags |
 | `GET /ops/console` | operations console data |
 | `GET /dashboard` | classic dashboard HTML |
 | `GET /dashboard/v2` | Dashboard v2 HTML |
@@ -245,8 +249,9 @@ Current version:
 
 - `VERSION`
 - `velocity_claw/__version__.py`
+- `GET /version`
 
-Both files are tested for consistency.
+All version metadata is tested for consistency where applicable. Use `/version` after deployment to verify the running service.
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -110,9 +110,12 @@ For a healthy deployment, verify:
 - the API service starts successfully
 - `/health` responds through the configured API port
 - protected API routes require `X-API-Key` or Bearer authentication
-- `/dashboard/v2` loads with authentication
+- `/version` returns the expected deployed version and runtime profile
+- `/dashboard/v2` loads with authentication and shows the expected version
+- `/diagnostics/v2` returns runtime summary and risk flags with authentication
 - `/runs` returns recent runs with authentication
 - `/approvals` returns pending approvals with authentication
+- `scripts/smoke_api.py` passes against the deployed service
 - `docs/API.md` matches the deployed API surface
 - logs are being written or available through the process manager
 - the memory database path is writable by the service user

--- a/tests/test_api_docs_v2.py
+++ b/tests/test_api_docs_v2.py
@@ -4,6 +4,7 @@ from pathlib import Path
 API_DOC = Path("docs/API.md")
 README = Path("README.md")
 DEPLOYMENT = Path("docs/DEPLOYMENT.md")
+CHANGELOG = Path("CHANGELOG.md")
 
 
 def test_api_doc_lists_v2_operator_endpoints():
@@ -37,3 +38,9 @@ def test_api_doc_documents_auth_headers_and_error_behavior():
 def test_primary_docs_link_to_api_guide():
     assert "docs/API.md" in README.read_text(encoding="utf-8")
     assert "docs/API.md" in DEPLOYMENT.read_text(encoding="utf-8")
+
+
+def test_primary_docs_document_version_endpoint():
+    assert "/version" in README.read_text(encoding="utf-8")
+    assert "/version" in DEPLOYMENT.read_text(encoding="utf-8")
+    assert "/version" in CHANGELOG.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Documents the `/version` endpoint and Dashboard v2 version surface across primary operator docs.

Changes:
- add `/version` to README quick API examples and API highlights
- document deployed version verification in README version section
- add `/version` and Dashboard v2 version checks to deployment operational checks
- update 0.2.2 changelog entry to include `/version` and Dashboard version surface
- add docs coverage test for `/version` in README, DEPLOYMENT, and CHANGELOG

Validation:
- pytest -q