### PR TITLE
Add Approval v2 operator index

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -134,13 +134,26 @@ curl -H "X-API-Key: $VELOCITY_CLAW_API_KEY" \
 
 | Method | Endpoint | Purpose |
 | --- | --- | --- |
-| GET | `/approvals` | List pending approvals |
+| GET | `/approvals` | Legacy pending approvals list |
+| GET | `/approvals/v2` | Approval v2 operator index with summaries and filters |
 | POST | `/approvals/explain` | Explain whether a step requires approval |
 | POST | `/approvals/{run_id}/{step_id}/approve` | Legacy approve endpoint |
 | POST | `/approvals/{run_id}/{step_id}/reject` | Legacy reject endpoint |
 | GET | `/approvals/v2/{run_id}/{step_id}` | Approval v2 detail before decision |
 | POST | `/approvals/v2/{run_id}/{step_id}/approve` | Guarded Approval v2 approve |
 | POST | `/approvals/v2/{run_id}/{step_id}/reject` | Guarded Approval v2 reject |
+
+Approval v2 index supports:
+
+- risk-priority sorting: high, medium, low, unknown
+- `risk` filter, for example `?risk=high`
+- exact `tool` filter, for example `?tool=shell.run`
+- `limit` from 1 to 100
+- counts by risk and tool
+- total, matched, returned, and decidable counts
+- normalized reason, profile, risk, triggers, and operator hints
+- approval history and artifact counts
+- links to decision, run detail, artifacts, Dashboard v2, and Diagnostics v2
 
 Approval v2 detail returns:
 
@@ -151,13 +164,16 @@ Approval v2 detail returns:
 - `can_decide`
 - approval history for that step
 - step artifacts
