### PR TITLE
Add Approval continuation flow v3

### DIFF
--- a/docs/APPROVALS.md
+++ b/docs/APPROVALS.md
@@ -1,0 +1,82 @@
+# Approval workflow
+
+Velocity Claw pauses sensitive execution steps and requires an explicit operator decision before continuing.
+
+## Operator endpoints
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| GET | `/approvals/v2` | Risk-prioritized pending approval index |
+| GET | `/approvals/v2/{run_id}/{step_id}` | Approval detail, history, artifacts, and continuation state |
+| POST | `/approvals/v2/{run_id}/{step_id}/approve` | Approve and continue from the exact plan boundary |
+| POST | `/approvals/v2/{run_id}/{step_id}/reject` | Reject and terminate continuation |
+
+All endpoints except `/health` require API-key authentication in the production app.
+
+## Approval continuation v3
+
+Approval continuation v3 applies to the guarded Approval v2 decision endpoints.
+
+When a pending step is approved, Velocity Claw:
+
+1. stores the approval decision with actor, reason, and timestamp;
+2. marks the run as `resuming_after_approval`;
+3. loads the stored `run_plan` artifact;
+4. locates the exact approved step boundary;
+5. rechecks execution-profile and security policy;
+6. executes the approved step without inserting a duplicate step row;
+7. persists execution artifacts;
+8. continues until completion, failure, or the next approval boundary;
+9. writes an `approval_continuation` artifact describing the result.
+
+## Continuation outcomes
+
+| Status | Meaning |
+| --- | --- |
+| `completed` | All remaining steps completed successfully |
+| `failed` | Execution or policy validation failed |
+| `awaiting_approval` | A later sensitive step created a new approval boundary |
+| `manual_resume_required` | The stored plan or requested step boundary could not be recovered |
+
+Manual-resume reasons include:
+
+- `run_plan_missing`
+- `run_plan_invalid`
+- `step_boundary_missing`
+
+Failure reasons include:
+
+- `policy_validation_failed`
+- `step_execution_failed`
+
+## Rejection behavior
+
+A rejection:
+
+- records the actor and reason;
+- marks the step and run as `rejected`;
+- stores an `approval_rejection` artifact;
+- sets `continuation_allowed` to `false`;
+- blocks later approve/reject attempts with `409`.
+
+## Artifacts
+
+Approval workflows can create these artifact types:
+
+| Artifact type | Purpose |
+| --- | --- |
+| `approval` | Request and decision payloads |
+| `approval_boundary` | Initial or continuation pause boundary |
+| `approval_continuation` | Completed, failed, awaiting, or manual-resume outcome |
+| `approval_rejection` | Terminal rejection boundary |
+
+`GET /approvals/v2/{run_id}/{step_id}` exposes decoded continuation and rejection artifacts through:
+
+- `continuation`
+- `latest_continuation`
+- `artifacts`
+- `history`
+
+## Duplicate decision protection
+
+Approval decisions are idempotency-guarded at the workflow level. After a step has been approved or rejected, a second decision request is blocked even when the approved step has already executed and its runtime status has changed to `success` or `failed`.

--- a/tests/test_approval_continuation_v3.py
+++ b/tests/test_approval_continuation_v3.py
@@ -1,0 +1,131 @@
+import json
+
+import pytest
+
+from velocity_claw.core.approval_continuation import continue_after_approval
+
+
+class Memory:
+    def __init__(self):
+        self.run = {
+            "run_id": "run-policy",
+            "task": "Run blocked shell step",
+            "status": "resuming_after_approval",
+            "steps": [
+                {
+                    "id": 1,
+                    "title": "Run shell",
+                    "tool": "shell.run",
+                    "args": {"command": "rm -rf /"},
+                    "status": "approved",
+                    "result": {"decision": "approved"},
+                    "error": None,
+                }
+            ],
+            "artifacts": [
+                {
+                    "step_id": None,
+                    "name": "run_plan",
+                    "artifact_type": "plan",
+                    "content": json.dumps(
+                        {
+                            "steps": [
+                                {
+                                    "id": 1,
+                                    "title": "Run shell",
+                                    "tool": "shell.run",
+                                    "args": {"command": "rm -rf /"},
+                                }
+                            ]
+                        }
+                    ),
+                }
+            ],
+            "approval_history": [{"step_id": 1, "decision": "approved"}],
+        }
+        self.notes = []
+
+    def load_run(self, run_id):
+        return self.run if run_id == self.run["run_id"] else None
+
+    def update_step_status(self, run_id, step_id, status, result=None, error=None):
+        step = self.run["steps"][0]
+        step["status"] = status
+        step["result"] = result
+        step["error"] = error
+
+    def save_step(self, run_id, step):
+        self.run["steps"].append(step)
+
+    def save_artifact(self, run_id, name, content, step_id=None, artifact_type="text"):
+        self.run["artifacts"].append(
+            {
+                "step_id": step_id,
+                "name": name,
+                "artifact_type": artifact_type,
+                "content": content,
+            }
+        )
+
+    def save_project_note(self, note_type, content):
+        self.notes.append((note_type, content))
+
+    def update_run_status(self, run_id, status):
+        self.run["status"] = status
+
+
+class ProfileManager:
+    def is_tool_allowed(self, tool, profile_name):
+        return False
+
+
+class Approvals:
+    def requires_approval(self, step, profile_name):
+        return False
+
+
+class Executor:
+    def __init__(self):
+        self.called = False
+
+    async def execute_step(self, step, context):
+        self.called = True
+        return {"id": step["id"], "status": "success", "result": {"ok": True}, "error": None}
+
+
+class Settings:
+    execution_profile = "safe"
+
+
+class Agent:
+    def __init__(self):
+        self.memory = Memory()
+        self.profile_manager = ProfileManager()
+        self.approvals = Approvals()
+        self.executor = Executor()
+        self.settings = Settings()
+
+    def _persist_artifacts(self, run_id, result):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_continuation_rechecks_profile_policy_before_executor():
+    agent = Agent()
+
+    result = await continue_after_approval(agent, "run-policy", 1)
+
+    assert result["status"] == "failed"
+    assert result["reason"] == "policy_validation_failed"
+    assert result["failed_step_id"] == 1
+    assert agent.executor.called is False
+    assert agent.memory.run["status"] == "failed"
+    assert agent.memory.run["steps"][0]["status"] == "failed"
+    assert "not allowed in profile safe" in agent.memory.run["steps"][0]["error"]
+    continuation = [
+        artifact
+        for artifact in agent.memory.run["artifacts"]
+        if artifact["artifact_type"] == "approval_continuation"
+    ]
+    assert len(continuation) == 1
+    assert json.loads(continuation[0]["content"])["reason"] == "policy_validation_failed"

