### PR TITLE
Add version metadata to Diagnostics v2

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -38,10 +38,24 @@ The smoke script checks public health, protected-route auth behavior, authentica
 | GET | `/status` | Agent runtime status |
 | GET | `/metrics` | Metrics counters |
 | GET | `/diagnostics` | Classic diagnostics snapshot |
-| GET | `/diagnostics/v2` | Diagnostics v2 runtime summary with risk flags |
+| GET | `/diagnostics/v2` | Diagnostics v2 runtime summary with version metadata and risk flags |
 | GET | `/ops/console` | Compact operations console snapshot |
 | GET | `/dashboard` | Classic HTML dashboard |
 | GET | `/dashboard/v2` | Dashboard v2 HTML overview |
+
+Diagnostics v2 includes:
+
+- product, version, and release stage
+- runtime environment and execution profile
+- safe/trusted/shell/git flags
+- release readiness
+- queue summary
+- pending approvals
+- provider health summary
+- last failed run
+- metrics snapshot
+- risk flags
+- troubleshooting links
 
 Example:
 

--- a/tests/test_diagnostics_v2.py
+++ b/tests/test_diagnostics_v2.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from velocity_claw.__version__ import __product_name__, __release_stage__, __version__
 from velocity_claw.api.app import install_diagnostics_v2
 from velocity_claw.api.diagnostics_v2 import build_diagnostics_v2
 
@@ -92,7 +93,7 @@ def make_app():
     return app
 
 
-def test_build_diagnostics_v2_summarizes_runtime_state_and_flags():
+def test_build_diagnostics_v2_summarizes_runtime_state_flags_and_version():
     result = build_diagnostics_v2(
         settings=RiskySettings(),
         release_state=FakeRelease().evaluate(),
@@ -107,12 +108,16 @@ def test_build_diagnostics_v2_summarizes_runtime_state_and_flags():
     )
 
     assert result["status"] == "ok"
+    assert result["version"]["product"] == __product_name__
+    assert result["version"]["version"] == __version__
+    assert result["version"]["release_stage"] == __release_stage__
     assert result["summary"]["queue_total"] == 3
     assert result["summary"]["queue_failed"] == 1
     assert result["summary"]["approvals_pending"] == 1
     assert result["summary"]["provider_failures"] == 2
     assert result["summary"]["provider_cooldowns"] == 1
     assert result["runtime"]["execution_profile"] == "safe"
+    assert result["links"]["version"] == "/version"
     codes = {flag["code"] for flag in result["risk_flags"]}
     assert "trusted_mode_enabled" in codes
     assert "shell_enabled" in codes
@@ -132,6 +137,7 @@ def test_diagnostics_v2_endpoint_returns_operational_snapshot():
     assert response.status_code == 200
     payload = response.json()
     assert payload["status"] == "ok"
+    assert payload["version"]["version"] == __version__
     assert payload["summary"]["release_readiness"] == "warning"
     assert payload["queue"]["running"] == 1
     assert payload["queue"]["failed"] == 1
@@ -139,3 +145,4 @@ def test_diagnostics_v2_endpoint_returns_operational_snapshot():
     assert payload["providers"]["summary"]["in_cooldown"] == 1
     assert payload["last_failed_run"]["run_id"] == "run-failed"
     assert payload["links"]["dashboard_v2"] == "/dashboard/v2"
+    assert payload["links"]["version"] == "/version"

--- a/velocity_claw/api/diagnostics_v2.py
+++ b/velocity_claw/api/diagnostics_v2.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from velocity_claw.__version__ import __product_name__, __release_stage__, __version__
+
 
 def _queue_summary(queue_jobs: list[dict[str, Any]], active_workers: int, max_concurrency: int) -> dict[str, Any]:
     return {
@@ -63,6 +65,11 @@ def build_diagnostics_v2(*, settings: Any, release_state: dict[str, Any], queue_
     )
     return {
         "status": "ok",
+        "version": {
+            "product": __product_name__,
+            "version": __version__,
+            "release_stage": __release_stage__,
+        },
         "summary": {
             "release_readiness": release_state.get("readiness"),
             "release_score": release_state.get("score"),
@@ -105,6 +112,7 @@ def build_diagnostics_v2(*, settings: Any, release_state: dict[str, Any], queue_
         "metrics": metrics,
         "risk_flags": flags,
         "links": {
+            "version": "/version",
             "dashboard_v2": "/dashboard/v2",
             "ops_console": "/ops/console",
             "runs": "/runs",


### PR DESCRIPTION
## Summary

Adds deployed version metadata to Diagnostics v2 so operators can verify runtime version from the diagnostics snapshot.

Changes:
- include product, version, and release stage in `/diagnostics/v2`
- add `/version` link to Diagnostics v2 links
- add version metadata to Diagnostics v2 tests
- document that `/diagnostics/v2` includes version/runtime metadata

Validation:
- pytest -q