-- approve/reject links
+- approve/reject and run links
 
 Approval v2 blocks duplicate decisions. If a step is already approved or rejected, the v2 decision endpoints return `409`.
 
 Example:
 
 ```bash
+curl -H "X-API-Key: $VELOCITY_CLAW_API_KEY" \
+  "http://127.0.0.1:8000/approvals/v2?risk=high&limit=20"
+
 curl -H "X-API-Key: $VELOCITY_CLAW_API_KEY" \
   http://127.0.0.1:8000/approvals/v2/<run_id>/<step_id>
 
@@ -212,7 +228,7 @@ Recommended operator flow:
 
 1. Open `/version` to verify the deployed version.
 2. Open `/dashboard/v2`.
-3. Review recent runs and pending approvals.
+3. Review `/approvals/v2` for risk-prioritized pending approvals.
 4. Open `/diagnostics/v2` when troubleshooting runtime state.
 5. Open `/runs/{run_id}/detail/v2` for compact run context.
 6. Open `/runs/{run_id}/artifacts/v2` for artifact grouping and previews.

--- a/scripts/smoke_api.py
+++ b/scripts/smoke_api.py
@@ -77,6 +77,7 @@ def run_smoke_checks(base_url: str, api_key: str) -> list[CheckResult]:
         request_json(base_url, "/diagnostics/v2", api_key=api_key, expected_status=200),
         request_json(base_url, "/runs", api_key=api_key, expected_status=200),
         request_json(base_url, "/approvals", api_key=api_key, expected_status=200),
+        request_json(base_url, "/approvals/v2", api_key=api_key, expected_status=200),
         request_json(base_url, "/profiles/active", api_key=api_key, expected_status=200),
         request_json(base_url, "/profiles/explain/shell__run", api_key=api_key, expected_status=200),
         request_json(base_url, "/release/readiness", api_key=api_key, expected_status=200),

--- a/tests/test_api_docs_v2.py
+++ b/tests/test_api_docs_v2.py
@@ -16,6 +16,7 @@ def test_api_doc_lists_v2_operator_endpoints():
         "/diagnostics/v2",
         "/runs/{run_id}/detail/v2",
         "/runs/{run_id}/artifacts/v2",
+        "/approvals/v2",
         "/approvals/v2/{run_id}/{step_id}",
         "/approvals/v2/{run_id}/{step_id}/approve",
         "/approvals/v2/{run_id}/{step_id}/reject",
@@ -23,6 +24,10 @@ def test_api_doc_lists_v2_operator_endpoints():
     ]
     for endpoint in required:
         assert endpoint in content
+
+    assert "GET | `/approvals/v2`" in content
+    assert "?risk=high" in content
+    assert "?tool=shell.run" in content
 
 
 def test_api_doc_documents_auth_headers_and_error_behavior():

--- a/tests/test_approval_workflow_v2.py
+++ b/tests/test_approval_workflow_v2.py
@@ -1,46 +1,66 @@
-import asyncio
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from velocity_claw.api.app import install_approval_v2
-from velocity_claw.api.approval_v2 import build_approval_detail, evaluate_approval_decision
+from velocity_claw.api.approval_v2 import build_approval_detail, build_approval_index, evaluate_approval_decision
 
 
 RUN_ID = "run-approval"
 
 
-def make_run(step_status="pending_approval"):
+def make_run(
+    step_status="pending_approval",
+    *,
+    run_id=RUN_ID,
+    step_id=7,
+    tool="patch.apply",
+    risk_level="medium",
+    started_at="2026-05-11T00:00:00Z",
+):
+    approval_record = {
+        "reason": f"{tool} requires review",
+        "profile": "safe",
+        "risk_level": risk_level,
+        "approval_label": f"{risk_level}:{tool}",
+        "triggers": ["safe_profile_sensitive_write_or_exec"],
+        "operator_hint": f"Review {tool} before continuing.",
+        "next_step_hint": f"If approved, {tool} will execute.",
+        "recommended_action": "review_then_approve_or_reject",
+        "summary": {"tool": tool, "path": "demo.py", "command": None},
+    }
     return {
-        "run_id": RUN_ID,
-        "task": "Apply guarded patch",
+        "run_id": run_id,
+        "task": f"Guarded operation with {tool}",
         "status": "awaiting_approval",
         "steps": [
             {
-                "id": 7,
-                "title": "Apply patch",
-                "tool": "patch.apply",
+                "id": step_id,
+                "title": f"Run {tool}",
+                "tool": tool,
                 "args": {"path": "demo.py"},
                 "status": step_status,
-                "result": {"reason": "patch requires review"},
+                "result": approval_record,
                 "error": None,
+                "started_at": started_at,
+                "completed_at": started_at,
             }
         ],
         "artifacts": [
             {
-                "step_id": 7,
-                "name": "approval_step_7",
+                "step_id": step_id,
+                "name": f"approval_step_{step_id}",
                 "artifact_type": "approval",
                 "content": "{}",
             }
         ],
         "approval_history": [
             {
-                "step_id": 7,
+                "step_id": step_id,
                 "decision": "requested",
                 "actor": None,
-                "reason": "patch requires review",
-                "payload": {"reason": "patch requires review"},
-                "created_at": "2026-05-11T00:00:00Z",
+                "reason": approval_record["reason"],
+                "payload": approval_record,
+                "created_at": started_at,
             }
         ],
     }
@@ -51,7 +71,7 @@ class FakeMemory:
         self.run = run
 
     def load_run(self, run_id):
-        if run_id != RUN_ID:
+        if run_id != self.run["run_id"]:
             return None
         return self.run
 
@@ -93,6 +113,23 @@ class FakeAgent:
     def __init__(self, run):
         self.memory = FakeMemory(run)
 
+    def list_pending_approvals(self):
+        step = self.memory.run["steps"][0]
+        if step["status"] != "pending_approval":
+            return []
+        return [
+            {
+                "run_id": self.memory.run["run_id"],
+                "step_id": step["id"],
+                "title": step["title"],
+                "tool": step["tool"],
+                "args": step["args"],
+                "result": step["result"],
+                "started_at": step["started_at"],
+                "completed_at": step["completed_at"],
+            }
+        ]
+
     async def approve_step(self, run_id, step_id, actor="owner", reason=None):
         self.memory.update_step_status(run_id, step_id, "approved", result={"decision": "approved", "actor": actor, "reason": reason})
         self.memory.save_approval_decision(run_id, step_id, "approved", actor=actor, reason=reason, payload={"decision": "approved"})
@@ -103,6 +140,39 @@ class FakeAgent:
         self.memory.save_approval_decision(run_id, step_id, "rejected", actor=actor, reason=reason, payload={"decision": "rejected"})
         self.memory.update_run_status(run_id, "rejected")
         return {"decision": "rejected", "actor": actor, "reason": reason}
+
+
+class MultiMemory:
+    def __init__(self, runs):
+        self.runs = {run["run_id"]: run for run in runs}
+
+    def load_run(self, run_id):
+        return self.runs.get(run_id)
+
+
+class MultiAgent:
+    def __init__(self, runs):
+        self.memory = MultiMemory(runs)
+
+    def list_pending_approvals(self):
+        pending = []
+        for run in self.memory.runs.values():
+            for step in run["steps"]:
+                if step["status"] != "pending_approval":
+                    continue
+                pending.append(
+                    {
+                        "run_id": run["run_id"],
+                        "step_id": step["id"],
+                        "title": step["title"],
+                        "tool": step["tool"],
+                        "args": step["args"],
+                        "result": step["result"],
+                        "started_at": step["started_at"],
+                        "completed_at": step["completed_at"],
+                    }
+                )
+        return pending
 
 
 def make_client(run):
@@ -117,10 +187,12 @@ def test_build_approval_detail_exposes_step_history_artifacts_and_links():
 
     assert detail["status"] == "ok"
     assert detail["can_decide"] is True
-    assert detail["step"]["title"] == "Apply patch"
+    assert detail["step"]["title"] == "Run patch.apply"
     assert len(detail["history"]) == 1
     assert len(detail["artifacts"]) == 1
     assert detail["links"]["approve"].endswith("/approvals/v2/run-approval/7/approve")
+    assert detail["links"]["run_detail_v2"] == "/runs/run-approval/detail/v2"
+    assert detail["links"]["run_artifacts_v2"] == "/runs/run-approval/artifacts/v2"
 
 
 def test_evaluate_approval_decision_blocks_non_pending_steps():
@@ -129,6 +201,63 @@ def test_evaluate_approval_decision_blocks_non_pending_steps():
     assert guard.allowed is False
     assert guard.reason == "already_approved"
     assert guard.current_status == "approved"
+
+
+def test_build_approval_index_summarizes_and_sorts_high_risk_first():
+    agent = MultiAgent(
+        [
+            make_run(run_id="run-low", step_id=1, tool="test.run", risk_level="low", started_at="2026-05-11T00:00:00Z"),
+            make_run(run_id="run-high", step_id=2, tool="shell.run", risk_level="high", started_at="2026-05-12T00:00:00Z"),
+            make_run(run_id="run-medium", step_id=3, tool="patch.apply", risk_level="medium", started_at="2026-05-10T00:00:00Z"),
+        ]
+    )
+
+    index = build_approval_index(agent)
+
+    assert index["status"] == "ok"
+    assert index["summary"]["total_pending"] == 3
+    assert index["summary"]["decidable"] == 3
+    assert index["summary"]["counts_by_risk"] == {"high": 1, "medium": 1, "low": 1}
+    assert index["summary"]["counts_by_tool"]["shell.run"] == 1
+    assert [item["risk_level"] for item in index["items"]] == ["high", "medium", "low"]
+    assert index["items"][0]["run_id"] == "run-high"
+    assert index["items"][0]["history_count"] == 1
+    assert index["items"][0]["artifact_count"] == 1
+    assert index["items"][0]["links"]["approve"].endswith("/run-high/2/approve")
+
+
+def test_build_approval_index_filters_by_risk_tool_and_clamps_limit():
+    agent = MultiAgent(
+        [
+            make_run(run_id="run-shell", step_id=1, tool="shell.run", risk_level="high"),
+            make_run(run_id="run-git", step_id=2, tool="git.run", risk_level="high"),
+            make_run(run_id="run-patch", step_id=3, tool="patch.apply", risk_level="medium"),
+        ]
+    )
+
+    filtered = build_approval_index(agent, risk="HIGH", tool="shell.run", limit=500)
+
+    assert filtered["summary"]["total_pending"] == 3
+    assert filtered["summary"]["matched"] == 1
+    assert filtered["summary"]["returned"] == 1
+    assert filtered["filters"] == {"risk": "high", "tool": "shell.run", "limit": 100}
+    assert filtered["items"][0]["run_id"] == "run-shell"
+
+
+def test_approval_index_v2_endpoint_returns_filtered_operator_summary():
+    client = make_client(make_run(risk_level="medium", tool="patch.apply"))
+
+    response = client.get("/approvals/v2?risk=medium&tool=patch.apply&limit=1")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["summary"]["total_pending"] == 1
+    assert payload["summary"]["matched"] == 1
+    assert payload["items"][0]["risk_level"] == "medium"
+    assert payload["items"][0]["tool"] == "patch.apply"
+    assert payload["items"][0]["history_count"] == 1
+    assert payload["items"][0]["artifact_count"] == 1
 
 
 def test_approval_detail_v2_endpoint_returns_context():

--- a/tests/test_smoke_api_script.py
+++ b/tests/test_smoke_api_script.py
@@ -47,4 +47,5 @@ def test_smoke_api_checks_expected_auth_and_operator_endpoints(monkeypatch):
     assert ("json", "/version", "secret", 200) in calls
     assert ("json", "/status", "secret", 200) in calls
     assert ("json", "/diagnostics/v2", "secret", 200) in calls
+    assert ("json", "/approvals/v2", "secret", 200) in calls
     assert ("html", "/dashboard/v2", "secret", 200) in calls

--- a/velocity_claw/api/app.py
+++ b/velocity_claw/api/app.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
 
-from velocity_claw.api.approval_v2 import approve_with_guard, build_approval_detail, reject_with_guard
+from velocity_claw.api.approval_v2 import (
+    approve_with_guard,
+    build_approval_detail,
+    build_approval_index,
+    reject_with_guard,
+)
 from velocity_claw.api.auth import install_api_key_auth
 from velocity_claw.api.dashboard_v2 import render_dashboard_v2
 from velocity_claw.api.diagnostics_v2 import build_diagnostics_v2
@@ -21,6 +26,15 @@ def install_version_endpoint(app: FastAPI) -> None:
 
 
 def install_approval_v2(app: FastAPI) -> None:
+    @app.get("/approvals/v2")
+    def approval_index_v2(limit: int = 50, risk: str | None = None, tool: str | None = None):
+        return build_approval_index(
+            app.state.agent,
+            limit=limit,
+            risk=risk,
+            tool=tool,
+        )
+
     @app.get("/approvals/v2/{run_id}/{step_id}")
     def approval_detail_v2(run_id: str, step_id: int):
         detail = build_approval_detail(app.state.agent.memory.load_run(run_id), step_id)

--- a/velocity_claw/api/approval_v2.py
+++ b/velocity_claw/api/approval_v2.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass
 from typing import Any
 
 
 TERMINAL_APPROVAL_STATUSES = {"approved", "rejected"}
 PENDING_APPROVAL_STATUS = "pending_approval"
+RISK_PRIORITY = {"high": 0, "medium": 1, "low": 2, "unknown": 3}
 
 
 @dataclass(frozen=True)
@@ -28,6 +30,20 @@ def _step_artifacts(run: dict[str, Any], step_id: int) -> list[dict[str, Any]]:
 
 def _step_history(run: dict[str, Any], step_id: int) -> list[dict[str, Any]]:
     return [event for event in run.get("approval_history", []) if event.get("step_id") == step_id]
+
+
+def _approval_record(pending: dict[str, Any], detail: dict[str, Any]) -> dict[str, Any]:
+    pending_result = pending.get("result")
+    if isinstance(pending_result, dict):
+        return pending_result
+    step = detail.get("step") or {}
+    step_result = step.get("result")
+    return step_result if isinstance(step_result, dict) else {}
+
+
+def _normalize_risk(value: Any) -> str:
+    normalized = str(value or "unknown").lower()
+    return normalized if normalized in RISK_PRIORITY else "unknown"
 
 
 def evaluate_approval_decision(run: dict[str, Any] | None, step_id: int) -> ApprovalDecisionGuard:
@@ -72,7 +88,108 @@ def build_approval_detail(run: dict[str, Any] | None, step_id: int) -> dict[str,
             "approve": f"/approvals/v2/{run.get('run_id')}/{step_id}/approve",
             "reject": f"/approvals/v2/{run.get('run_id')}/{step_id}/reject",
             "run": f"/runs/{run.get('run_id')}",
+            "run_detail_v2": f"/runs/{run.get('run_id')}/detail/v2",
+            "run_artifacts_v2": f"/runs/{run.get('run_id')}/artifacts/v2",
             "run_view": f"/runs/{run.get('run_id')}/view",
+        },
+    }
+
+
+def build_approval_index(
+    agent: Any,
+    *,
+    limit: int = 50,
+    risk: str | None = None,
+    tool: str | None = None,
+) -> dict[str, Any]:
+    pending = agent.list_pending_approvals()
+    normalized_items: list[dict[str, Any]] = []
+
+    for item in pending:
+        run_id = item.get("run_id")
+        step_id = item.get("step_id")
+        run = agent.memory.load_run(run_id) if run_id else None
+        detail = build_approval_detail(run, step_id) if isinstance(step_id, int) else {
+            "status": "not_found",
+            "can_decide": False,
+            "history": [],
+            "artifacts": [],
+            "links": {},
+        }
+        record = _approval_record(item, detail)
+        risk_level = _normalize_risk(record.get("risk_level"))
+        reason = record.get("reason") or item.get("reason") or "Approval required."
+        profile = record.get("profile")
+        normalized_items.append(
+            {
+                "run_id": run_id,
+                "run_status": detail.get("run_status"),
+                "task": detail.get("task"),
+                "step_id": step_id,
+                "title": item.get("title") or (detail.get("step") or {}).get("title"),
+                "tool": item.get("tool") or (detail.get("step") or {}).get("tool"),
+                "args": item.get("args") or (detail.get("step") or {}).get("args") or {},
+                "current_status": detail.get("current_status") or PENDING_APPROVAL_STATUS,
+                "can_decide": detail.get("can_decide", False),
+                "profile": profile,
+                "risk_level": risk_level,
+                "approval_label": record.get("approval_label"),
+                "reason": reason,
+                "triggers": record.get("triggers") or [],
+                "operator_hint": record.get("operator_hint"),
+                "next_step_hint": record.get("next_step_hint"),
+                "recommended_action": record.get("recommended_action"),
+                "summary": record.get("summary") or {},
+                "history_count": len(detail.get("history") or []),
+                "artifact_count": len(detail.get("artifacts") or []),
+                "started_at": item.get("started_at"),
+                "completed_at": item.get("completed_at"),
+                "links": detail.get("links") or {},
+            }
+        )
+
+    normalized_items.sort(
+        key=lambda item: (
+            RISK_PRIORITY.get(item.get("risk_level", "unknown"), RISK_PRIORITY["unknown"]),
+            item.get("started_at") is None,
+            item.get("started_at") or "",
+            str(item.get("run_id") or ""),
+            int(item.get("step_id") or 0),
+        )
+    )
+
+    risk_filter = _normalize_risk(risk) if risk else None
+    tool_filter = tool.strip() if tool else None
+    matched = [
+        item
+        for item in normalized_items
+        if (risk_filter is None or item.get("risk_level") == risk_filter)
+        and (tool_filter is None or item.get("tool") == tool_filter)
+    ]
+    safe_limit = max(1, min(int(limit), 100))
+    risk_counts = Counter(item.get("risk_level") or "unknown" for item in normalized_items)
+    tool_counts = Counter(item.get("tool") or "unknown" for item in normalized_items)
+
+    return {
+        "status": "ok",
+        "summary": {
+            "total_pending": len(normalized_items),
+            "matched": len(matched),
+            "returned": min(len(matched), safe_limit),
+            "counts_by_risk": dict(risk_counts),
+            "counts_by_tool": dict(tool_counts),
+            "decidable": sum(1 for item in normalized_items if item.get("can_decide")),
+        },
+        "filters": {
+            "risk": risk_filter,
+            "tool": tool_filter,
+            "limit": safe_limit,
+        },
+        "items": matched[:safe_limit],
+        "links": {
+            "legacy": "/approvals",
+            "dashboard_v2": "/dashboard/v2",
+            "diagnostics_v2": "/diagnostics/v2",
         },
     }
 


### PR DESCRIPTION
## Summary

Adds a structured Approval v2 operator index for pending approval review.

Changes:
- add `GET /approvals/v2`
- normalize pending approvals with reason, profile, risk, triggers, hints, history count, artifact count, and related links
- sort approvals by risk priority: high, medium, low, unknown
- add `risk`, exact `tool`, and bounded `limit` filters
- add total/matched/returned/decidable summaries and counts by risk/tool
- enrich approval detail links with Run detail v2 and Artifact index v2
- include `/approvals/v2` in deployment smoke checks
- document the operator index and filters
- add unit, endpoint, smoke, and docs coverage tests

Related: #19, #13

Validation:
- pytest -q