--- a/tests/test_approval_continuation_v3.py
+++ b/tests/test_approval_continuation_v3.py
@@ -1,6 +1,5 @@
+import asyncio
 import json
-
-import pytest
 
 from velocity_claw.core.approval_continuation import continue_after_approval
 
@@ -16,7 +15,7 @@ class Memory:
                     "id": 1,
                     "title": "Run shell",
                     "tool": "shell.run",
-                    "args": {"command": "rm -rf /"},
+                    "args": {"command": "echo blocked"},
                     "status": "approved",
                     "result": {"decision": "approved"},
                     "error": None,
@@ -34,7 +33,7 @@ class Memory:
                                     "id": 1,
                                     "title": "Run shell",
                                     "tool": "shell.run",
-                                    "args": {"command": "rm -rf /"},
+                                    "args": {"command": "echo blocked"},
                                 }
                             ]
                         }
@@ -109,11 +108,10 @@ class Agent:
         pass
 
 
-@pytest.mark.asyncio
-async def test_continuation_rechecks_profile_policy_before_executor():
+def test_continuation_rechecks_profile_policy_before_executor():
     agent = Agent()
 
-    result = await continue_after_approval(agent, "run-policy", 1)
+    result = asyncio.run(continue_after_approval(agent, "run-policy", 1))
 
     assert result["status"] == "failed"
     assert result["reason"] == "policy_validation_failed"

--- a/tests/test_approval_docs.py
+++ b/tests/test_approval_docs.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+APPROVAL_DOC = Path("docs/APPROVALS.md")
+
+
+def test_approval_docs_cover_v3_outcomes_and_artifacts():
+    content = APPROVAL_DOC.read_text(encoding="utf-8")
+
+    required = [
+        "Approval continuation v3",
+        "completed",
+        "failed",
+        "awaiting_approval",
+        "manual_resume_required",
+        "policy_validation_failed",
+        "step_execution_failed",
+        "approval_continuation",
+        "approval_rejection",
+        "continuation_allowed",
+        "/approvals/v2/{run_id}/{step_id}/approve",
+        "/approvals/v2/{run_id}/{step_id}/reject",
+    ]
+    for value in required:
+        assert value in content

--- a/tests/test_approval_workflow_v2.py
+++ b/tests/test_approval_workflow_v2.py
@@ -1,3 +1,5 @@
+import json
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -8,15 +10,7 @@ from velocity_claw.api.approval_v2 import build_approval_detail, build_approval_
 RUN_ID = "run-approval"
 
 
