### PR TITLE
Add automated GitHub release publishing v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,35 @@ jobs:
           echo "version=${VERSION_VALUE}" >> "${GITHUB_OUTPUT}"
           echo "tag=${EXPECTED_TAG}" >> "${GITHUB_OUTPUT}"
 
+      - name: Inspect existing tag and release
+        id: state
+        env:
+          TAG_VALUE: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+
+          TAG_SHA=""
+          if git show-ref --verify --quiet "refs/tags/${TAG_VALUE}"; then
+            TAG_SHA="$(git rev-list -n 1 "${TAG_VALUE}")"
+          fi
+
+          if gh release view "${TAG_VALUE}" >/dev/null 2>&1; then
+            RELEASE_EXISTS="true"
+          else
+            RELEASE_EXISTS="false"
+          fi
+
+          if [[ -n "${TAG_SHA}" && "${TAG_SHA}" != "${GITHUB_SHA}" ]]; then
+            if [[ "${RELEASE_EXISTS}" == "false" || "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+              echo "Tag ${TAG_VALUE} points to ${TAG_SHA}, but this run uses ${GITHUB_SHA}. Select the tag ref for a manual repair run." >&2
+              exit 1
+            fi
+          fi
+
+          echo "tag_sha=${TAG_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "release_exists=${RELEASE_EXISTS}" >> "${GITHUB_OUTPUT}"
+
       - name: Build Python artifacts
         run: |
           set -euo pipefail
@@ -116,24 +145,31 @@ jobs:
             echo
             echo "- CHANGELOG.md"
             echo "- docs/RELEASE.md"
+            echo "- docs/RELEASE_AUTOMATION.md"
             echo "- docs/DEPLOYMENT.md"
           } > dist/release-summary.md
 
       - name: Publish or update GitHub Release
+        env:
+          RELEASE_EXISTS: ${{ steps.state.outputs.release_exists }}
         run: |
           set -euo pipefail
           TAG_VALUE="${{ steps.release.outputs.tag }}"
           VERSION_VALUE="${{ steps.release.outputs.version }}"
 
-          if gh release view "${TAG_VALUE}" >/dev/null 2>&1; then
-            gh release edit "${TAG_VALUE}" \
-              --title "Velocity Claw ${VERSION_VALUE}" \
-              --notes-file dist/release-notes.md
-            gh release upload "${TAG_VALUE}" \
-              dist/*.whl \
-              dist/*.tar.gz \
-              dist/release-summary.md \
-              --clobber
+          if [[ "${RELEASE_EXISTS}" == "true" ]]; then
+            if [[ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ]]; then
+              echo "Release ${TAG_VALUE} already exists; automatic runs preserve immutable release assets."
+            else
+              gh release edit "${TAG_VALUE}" \
+                --title "Velocity Claw ${VERSION_VALUE}" \
+                --notes-file dist/release-notes.md
+              gh release upload "${TAG_VALUE}" \
+                dist/*.whl \
+                dist/*.tar.gz \
+                dist/release-summary.md \
+                --clobber
+            fi
           else
             gh release create "${TAG_VALUE}" \
               dist/*.whl \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,38 @@
 name: release
 
 on:
+  push:
+    branches:
+      - master
+    paths:
+      - VERSION
+      - .github/workflows/release.yml
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag, for example v0.2.0"
-        required: true
+        description: "Optional release tag; must match VERSION, for example v0.2.3"
+        required: false
+        default: ""
         type: string
 
 permissions:
-  contents: read
+  contents: write
+
+concurrency:
+  group: release-${{ github.repository }}
+  cancel-in-progress: false
 
 jobs:
-  validate-release:
+  publish-release:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -26,30 +41,66 @@ jobs:
 
       - name: Install dependencies
         run: |
+          set -euo pipefail
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install build pip-audit
 
       - name: Validate package metadata
         run: |
+          set -euo pipefail
           python scripts/validate_package.py
 
       - name: Run tests
         run: |
-          pytest -q
+          set -euo pipefail
+          pytest -q 2>&1 | tee pytest-output.txt
 
-      - name: Validate release tag matches VERSION
+      - name: Audit dependencies
         run: |
-          VERSION_VALUE="$(cat VERSION | tr -d '[:space:]')"
+          set -euo pipefail
+          pip-audit -r requirements.txt
+
+      - name: Resolve release tag
+        id: release
+        run: |
+          set -euo pipefail
+          VERSION_VALUE="$(tr -d '[:space:]' < VERSION)"
           EXPECTED_TAG="v${VERSION_VALUE}"
-          if [ "${{ inputs.tag }}" != "$EXPECTED_TAG" ]; then
-            echo "Release tag ${{ inputs.tag }} does not match VERSION $EXPECTED_TAG" >&2
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            REQUESTED_TAG="${{ inputs.tag }}"
+            if [[ -z "${REQUESTED_TAG}" ]]; then
+              REQUESTED_TAG="${EXPECTED_TAG}"
+            fi
+          else
+            REQUESTED_TAG="${EXPECTED_TAG}"
+          fi
+
+          if [[ "${REQUESTED_TAG}" != "${EXPECTED_TAG}" ]]; then
+            echo "Release tag ${REQUESTED_TAG} does not match VERSION ${EXPECTED_TAG}" >&2
             exit 1
           fi
 
+          echo "version=${VERSION_VALUE}" >> "${GITHUB_OUTPUT}"
+          echo "tag=${EXPECTED_TAG}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build Python artifacts
+        run: |
+          set -euo pipefail
+          rm -rf dist build
+          python -m build
+
+      - name: Generate release notes
+        run: |
+          set -euo pipefail
+          python scripts/generate_release_notes.py
+
       - name: Generate release summary
         run: |
-          VERSION_VALUE="$(cat VERSION | tr -d '[:space:]')"
-          mkdir -p dist
+          set -euo pipefail
+          VERSION_VALUE="${{ steps.release.outputs.version }}"
+          TAG_VALUE="${{ steps.release.outputs.tag }}"
           {
             echo "# Velocity Claw ${VERSION_VALUE}"
             echo
@@ -57,22 +108,64 @@ jobs:
             echo
             echo "- Package metadata validated"
             echo "- Tests passed"
-            echo "- Release tag matched VERSION"
+            echo "- Dependency audit passed"
+            echo "- Wheel and source distribution built"
+            echo "- Release tag ${TAG_VALUE} matched VERSION"
             echo
             echo "## Release docs"
             echo
+            echo "- CHANGELOG.md"
             echo "- docs/RELEASE.md"
             echo "- docs/DEPLOYMENT.md"
           } > dist/release-summary.md
 
-      - name: Generate release notes
+      - name: Publish or update GitHub Release
         run: |
-          python scripts/generate_release_notes.py
+          set -euo pipefail
+          TAG_VALUE="${{ steps.release.outputs.tag }}"
+          VERSION_VALUE="${{ steps.release.outputs.version }}"
+
+          if gh release view "${TAG_VALUE}" >/dev/null 2>&1; then
+            gh release edit "${TAG_VALUE}" \
+              --title "Velocity Claw ${VERSION_VALUE}" \
+              --notes-file dist/release-notes.md
+            gh release upload "${TAG_VALUE}" \
+              dist/*.whl \
+              dist/*.tar.gz \
+              dist/release-summary.md \
+              --clobber
+          else
+            gh release create "${TAG_VALUE}" \
+              dist/*.whl \
+              dist/*.tar.gz \
+              dist/release-summary.md \
+              --target "${GITHUB_SHA}" \
+              --title "Velocity Claw ${VERSION_VALUE}" \
+              --notes-file dist/release-notes.md
+          fi
+
+      - name: Verify published release
+        run: |
+          set -euo pipefail
+          gh release view "${{ steps.release.outputs.tag }}" --json tagName,name,isDraft,isPrerelease
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: release-artifacts
+          name: release-artifacts-${{ steps.release.outputs.tag }}
           path: |
+            dist/*.whl
+            dist/*.tar.gz
             dist/release-summary.md
             dist/release-notes.md
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Upload pytest failure output
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-pytest-failure-output
+          path: pytest-output.txt
+          if-no-files-found: ignore
+          retention-days: 7

--- a/docs/RELEASE_AUTOMATION.md
+++ b/docs/RELEASE_AUTOMATION.md
@@ -1,0 +1,34 @@
+# Release automation
+
+Velocity Claw publishes releases through `.github/workflows/release.yml`.
+
+## Automatic trigger
+
+The workflow starts after a push to `master` that changes `VERSION` or the release workflow itself. This allows a version-bump pull request to publish its release after merge and also lets workflow repairs publish a pending version.
+
+## Validation gates
+
+Before publication the workflow:
+
+- validates `VERSION`, `velocity_claw/__version__.py`, and `pyproject.toml`;
+- runs the complete test suite;
+- audits pinned dependencies;
+- verifies that the tag equals `v<VERSION>`;
+- builds the wheel and source distribution;
+- generates notes from the matching section in `CHANGELOG.md`.
+
+A failed gate stops publication.
+
+## GitHub Release behavior
+
+For a new version, the workflow creates the tag and GitHub Release at the validated `master` commit. It attaches the wheel, source archive, and validation summary.
+
+For an existing version, the workflow updates the release notes and replaces package assets. This makes manual reruns safe after an interrupted publication.
+
+## Manual run
+
+The workflow can be started manually. The optional tag must match `v<VERSION>`. When omitted, the workflow derives the tag from `VERSION`.
+
+## Permissions
+
+The workflow uses the repository GitHub token with `contents: write` only for tag and release publication. Source checkout, tests, package validation, and dependency audit run before that publication step.

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -1,8 +1,35 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def extract_changelog_section(root: Path, version: str) -> str:
+    changelog_path = root / "CHANGELOG.md"
+    if not changelog_path.exists():
+        return ""
+
+    lines = changelog_path.read_text(encoding="utf-8").splitlines()
+    header_pattern = re.compile(rf"^##\s+{re.escape(version)}(?:\s+-\s+.*)?$")
+    start: int | None = None
+
+    for index, line in enumerate(lines):
+        if header_pattern.match(line.strip()):
+            start = index + 1
+            break
+
+    if start is None:
+        return ""
+
+    section: list[str] = []
+    for line in lines[start:]:
+        if line.startswith("## "):
+            break
+        section.append(line)
+
+    return "\n".join(section).strip()
 
 
 def generate_release_notes(root: Path = ROOT) -> str:
@@ -10,10 +37,12 @@ def generate_release_notes(root: Path = ROOT) -> str:
     deployment_doc = root / "docs" / "DEPLOYMENT.md"
     release_doc = root / "docs" / "RELEASE.md"
     pyproject = root / "pyproject.toml"
+    changelog = extract_changelog_section(root, version)
 
     checks = {
         "deployment_guide": deployment_doc.exists(),
         "release_guide": release_doc.exists(),
+        "changelog": (root / "CHANGELOG.md").exists(),
         "pyproject": pyproject.exists(),
         "systemd_deployment": (root / "deploy" / "systemd" / "velocity-claw.service").exists(),
         "docker_compose_deployment": (root / "deploy" / "docker" / "docker-compose.yml").exists(),
@@ -23,18 +52,17 @@ def generate_release_notes(root: Path = ROOT) -> str:
     }
 
     checklist = "\n".join(f"- [{'x' if ok else ' '}] {name.replace('_', ' ')}" for name, ok in checks.items())
+    changes = changelog or "No matching changelog section was found for this version."
+
     return f"""# Velocity Claw v{version}
 
 ## Summary
 
-Velocity Claw v{version} is an advanced self-hosted AI dev-agent release focused on controlled execution, operator workflows, deployment readiness, package metadata, and release automation.
+Velocity Claw v{version} is a self-hosted AI dev-agent release focused on controlled execution, operator workflows, runtime resilience, deployment readiness, and reproducible release automation.
 
-## Included release areas
+## Changes in this release
 
-- Agent runtime, memory, approvals, retry/replay, and reports
-- API, dashboard helpers, operator CLI, and queue/metrics foundations
-- Systemd deployment, Docker Compose deployment, and production installer
-- Version metadata, package validation, release workflow, and build artifact workflow
+{changes}
 
 ## Release readiness checklist
 
@@ -43,12 +71,13 @@ Velocity Claw v{version} is an advanced self-hosted AI dev-agent release focused
 ## Operator docs
 
 - `README.md`
+- `CHANGELOG.md`
 - `docs/DEPLOYMENT.md`
 - `docs/RELEASE.md`
 
 ## Build artifacts
 
-Python package artifacts are built through the `build-artifacts` workflow and uploaded as GitHub Actions artifacts.
+The GitHub Release includes the Python wheel, source distribution, and release validation summary. The same files are retained as GitHub Actions artifacts.
 """
 
 

--- a/tests/test_release_automation_v2.py
+++ b/tests/test_release_automation_v2.py
@@ -1,0 +1,122 @@
+from pathlib import Path
+
+from scripts.generate_release_notes import extract_changelog_section, generate_release_notes
+
+
+RELEASE_WORKFLOW = Path(".github/workflows/release.yml")
+RELEASE_AUTOMATION_DOC = Path("docs/RELEASE_AUTOMATION.md")
+
+
+def test_release_workflow_publishes_version_changes_idempotently():
+    content = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    required = [
+        "push:",
+        "workflow_dispatch:",
+        "- VERSION",
+        "contents: write",
+        "pip-audit -r requirements.txt",
+        "python -m build",
+        "python scripts/generate_release_notes.py",
+        'gh release view "${TAG_VALUE}"',
+        'gh release create "${TAG_VALUE}"',
+        'gh release edit "${TAG_VALUE}"',
+        'gh release upload "${TAG_VALUE}"',
+        "--clobber",
+        "dist/*.whl",
+        "dist/*.tar.gz",
+        "--notes-file dist/release-notes.md",
+    ]
+
+    for value in required:
+        assert value in content
+
+
+def test_release_workflow_validates_tag_against_version():
+    content = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'EXPECTED_TAG="v${VERSION_VALUE}"' in content
+    assert "does not match VERSION" in content
+    assert 'echo "version=${VERSION_VALUE}"' in content
+    assert 'echo "tag=${EXPECTED_TAG}"' in content
+
+
+def test_release_automation_documentation_covers_gates_and_repair_runs():
+    content = RELEASE_AUTOMATION_DOC.read_text(encoding="utf-8")
+
+    required = [
+        "VERSION",
+        "velocity_claw/__version__.py",
+        "pyproject.toml",
+        "dependency",
+        "CHANGELOG.md",
+        "contents: write",
+        "existing version",
+        "manual",
+    ]
+    for value in required:
+        assert value in content
+
+
+def _create_release_fixture(root: Path) -> None:
+    (root / "VERSION").write_text("1.2.3\n", encoding="utf-8")
+    (root / "CHANGELOG.md").write_text(
+        """# Changelog
+
+## 1.2.3 - 2026-06-22
+
+### Added
+
+- Current release feature.
+
+### Fixed
+
+- Current release fix.
+
+## 1.2.2 - 2026-06-01
+
+### Added
+
+- Previous release feature.
+""",
+        encoding="utf-8",
+    )
+    (root / "pyproject.toml").write_text('[project]\nversion = "1.2.3"\n', encoding="utf-8")
+
+    for path in [
+        "docs/DEPLOYMENT.md",
+        "docs/RELEASE.md",
+        "deploy/systemd/velocity-claw.service",
+        "deploy/docker/docker-compose.yml",
+        "deploy/install/install.sh",
+        ".github/workflows/build-artifacts.yml",
+        ".github/workflows/release.yml",
+    ]:
+        target = root / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("fixture\n", encoding="utf-8")
+
+
+def test_release_notes_include_only_current_changelog_section(tmp_path: Path):
+    _create_release_fixture(tmp_path)
+
+    section = extract_changelog_section(tmp_path, "1.2.3")
+    notes = generate_release_notes(tmp_path)
+
+    assert "Current release feature." in section
+    assert "Current release fix." in section
+    assert "Previous release feature." not in section
+    assert "# Velocity Claw v1.2.3" in notes
+    assert "## Changes in this release" in notes
+    assert "Current release feature." in notes
+    assert "Current release fix." in notes
+    assert "Previous release feature." not in notes
+
+
+def test_release_notes_report_missing_version_section(tmp_path: Path):
+    _create_release_fixture(tmp_path)
+    (tmp_path / "VERSION").write_text("9.9.9\n", encoding="utf-8")
+
+    notes = generate_release_notes(tmp_path)
+
+    assert "No matching changelog section was found for this version." in notes


### PR DESCRIPTION
## Summary

Turns the existing validation-only release workflow into an actual, restart-safe publication pipeline.

Changes:
- trigger release publication after `VERSION` or release-workflow changes land on `master`
- keep manual workflow dispatch with tag-to-version validation
- grant narrowly scoped `contents: write` permission for tag and release creation
- validate package metadata, run tests, audit dependencies, and build wheel/sdist before publication
- create the `v<VERSION>` tag and GitHub Release when absent
- update release notes and replace package assets when the release already exists
- verify the published release through the GitHub CLI
- generate release notes from the matching `CHANGELOG.md` section
- add release automation operator documentation
- add contract tests for triggers, validation gates, package assets, idempotent publication, and changelog extraction

Bootstrap behavior:
- merging this PR changes `.github/workflows/release.yml`
- the push-to-master trigger should publish the currently pending `v0.2.3` release

Validation:
- `python scripts/validate_package.py`
- `pytest -q`
- dependency audit
- package build