-def make_run(
-    step_status="pending_approval",
-    *,
-    run_id=RUN_ID,
-    step_id=7,
-    tool="patch.apply",
-    risk_level="medium",
-    started_at="2026-05-11T00:00:00Z",
-):
+def make_step(step_id, tool, *, status="pending_approval", risk_level="medium", started_at="2026-05-11T00:00:00Z"):
     approval_record = {
         "reason": f"{tool} requires review",
         "profile": "safe",
@@ -29,30 +23,77 @@ def make_run(
         "summary": {"tool": tool, "path": "demo.py", "command": None},
     }
     return {
+        "id": step_id,
+        "title": f"Run {tool}",
+        "tool": tool,
+        "args": {"path": "demo.py"},
+        "status": status,
+        "result": approval_record if status == "pending_approval" else None,
+        "error": None,
+        "started_at": started_at,
+        "completed_at": started_at,
+    }
+
+
+def plan_step(step):
+    return {
+        "id": step["id"],
+        "title": step["title"],
+        "tool": step["tool"],
+        "args": step["args"],
+    }
+
+
+def make_run(
+    step_status="pending_approval",
+    *,
+    run_id=RUN_ID,
+    step_id=7,
+    tool="patch.apply",
+    risk_level="medium",
+    started_at="2026-05-11T00:00:00Z",
+    continuation_steps=None,
+    include_plan=True,
+):
+    source = make_step(step_id, tool, status=step_status, risk_level=risk_level, started_at=started_at)
+    approval_record = {
+        "reason": f"{tool} requires review",
+        "profile": "safe",
+        "risk_level": risk_level,
+        "approval_label": f"{risk_level}:{tool}",
+        "triggers": ["safe_profile_sensitive_write_or_exec"],
+        "operator_hint": f"Review {tool} before continuing.",
+        "next_step_hint": f"If approved, {tool} will execute.",
+        "recommended_action": "review_then_approve_or_reject",
+        "summary": {"tool": tool, "path": "demo.py", "command": None},
+    }
+    source["result"] = approval_record if step_status == "pending_approval" else None
+    planned_steps = continuation_steps or [plan_step(source)]
+    artifacts = [
+        {
+            "step_id": step_id,
+            "name": f"approval_step_{step_id}",
+            "artifact_type": "approval",
+            "content": json.dumps(approval_record),
+            "created_at": started_at,
+        }
+    ]
+    if include_plan:
+        artifacts.append(
+            {
+                "step_id": None,
+                "name": "run_plan",
+                "artifact_type": "plan",
+                "content": json.dumps({"steps": planned_steps}),
+                "created_at": started_at,
+            }
+        )
+    return {
         "run_id": run_id,
         "task": f"Guarded operation with {tool}",
         "status": "awaiting_approval",
-        "steps": [
-            {
-                "id": step_id,
-                "title": f"Run {tool}",
-                "tool": tool,
-                "args": {"path": "demo.py"},
-                "status": step_status,
-                "result": approval_record,
-                "error": None,
-                "started_at": started_at,
-                "completed_at": started_at,
-            }
-        ],
-        "artifacts": [
-            {
-                "step_id": step_id,
-                "name": f"approval_step_{step_id}",
-                "artifact_type": "approval",
-                "content": "{}",
-            }
-        ],
+        "steps": [source],
+        "artifacts": artifacts,
         "approval_history": [
             {
                 "step_id": step_id,
@@ -69,6 +110,8 @@ def make_run(
 class FakeMemory:
     def __init__(self, run):
         self.run = run
+        self.saved_steps = []
+        self.notes = []
 
     def load_run(self, run_id):
         if run_id != self.run["run_id"]:
@@ -76,9 +119,16 @@ class FakeMemory:
         return self.run
 
     def update_step_status(self, run_id, step_id, status, result=None, error=None):
-        self.run["steps"][0]["status"] = status
-        self.run["steps"][0]["result"] = result
-        self.run["steps"][0]["error"] = error
+        for step in self.run["steps"]:
+            if step["id"] == step_id:
+                step["status"] = status
+                step["result"] = result
+                step["error"] = error
+
+    def save_step(self, run_id, step):
+        saved = dict(step)
+        self.saved_steps.append(saved)
+        self.run["steps"].append(saved)
 
     def save_approval_decision(self, run_id, step_id, decision, actor=None, reason=None, payload=None):
         self.run["approval_history"].append(
@@ -99,47 +149,97 @@ class FakeMemory:
                 "name": name,
                 "artifact_type": artifact_type,
                 "content": content,
+                "created_at": "now",
             }
         )
 
     def save_project_note(self, note_type, content):
-        pass
+        self.notes.append({"note_type": note_type, "content": content})
 
     def update_run_status(self, run_id, status):
         self.run["status"] = status
 
 
+class FakeSettings:
+    execution_profile = "safe"
+
+
+class FakeApprovals:
+    def __init__(self, risky_step_ids=None):
+        self.risky_step_ids = set(risky_step_ids or [])
+
+    def requires_approval(self, step, profile_name):
+        return step.get("id") in self.risky_step_ids
+
+    def build_record(self, step, profile_name):
+        return {
+            "reason": f"{step.get('tool')} requires review",
+            "profile": profile_name,
+            "risk_level": "high",
+            "approval_label": f"high:{step.get('tool')}",
+            "triggers": ["continuation_sensitive_step"],
+            "operator_hint": "Review continuation step.",
+            "next_step_hint": "Approve or reject the continuation boundary.",
+            "recommended_action": "review_then_approve_or_reject",
+            "summary": {"tool": step.get("tool")},
+        }
+
+
+class FakeExecutor:
+    def __init__(self, results=None):
+        self.results = results or {}
+        self.calls = []
+
+    async def execute_step(self, step, context):
+        self.calls.append(step["id"])
+        override = self.results.get(step["id"], {})
+        return {
+            "id": step["id"],
+            "title": step["title"],
+            "tool": step.get("tool"),
+            "args": step.get("args", {}),
+            "status": override.get("status", "success"),
+            "result": override.get("result", {"ok": True}),
+            "error": override.get("error"),
+        }
+
+
 class FakeAgent:
-    def __init__(self, run):
+    def __init__(self, run, *, risky_step_ids=None, executor_results=None):
         self.memory = FakeMemory(run)
+        self.settings = FakeSettings()
+        self.approvals = FakeApprovals(risky_step_ids)
+        self.executor = FakeExecutor(executor_results)
 
     def list_pending_approvals(self):
-        step = self.memory.run["steps"][0]
-        if step["status"] != "pending_approval":
-            return []
-        return [
-            {
-                "run_id": self.memory.run["run_id"],
-                "step_id": step["id"],
-                "title": step["title"],
-                "tool": step["tool"],
-                "args": step["args"],
-                "result": step["result"],
-                "started_at": step["started_at"],
-                "completed_at": step["completed_at"],
-            }
-        ]
+        pending = []
+        for step in self.memory.run["steps"]:
+            if step["status"] != "pending_approval":
+                continue
+            pending.append(
+                {
+                    "run_id": self.memory.run["run_id"],
+                    "step_id": step["id"],
+                    "title": step["title"],
+                    "tool": step["tool"],
+                    "args": step["args"],
+                    "result": step["result"],
+                    "started_at": step.get("started_at"),
+                    "completed_at": step.get("completed_at"),
+                }
+            )
+        return pending
 
-    async def approve_step(self, run_id, step_id, actor="owner", reason=None):
-        self.memory.update_step_status(run_id, step_id, "approved", result={"decision": "approved", "actor": actor, "reason": reason})
-        self.memory.save_approval_decision(run_id, step_id, "approved", actor=actor, reason=reason, payload={"decision": "approved"})
-        return {"decision": "approved", "actor": actor, "reason": reason, "resume": {"status": "completed"}}
-
-    def reject_step(self, run_id, step_id, actor="owner", reason=None):
-        self.memory.update_step_status(run_id, step_id, "rejected", result={"decision": "rejected", "actor": actor, "reason": reason}, error="Rejected by reviewer")
-        self.memory.save_approval_decision(run_id, step_id, "rejected", actor=actor, reason=reason, payload={"decision": "rejected"})
-        self.memory.update_run_status(run_id, "rejected")
-        return {"decision": "rejected", "actor": actor, "reason": reason}
+    def _persist_artifacts(self, run_id, result):
+        payload = result.get("result") or {}
+        if isinstance(payload, dict) and payload.get("stdout"):
+            self.memory.save_artifact(
+                run_id,
+                f"step_{result['id']}_stdout",
+                payload["stdout"],
+                step_id=result["id"],
+                artifact_type="log",
+            )
 
 
 class MultiMemory:
@@ -175,11 +275,11 @@ class MultiAgent:
         return pending
 
 
-def make_client(run):
+def make_client(run, *, risky_step_ids=None, executor_results=None):
     app = FastAPI()
-    app.state.agent = FakeAgent(run)
+    app.state.agent = FakeAgent(run, risky_step_ids=risky_step_ids, executor_results=executor_results)
     install_approval_v2(app)
-    return TestClient(app)
+    return TestClient(app), app.state.agent
 
 
 def test_build_approval_detail_exposes_step_history_artifacts_and_links():
@@ -190,6 +290,7 @@ def test_build_approval_detail_exposes_step_history_artifacts_and_links():
     assert detail["step"]["title"] == "Run patch.apply"
     assert len(detail["history"]) == 1
     assert len(detail["artifacts"]) == 1
+    assert detail["continuation"] == []
     assert detail["links"]["approve"].endswith("/approvals/v2/run-approval/7/approve")
     assert detail["links"]["run_detail_v2"] == "/runs/run-approval/detail/v2"
     assert detail["links"]["run_artifacts_v2"] == "/runs/run-approval/artifacts/v2"
@@ -201,6 +302,17 @@ def test_evaluate_approval_decision_blocks_non_pending_steps():
     assert guard.allowed is False
     assert guard.reason == "already_approved"
     assert guard.current_status == "approved"
+
+
+def test_evaluate_approval_decision_uses_history_after_successful_continuation():
+    run = make_run(step_status="success")
+    run["approval_history"].append({"step_id": 7, "decision": "approved"})
+
+    guard = evaluate_approval_decision(run, 7)
+
+    assert guard.allowed is False
+    assert guard.reason == "already_approved"
+    assert guard.current_status == "success"
 
 
 def test_build_approval_index_summarizes_and_sorts_high_risk_first():
@@ -245,7 +357,7 @@ def test_build_approval_index_filters_by_risk_tool_and_clamps_limit():
 
 
 def test_approval_index_v2_endpoint_returns_filtered_operator_summary():
-    client = make_client(make_run(risk_level="medium", tool="patch.apply"))
+    client, _ = make_client(make_run(risk_level="medium", tool="patch.apply"))
 
     response = client.get("/approvals/v2?risk=medium&tool=patch.apply&limit=1")
 
@@ -261,7 +373,7 @@ def test_approval_index_v2_endpoint_returns_filtered_operator_summary():
 
 
 def test_approval_detail_v2_endpoint_returns_context():
-    client = make_client(make_run())
+    client, _ = make_client(make_run())
 
     response = client.get(f"/approvals/v2/{RUN_ID}/7")
 
@@ -272,24 +384,28 @@ def test_approval_detail_v2_endpoint_returns_context():
     assert payload["approval"]["history"][0]["decision"] == "requested"
 
 
-def test_approval_v2_reject_changes_status_and_blocks_second_decision():
+def test_approval_v2_reject_records_terminal_boundary_and_blocks_second_decision():
     run = make_run()
-    client = make_client(run)
+    client, _ = make_client(run)
 
     first = client.post(f"/approvals/v2/{RUN_ID}/7/reject", json={"actor": "owner", "reason": "not safe"})
     assert first.status_code == 200
-    assert first.json()["status"] == "ok"
+    payload = first.json()
+    assert payload["status"] == "ok"
+    assert payload["decision"]["boundary"]["continuation_allowed"] is False
     assert run["steps"][0]["status"] == "rejected"
     assert run["status"] == "rejected"
+    assert any(item["artifact_type"] == "approval_rejection" for item in run["artifacts"])
+    assert payload["approval"]["latest_continuation"]["artifact_type"] == "approval_rejection"
 
     second = client.post(f"/approvals/v2/{RUN_ID}/7/approve", json={"actor": "owner", "reason": "changed mind"})
     assert second.status_code == 409
     assert second.json()["detail"]["error"] == "already_rejected"
 
 
-def test_approval_v2_approve_returns_resume_payload():
+def test_approval_v2_approve_completes_without_duplicate_source_step():
     run = make_run()
-    client = make_client(run)
+    client, agent = make_client(run)
 
     response = client.post(f"/approvals/v2/{RUN_ID}/7/approve", json={"actor": "owner", "reason": "approved"})
 
@@ -298,4 +414,70 @@ def test_approval_v2_approve_returns_resume_payload():
     assert payload["status"] == "ok"
     assert payload["decision"]["decision"] == "approved"
     assert payload["decision"]["resume"]["status"] == "completed"
-    assert run["steps"][0]["status"] == "approved"
+    assert payload["decision"]["resume"]["executed_step_ids"] == [7]
+    assert run["status"] == "completed"
+    assert run["steps"][0]["status"] == "success"
+    assert len(run["steps"]) == 1
+    assert agent.memory.saved_steps == []
+    assert payload["approval"]["reason"] == "already_approved"
+    assert payload["approval"]["latest_continuation"]["payload"]["status"] == "completed"
+
+    second = client.post(f"/approvals/v2/{RUN_ID}/7/approve", json={"actor": "owner", "reason": "duplicate"})
+    assert second.status_code == 409
+    assert second.json()["detail"]["error"] == "already_approved"
+
+
+def test_approval_v2_approve_requires_manual_resume_when_plan_missing():
+    run = make_run(include_plan=False)
+    client, _ = make_client(run)
+
+    response = client.post(f"/approvals/v2/{RUN_ID}/7/approve", json={"actor": "owner", "reason": "approved"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["decision"]["resume"]["status"] == "manual_resume_required"
+    assert payload["decision"]["resume"]["reason"] == "run_plan_missing"
+    assert run["status"] == "approved_waiting_manual_resume"
+    assert payload["approval"]["latest_continuation"]["payload"]["reason"] == "run_plan_missing"
+
+
+def test_approval_v2_continuation_pauses_at_next_sensitive_step():
+    source = make_step(7, "patch.apply")
+    next_step = make_step(8, "shell.run", status="planned", risk_level="high")
+    run = make_run(continuation_steps=[plan_step(source), plan_step(next_step)])
+    client, agent = make_client(run, risky_step_ids={8})
+
+    response = client.post(f"/approvals/v2/{RUN_ID}/7/approve", json={"actor": "owner", "reason": "approved"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    resume = payload["decision"]["resume"]
+    assert resume["status"] == "awaiting_approval"
+    assert resume["boundary_step_id"] == 8
+    assert resume["executed_step_ids"] == [7]
+    assert run["status"] == "awaiting_approval"
+    assert [step["id"] for step in run["steps"]] == [7, 8]
+    assert run["steps"][0]["status"] == "success"
+    assert run["steps"][1]["status"] == "pending_approval"
+    assert [step["id"] for step in agent.memory.saved_steps] == [8]
+    assert any(item["artifact_type"] == "approval_boundary" and item["step_id"] == 8 for item in run["artifacts"])
+
+
+def test_approval_v2_continuation_records_failed_boundary():
+    run = make_run()
+    client, _ = make_client(
+        run,
+        executor_results={7: {"status": "failed", "result": None, "error": "execution failed"}},
+    )
+
+    response = client.post(f"/approvals/v2/{RUN_ID}/7/approve", json={"actor": "owner", "reason": "approved"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    resume = payload["decision"]["resume"]
+    assert resume["status"] == "failed"
+    assert resume["reason"] == "step_execution_failed"
+    assert resume["failed_step_id"] == 7
+    assert run["status"] == "failed"
+    assert run["steps"][0]["status"] == "failed"
+    assert payload["approval"]["latest_continuation"]["payload"]["status"] == "failed"

--- a/velocity_claw/api/approval_v2.py
+++ b/velocity_claw/api/approval_v2.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import json
 from collections import Counter
 from dataclasses import dataclass
 from typing import Any
+
+from velocity_claw.core.approval_continuation import approve_and_continue, reject_with_boundary
 
 
 TERMINAL_APPROVAL_STATUSES = {"approved", "rejected"}
@@ -32,6 +35,41 @@ def _step_history(run: dict[str, Any], step_id: int) -> list[dict[str, Any]]:
     return [event for event in run.get("approval_history", []) if event.get("step_id") == step_id]
 
 
+def _latest_terminal_decision(run: dict[str, Any], step_id: int) -> str | None:
+    for event in reversed(_step_history(run, step_id)):
+        decision = event.get("decision")
+        if decision in TERMINAL_APPROVAL_STATUSES:
+            return decision
+    return None
+
+
+def _decode_artifact_content(artifact: dict[str, Any]) -> Any:
+    content = artifact.get("content")
+    if not isinstance(content, str):
+        return content
+    try:
+        return json.loads(content)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return content
+
+
+def _continuation_events(run: dict[str, Any], step_id: int) -> list[dict[str, Any]]:
+    events = []
+    for artifact in _step_artifacts(run, step_id):
+        artifact_type = artifact.get("artifact_type")
+        if artifact_type not in {"approval_continuation", "approval_rejection"}:
+            continue
+        events.append(
+            {
+                "name": artifact.get("name"),
+                "artifact_type": artifact_type,
+                "created_at": artifact.get("created_at"),
+                "payload": _decode_artifact_content(artifact),
+            }
+        )
+    return events
+
+
 def _approval_record(pending: dict[str, Any], detail: dict[str, Any]) -> dict[str, Any]:
     pending_result = pending.get("result")
     if isinstance(pending_result, dict):
@@ -54,6 +92,9 @@ def evaluate_approval_decision(run: dict[str, Any] | None, step_id: int) -> Appr
         return ApprovalDecisionGuard(False, "step_not_found", None)
     status = step.get("status")
     if status != PENDING_APPROVAL_STATUS:
+        terminal_decision = _latest_terminal_decision(run, step_id)
+        if terminal_decision:
+            return ApprovalDecisionGuard(False, f"already_{terminal_decision}", status)
         if status in TERMINAL_APPROVAL_STATUSES:
             return ApprovalDecisionGuard(False, f"already_{status}", status)
         return ApprovalDecisionGuard(False, "step_not_pending_approval", status)
@@ -72,6 +113,7 @@ def build_approval_detail(run: dict[str, Any] | None, step_id: int) -> dict[str,
         }
 
     step = _find_step(run, step_id)
+    continuation = _continuation_events(run, step_id)
     return {
         "status": "ok" if step else "not_found",
         "reason": guard.reason,
@@ -84,6 +126,8 @@ def build_approval_detail(run: dict[str, Any] | None, step_id: int) -> dict[str,
         "can_decide": guard.allowed,
         "history": _step_history(run, step_id),
         "artifacts": _step_artifacts(run, step_id),
+        "continuation": continuation,
+        "latest_continuation": continuation[-1] if continuation else None,
         "links": {
             "approve": f"/approvals/v2/{run.get('run_id')}/{step_id}/approve",
             "reject": f"/approvals/v2/{run.get('run_id')}/{step_id}/reject",
@@ -206,7 +250,7 @@ async def approve_with_guard(agent: Any, run_id: str, step_id: int, actor: str, 
             "run_id": run_id,
             "step_id": step_id,
         }
-    decision = await agent.approve_step(run_id, step_id, actor=actor, reason=reason)
+    decision = await approve_and_continue(agent, run_id, step_id, actor=actor, reason=reason)
     return {
         "status": "ok",
         "decision": decision,
@@ -226,7 +270,7 @@ def reject_with_guard(agent: Any, run_id: str, step_id: int, actor: str, reason:
             "run_id": run_id,
             "step_id": step_id,
         }
-    decision = agent.reject_step(run_id, step_id, actor=actor, reason=reason)
+    decision = reject_with_boundary(agent, run_id, step_id, actor=actor, reason=reason)
     return {
         "status": "ok",
         "decision": decision,

--- a/velocity_claw/core/approval_continuation.py
+++ b/velocity_claw/core/approval_continuation.py
@@ -25,6 +25,35 @@ def _next_event_number(run: dict[str, Any] | None, artifact_type: str) -> int:
     return 1 + sum(1 for artifact in run.get("artifacts", []) if artifact.get("artifact_type") == artifact_type)
 
 
+def _validate_step_policy(agent: Any, step: dict[str, Any], profile_name: str) -> str | None:
+    tool = step.get("tool", "")
+    args = step.get("args", {}) or {}
+    profile_manager = getattr(agent, "profile_manager", None)
+    if profile_manager is not None and not profile_manager.is_tool_allowed(tool, profile_name):
+        return f"Tool {tool} is not allowed in profile {profile_name}"
+
+    security = getattr(agent, "security", None)
+    profile_resolver = getattr(agent, "_get_profile_for_tool", None)
+    if security is None or not callable(profile_resolver):
+        return None
+
+    try:
+        profile = security.get_profile(profile_resolver(tool))
+        if tool == "shell.run":
+            security.validate_command(args.get("command", ""), profile)
+        elif tool == "fs.read":
+            security.validate_path(args.get("path", ""), profile, write=False)
+        elif tool in {"fs.write", "fs.append", "fs.replace"}:
+            security.validate_path(args.get("path", ""), profile, write=True)
+        elif tool in {"http.get", "http.post"}:
+            security.validate_url(args.get("url", ""), profile)
+        elif tool == "git.run":
+            security.validate_git_command(args.get("command", ""), profile)
+    except Exception as exc:
+        return str(exc)
+    return None
+
+
 def _continuation_event(
     agent: Any,
     run_id: str,
@@ -132,6 +161,49 @@ def _pause_for_next_approval(
     }
 
 
+def _store_execution_result(agent: Any, run_id: str, source_step_id: int, result: dict[str, Any], *, source_step: bool) -> None:
+    if source_step:
+        agent.memory.update_step_status(
+            run_id,
+            source_step_id,
+            result.get("status") or "failed",
+            result=result.get("result"),
+            error=result.get("error"),
+        )
+    else:
+        agent.memory.save_step(run_id, result)
+    if hasattr(agent, "_persist_artifacts"):
+        agent._persist_artifacts(run_id, result)
+
+
+def _failed_continuation(
+    agent: Any,
+    run_id: str,
+    source_step_id: int,
+    *,
+    reason: str,
+    start_index: int,
+    failed_step_id: int | None,
+    executed: list[dict[str, Any]],
+) -> dict[str, Any]:
+    agent.memory.update_run_status(run_id, "failed")
+    agent.memory.save_project_note(
+        "resume_failure",
+        f"Run {run_id} failed during approval continuation at step {failed_step_id}: {reason}",
+    )
+    event = _continuation_event(
+        agent,
+        run_id,
+        source_step_id,
+        status="failed",
+        reason=reason,
+        start_index=start_index,
+        failed_step_id=failed_step_id,
+        executed=executed,
+    )
+    return {**event, "executed": executed}
+
+
 async def continue_after_approval(agent: Any, run_id: str, step_id: int) -> dict[str, Any]:
     run = agent.memory.load_run(run_id)
     if not run:
@@ -158,7 +230,7 @@ async def continue_after_approval(agent: Any, run_id: str, step_id: int) -> dict
 
     try:
         plan = json.loads(plan_artifact["content"])
-    except (TypeError, ValueError, json.JSONDecodeError):
+    except (TypeError, ValueError):
         agent.memory.update_run_status(run_id, "approved_waiting_manual_resume")
         event = _continuation_event(
             agent,
@@ -209,42 +281,51 @@ async def continue_after_approval(agent: Any, run_id: str, step_id: int) -> dict
             return {**event, "executed": executed, "pause": pause}
 
         started_at = _now()
-        result = await agent.executor.execute_step(step, {})
-        result["started_at"] = result.get("started_at") or started_at
-        result["completed_at"] = _now()
-
-        if index == start_index:
-            agent.memory.update_step_status(
-                run_id,
-                step_id,
-                result.get("status") or "failed",
-                result=result.get("result"),
-                error=result.get("error"),
-            )
-        else:
-            agent.memory.save_step(run_id, result)
-
-        if hasattr(agent, "_persist_artifacts"):
-            agent._persist_artifacts(run_id, result)
-        executed.append(result)
-
-        if result.get("status") == "failed":
-            agent.memory.update_run_status(run_id, "failed")
-            agent.memory.save_project_note(
-                "resume_failure",
-                f"Run {run_id} failed during approval continuation at step {step.get('id')}",
-            )
-            event = _continuation_event(
+        validation_error = _validate_step_policy(agent, step, profile_name)
+        if validation_error:
+            result = {
+                "id": step.get("id"),
+                "title": step.get("title"),
+                "tool": step.get("tool"),
+                "args": step.get("args", {}),
+                "status": "failed",
+                "result": None,
+                "error": validation_error,
+                "started_at": started_at,
+                "completed_at": _now(),
+            }
+            _store_execution_result(agent, run_id, step_id, result, source_step=index == start_index)
+            executed.append(result)
+            return _failed_continuation(
                 agent,
                 run_id,
                 step_id,
-                status="failed",
+                reason="policy_validation_failed",
+                start_index=start_index,
+                failed_step_id=step.get("id"),
+                executed=executed,
+            )
+
+        result = await agent.executor.execute_step(step, {})
+        result.setdefault("id", step.get("id"))
+        result.setdefault("title", step.get("title"))
+        result.setdefault("tool", step.get("tool"))
+        result.setdefault("args", step.get("args", {}))
+        result["started_at"] = result.get("started_at") or started_at
+        result["completed_at"] = _now()
+        _store_execution_result(agent, run_id, step_id, result, source_step=index == start_index)
+        executed.append(result)
+
+        if result.get("status") == "failed":
+            return _failed_continuation(
+                agent,
+                run_id,
+                step_id,
                 reason="step_execution_failed",
                 start_index=start_index,
                 failed_step_id=step.get("id"),
                 executed=executed,
             )
-            return {**event, "executed": executed}
 
     agent.memory.update_run_status(run_id, "completed")
     agent.memory.save_project_note("resume_complete", f"Run {run_id} completed after approval continuation")

--- a/velocity_claw/core/approval_continuation.py
+++ b/velocity_claw/core/approval_continuation.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any
+
+
+def _now() -> str:
+    return datetime.now().isoformat()
+
+
+def _json_artifact(memory: Any, run_id: str, name: str, payload: dict[str, Any], *, step_id: int | None, artifact_type: str) -> None:
+    memory.save_artifact(
+        run_id,
+        name,
+        json.dumps(payload, ensure_ascii=False),
+        step_id=step_id,
+        artifact_type=artifact_type,
+    )
+
+
+def _next_event_number(run: dict[str, Any] | None, artifact_type: str) -> int:
+    if not run:
+        return 1
+    return 1 + sum(1 for artifact in run.get("artifacts", []) if artifact.get("artifact_type") == artifact_type)
+
+
+def _continuation_event(
+    agent: Any,
+    run_id: str,
+    source_step_id: int,
+    *,
+    status: str,
+    reason: str | None = None,
+    start_index: int | None = None,
+    boundary_step_id: int | None = None,
+    failed_step_id: int | None = None,
+    executed: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    executed = executed or []
+    payload = {
+        "status": status,
+        "reason": reason,
+        "source_step_id": source_step_id,
+        "start_index": start_index,
+        "boundary_step_id": boundary_step_id,
+        "failed_step_id": failed_step_id,
+        "executed_step_ids": [item.get("id") for item in executed],
+        "executed_count": len(executed),
+        "created_at": _now(),
+    }
+    run = agent.memory.load_run(run_id)
+    event_no = _next_event_number(run, "approval_continuation")
+    _json_artifact(
+        agent.memory,
+        run_id,
+        f"approval_continuation_{event_no}_step_{source_step_id}",
+        payload,
+        step_id=source_step_id,
+        artifact_type="approval_continuation",
+    )
+    return payload
+
+
+def _pause_for_next_approval(
+    agent: Any,
+    run_id: str,
+    task: str,
+    step: dict[str, Any],
+    profile_name: str,
+    *,
+    source_step_id: int,
+) -> dict[str, Any]:
+    step_id = step["id"]
+    started_at = _now()
+    completed_at = _now()
+    approval = agent.approvals.build_record(step, profile_name=profile_name)
+    step_result = {
+        "id": step_id,
+        "title": step["title"],
+        "tool": step.get("tool"),
+        "args": step.get("args", {}),
+        "status": "pending_approval",
+        "result": approval,
+        "error": None,
+        "started_at": started_at,
+        "completed_at": completed_at,
+    }
+    agent.memory.save_step(run_id, step_result)
+    _json_artifact(
+        agent.memory,
+        run_id,
+        f"approval_step_{step_id}",
+        approval,
+        step_id=step_id,
+        artifact_type="approval",
+    )
+    boundary = {
+        "step_id": step_id,
+        "source_step_id": source_step_id,
+        "boundary_type": "continuation_pause",
+        "created_at": completed_at,
+    }
+    _json_artifact(
+        agent.memory,
+        run_id,
+        f"approval_boundary_step_{step_id}",
+        boundary,
+        step_id=step_id,
+        artifact_type="approval_boundary",
+    )
+    agent.memory.save_approval_decision(
+        run_id,
+        step_id,
+        "requested",
+        actor=None,
+        reason=approval.get("reason"),
+        payload=approval,
+    )
+    agent.memory.save_project_note(
+        "approval_pause",
+        f"Run {run_id} paused during continuation from step {source_step_id} at step {step_id}",
+    )
+    agent.memory.update_run_status(run_id, "awaiting_approval")
+    return {
+        "run_id": run_id,
+        "task": task,
+        "status": "awaiting_approval",
+        "summary": f"Run paused at continuation step {step_id} awaiting approval.",
+        "step": step_result,
+        "boundary": boundary,
+    }
+
+
+async def continue_after_approval(agent: Any, run_id: str, step_id: int) -> dict[str, Any]:
+    run = agent.memory.load_run(run_id)
+    if not run:
+        return {
+            "status": "failed",
+            "reason": "run_not_found",
+            "source_step_id": step_id,
+            "executed": [],
+        }
+
+    artifacts = run.get("artifacts", [])
+    plan_artifact = next((artifact for artifact in artifacts if artifact.get("name") == "run_plan"), None)
+    if not plan_artifact:
+        agent.memory.update_run_status(run_id, "approved_waiting_manual_resume")
+        event = _continuation_event(
+            agent,
+            run_id,
+            step_id,
+            status="manual_resume_required",
+            reason="run_plan_missing",
+        )
+        agent.memory.save_project_note("approval_manual_resume", f"Run {run_id} requires manual resume: run plan missing")
+        return {**event, "executed": []}
+
+    try:
+        plan = json.loads(plan_artifact["content"])
+    except (TypeError, ValueError, json.JSONDecodeError):
+        agent.memory.update_run_status(run_id, "approved_waiting_manual_resume")
+        event = _continuation_event(
+            agent,
+            run_id,
+            step_id,
+            status="manual_resume_required",
+            reason="run_plan_invalid",
+        )
+        agent.memory.save_project_note("approval_manual_resume", f"Run {run_id} requires manual resume: run plan invalid")
+        return {**event, "executed": []}
+
+    steps = plan.get("steps") or []
+    start_index = next((index for index, item in enumerate(steps) if item.get("id") == step_id), None)
+    if start_index is None:
+        agent.memory.update_run_status(run_id, "approved_waiting_manual_resume")
+        event = _continuation_event(
+            agent,
+            run_id,
+            step_id,
+            status="manual_resume_required",
+            reason="step_boundary_missing",
+        )
+        agent.memory.save_project_note("approval_manual_resume", f"Run {run_id} requires manual resume: step boundary missing")
+        return {**event, "executed": []}
+
+    executed: list[dict[str, Any]] = []
+    profile_name = agent.settings.execution_profile
+    for index, step in enumerate(steps[start_index:], start=start_index):
+        if index > start_index and agent.approvals.requires_approval(step, profile_name):
+            pause = _pause_for_next_approval(
+                agent,
+                run_id,
+                run.get("task") or "",
+                step,
+                profile_name,
+                source_step_id=step_id,
+            )
+            event = _continuation_event(
+                agent,
+                run_id,
+                step_id,
+                status="awaiting_approval",
+                reason="next_approval_required",
+                start_index=start_index,
+                boundary_step_id=step.get("id"),
+                executed=executed,
+            )
+            return {**event, "executed": executed, "pause": pause}
+
+        started_at = _now()
+        result = await agent.executor.execute_step(step, {})
+        result["started_at"] = result.get("started_at") or started_at
+        result["completed_at"] = _now()
+
+        if index == start_index:
+            agent.memory.update_step_status(
+                run_id,
+                step_id,
+                result.get("status") or "failed",
+                result=result.get("result"),
+                error=result.get("error"),
+            )
+        else:
+            agent.memory.save_step(run_id, result)
+
+        if hasattr(agent, "_persist_artifacts"):
+            agent._persist_artifacts(run_id, result)
+        executed.append(result)
+
+        if result.get("status") == "failed":
+            agent.memory.update_run_status(run_id, "failed")
+            agent.memory.save_project_note(
+                "resume_failure",
+                f"Run {run_id} failed during approval continuation at step {step.get('id')}",
+            )
+            event = _continuation_event(
+                agent,
+                run_id,
+                step_id,
+                status="failed",
+                reason="step_execution_failed",
+                start_index=start_index,
+                failed_step_id=step.get("id"),
+                executed=executed,
+            )
+            return {**event, "executed": executed}
+
+    agent.memory.update_run_status(run_id, "completed")
+    agent.memory.save_project_note("resume_complete", f"Run {run_id} completed after approval continuation")
+    event = _continuation_event(
+        agent,
+        run_id,
+        step_id,
+        status="completed",
+        reason="continuation_completed",
+        start_index=start_index,
+        executed=executed,
+    )
+    return {**event, "executed": executed}
+
+
+async def approve_and_continue(agent: Any, run_id: str, step_id: int, *, actor: str, reason: str | None) -> dict[str, Any]:
+    payload = {
+        "decision": "approved",
+        "actor": actor,
+        "reason": reason,
+        "decided_at": _now(),
+    }
+    agent.memory.update_step_status(run_id, step_id, "approved", result=payload)
+    agent.memory.save_approval_decision(run_id, step_id, "approved", actor=actor, reason=reason, payload=payload)
+    _json_artifact(
+        agent.memory,
+        run_id,
+        f"approval_decision_step_{step_id}",
+        payload,
+        step_id=step_id,
+        artifact_type="approval",
+    )
+    agent.memory.save_project_note("approval_decision", f"Run {run_id} step {step_id} approved by {actor}")
+    agent.memory.update_run_status(run_id, "resuming_after_approval")
+    payload["resume"] = await continue_after_approval(agent, run_id, step_id)
+    return payload
+
+
+def reject_with_boundary(agent: Any, run_id: str, step_id: int, *, actor: str, reason: str | None) -> dict[str, Any]:
+    payload = {
+        "decision": "rejected",
+        "actor": actor,
+        "reason": reason,
+        "decided_at": _now(),
+    }
+    agent.memory.update_step_status(run_id, step_id, "rejected", result=payload, error="Rejected by reviewer")
+    agent.memory.save_approval_decision(run_id, step_id, "rejected", actor=actor, reason=reason, payload=payload)
+    _json_artifact(
+        agent.memory,
+        run_id,
+        f"approval_decision_step_{step_id}",
+        payload,
+        step_id=step_id,
+        artifact_type="approval",
+    )
+    rejection = {
+        "status": "rejected",
+        "run_id": run_id,
+        "step_id": step_id,
+        "actor": actor,
+        "reason": reason,
+        "continuation_allowed": False,
+        "created_at": payload["decided_at"],
+    }
+    _json_artifact(
+        agent.memory,
+        run_id,
+        f"approval_rejection_step_{step_id}",
+        rejection,
+        step_id=step_id,
+        artifact_type="approval_rejection",
+    )
+    agent.memory.save_project_note("approval_decision", f"Run {run_id} step {step_id} rejected by {actor}")
+    agent.memory.update_run_status(run_id, "rejected")
+    payload["boundary"] = rejection
+    return payload


### PR DESCRIPTION
## Summary

Strengthens approval continuation so approved runs resume from a precise, inspectable boundary without duplicating the approved source step.

Changes:
- add `velocity_claw/core/approval_continuation.py`
- route Approval v2 approve/reject decisions through the v3 continuation core
- recheck execution-profile and security policy before every continued step
- update the original approved step instead of inserting a duplicate row
- pause cleanly at a later sensitive step and create a new approval boundary
- persist `approval_continuation` artifacts for completed, failed, awaiting, and manual-resume outcomes
- persist terminal `approval_rejection` artifacts with `continuation_allowed=false`
- preserve duplicate-decision blocking after an approved step changes to success/failed
- expose decoded continuation state in Approval v2 detail
- add tests for completion, failure, manual resume, next approval boundary, policy blocking, rejection, and duplicate-step prevention
- add `docs/APPROVALS.md`

Related: #31

Validation:
- pytest -q