### PR TITLE
Add worker orchestration and concurrency v2

### DIFF
--- a/docs/QUEUE.md
+++ b/docs/QUEUE.md
@@ -1,6 +1,14 @@
-# Queue persistence v2
+# Queue persistence and worker orchestration v2
 
-Velocity Claw stores queue jobs in SQLite and restores them when the API process restarts.
+Velocity Claw stores queue jobs in SQLite and runs them through a bounded asynchronous worker orchestrator.
+
+## Runtime model
+
+The orchestrator tracks explicit task handles instead of creating an unbounded number of coroutines that wait on a semaphore.
+
+At most `QUEUE_MAX_CONCURRENCY` jobs are scheduled at one time. When one worker finishes, the oldest remaining queued job is scheduled automatically. This keeps memory use predictable while preserving FIFO execution order.
+
+Each active job receives the lowest available deterministic worker slot, such as `slot-1` or `slot-2`. Slots are released when a job completes, fails, or is cancelled.
 
 ## Startup recovery
 
@@ -23,31 +31,63 @@ Normal transitions are:
 - `queued` or `running` to `cancelled` after operator cancellation;
 - `failed` or `cancelled` to `queued` after requeue.
 
-Terminal reasons include `runner_completed`, `runner_exception`, `cancelled_by_operator`, `max_attempts_exhausted`, and `invalid_persisted_status`.
+Terminal reasons include `runner_completed`, `runner_exception`, `cancelled_by_operator`, `worker_task_cancelled`, `max_attempts_exhausted`, and `invalid_persisted_status`.
 
-A cancelled running job remains cancelled even when the underlying runner finishes later. The late result is discarded.
+Cancelling a scheduled or running job cancels its tracked `asyncio.Task`. A cancelled runner cannot overwrite the persisted terminal state with a late result.
+
+## Pause, resume, drain, and shutdown
+
+`pause` stops new worker scheduling without changing queued jobs or interrupting active workers.
+
+`resume` enables scheduling and immediately fills available worker capacity from the oldest queued jobs.
+
+`drain` pauses scheduling and waits up to the requested timeout for currently tracked workers. It does not cancel active work. Jobs that were not yet scheduled stay queued until resume.
+
+Application shutdown stops accepting work, cancels tracked runners, waits up to `QUEUE_SHUTDOWN_TIMEOUT_SECONDS`, and persists cancellation state before the API process exits.
 
 ## Retry behavior
 
-Use `POST /queue/v2/{job_id}/requeue` to retry a failed or cancelled job. The job is immediately scheduled after it returns to `queued`.
+Use `POST /queue/v2/{job_id}/requeue` to retry a failed or cancelled job. The job is immediately scheduled when the orchestrator is accepting work and has capacity. Otherwise it remains queued and is picked up automatically when capacity becomes available or the queue is resumed.
 
 When the attempt limit is reached, the endpoint returns `409 max_attempts_exhausted`. An explicit operator retry can use `force=true`. Completed jobs cannot be requeued.
+
+## Runtime settings
+
+All settings support the `VELOCITY_CLAW_` prefix and the legacy short name.
+
+| Setting | Default | Purpose |
+| --- | ---: | --- |
+| `QUEUE_MAX_CONCURRENCY` | `2` | Maximum tracked and active worker tasks |
+| `QUEUE_MAX_ATTEMPTS` | `3` | Maximum attempts before normal requeue is blocked |
+| `QUEUE_RECOVER_ON_STARTUP` | `true` | Recover interrupted persisted work at startup |
+| `QUEUE_SHUTDOWN_TIMEOUT_SECONDS` | `10` | Maximum graceful shutdown wait |
 
 ## Operator endpoints
 
 | Method | Endpoint | Purpose |
 | --- | --- | --- |
-| GET | `/queue/v2/runtime` | Inspect counts, workers, limits, persistence, and startup recovery |
-| POST | `/queue/v2/recover` | Schedule all queued jobs without duplicate worker tasks |
+| GET | `/queue/v2/runtime` | Inspect counts, tracked tasks, worker slots, limits, persistence, and recovery |
+| POST | `/queue/v2/recover` | Fill available capacity from queued jobs without duplicates |
+| POST | `/queue/v2/pause` | Stop new scheduling while current workers continue |
+| POST | `/queue/v2/resume` | Resume scheduling and fill worker capacity |
+| POST | `/queue/v2/drain?timeout_seconds=10` | Pause and wait for tracked workers without cancelling them |
 | POST | `/queue/v2/{job_id}/requeue` | Requeue and schedule a failed or cancelled job |
-| POST | `/queue/v2/{job_id}/cancel` | Cancel a queued or running job |
+| POST | `/queue/v2/{job_id}/cancel` | Cancel a queued or running job and interrupt its task |
 
-Legacy queue endpoints remain available for compatibility.
+Legacy queue endpoints remain available for compatibility. New operator workflows should use `/queue/v2/*`.
 
 ## Duplicate scheduling protection
 
-Scheduled and active job IDs are tracked separately. Repeated recovery calls do not create duplicate worker tasks for the same job.
+Tracked task handles, scheduled IDs, and active IDs are checked before a job is scheduled. Repeated recovery or resume calls do not create duplicate worker tasks for the same job.
 
 ## Diagnostics
 
-`GET /diagnostics/v2` includes queue counts, active and scheduled workers, retry limits, persistence state, startup recovery details, and recovery-related risk flags.
+`GET /diagnostics/v2` includes:
+
+- accepting/paused state;
+- tracked, scheduled, and active worker counts;
+- deterministic active slot mapping;
+- available and scheduling capacity;
+- retry limits and persistence state;
+- startup recovery details;
+- a `queue_not_accepting_work` information flag while paused or draining.

--- a/tests/test_legacy_queue_tracking_v2.py
+++ b/tests/test_legacy_queue_tracking_v2.py
@@ -1,0 +1,57 @@
+import asyncio
+
+from velocity_claw.core.queue import RunQueue
+from velocity_claw.core.queue_tracking import install_direct_run_tracking
+
+
+async def wait_for(predicate, timeout: float = 2.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("condition was not reached before timeout")
+
+
+def test_legacy_direct_run_is_tracked_cancelled_and_capacity_bounded():
+    async def scenario():
+        queue = RunQueue(max_concurrency=1)
+        install_direct_run_tracking(queue)
+        first = queue.enqueue("first")
+        second = queue.enqueue("second")
+        first_started = asyncio.Event()
+        first_interrupted = asyncio.Event()
+        calls = []
+
+        async def runner(task, context):
+            calls.append(task)
+            if task == "first":
+                first_started.set()
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    first_interrupted.set()
+                    raise
+            return {"status": "completed", "task": task}
+
+        first_task = asyncio.create_task(queue.run_job(first.job_id, runner))
+        await first_started.wait()
+        assert queue.tracked_task_count() == 1
+
+        second_task = asyncio.create_task(queue.run_job(second.job_id, runner))
+        await second_task
+        assert second.status == "queued"
+        assert second.attempts == 0
+        assert queue.tracked_task_count() == 1
+
+        queue.cancel(first.job_id)
+        await first_task
+        await wait_for(first_interrupted.is_set)
+        await wait_for(lambda: second.status == "completed")
+        await wait_for(lambda: queue.tracked_task_count() == 0)
+
+        assert first.status == "cancelled"
+        assert calls == ["first", "second"]
+
+    asyncio.run(scenario())

--- a/tests/test_queue_orchestration_api_v2.py
+++ b/tests/test_queue_orchestration_api_v2.py
@@ -1,0 +1,100 @@
+import time
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from velocity_claw.api.app import install_queue_persistence_v2
+from velocity_claw.core.queue import RunQueue
+
+
+class QueueSettings:
+    queue_max_concurrency = 1
+    queue_max_attempts = 3
+    queue_recover_on_startup = False
+    queue_shutdown_timeout_seconds = 1
+
+
+class FakeAgent:
+    def __init__(self):
+        self.calls = []
+
+    async def run_task(self, task, context=None):
+        self.calls.append((task, context))
+        return {"status": "completed", "task": task}
+
+
+class FakeLogger:
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+
+def wait_for(predicate, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition was not reached before timeout")
+
+
+def build_app(tmp_path: Path):
+    app = FastAPI()
+    app.state.settings = QueueSettings()
+    app.state.queue = RunQueue(db_path=str(tmp_path / "queue.db"), max_concurrency=3)
+    app.state.agent = FakeAgent()
+    app.state.logger = FakeLogger()
+    install_queue_persistence_v2(app)
+    return app
+
+
+def test_queue_runtime_exposes_orchestrator_state(tmp_path: Path):
+    app = build_app(tmp_path)
+
+    with TestClient(app) as client:
+        response = client.get("/queue/v2/runtime")
+        assert response.status_code == 200
+        runtime = response.json()["queue"]
+
+        assert runtime["orchestrator"] == "v2"
+        assert runtime["accepting_work"] is True
+        assert runtime["max_concurrency"] == 1
+        assert runtime["tracked_tasks"] == 0
+        assert runtime["active_slots"] == {}
+
+
+def test_pause_and_resume_control_queue_scheduling(tmp_path: Path):
+    app = build_app(tmp_path)
+
+    with TestClient(app) as client:
+        paused = client.post("/queue/v2/pause")
+        assert paused.status_code == 200
+        assert paused.json()["queue"]["accepting_work"] is False
+
+        job = app.state.queue.enqueue("resume-me")
+        recover = client.post("/queue/v2/recover")
+        assert recover.status_code == 200
+        assert recover.json()["scheduled_count"] == 0
+        assert app.state.queue.get(job.job_id).status == "queued"
+
+        resumed = client.post("/queue/v2/resume")
+        assert resumed.status_code == 200
+        assert resumed.json()["scheduled_job_ids"] == [job.job_id]
+        wait_for(lambda: app.state.queue.get(job.job_id).status == "completed")
+        assert app.state.agent.calls == [("resume-me", None)]
+
+
+def test_drain_endpoint_validates_timeout_and_pauses_queue(tmp_path: Path):
+    app = build_app(tmp_path)
+
+    with TestClient(app) as client:
+        invalid = client.post("/queue/v2/drain?timeout_seconds=-1")
+        assert invalid.status_code == 400
+
+        drained = client.post("/queue/v2/drain?timeout_seconds=0")
+        assert drained.status_code == 200
+        assert drained.json()["status"] == "drained"
+        assert drained.json()["queue"]["accepting_work"] is False

--- a/tests/test_queue_persistence_v2.py
+++ b/tests/test_queue_persistence_v2.py
@@ -140,7 +140,7 @@ def test_cancelled_running_job_is_not_overwritten_by_runner_result():
     assert final.status == "cancelled"
     assert final.result is None
     assert final.terminal_reason == "cancelled_by_operator"
-    assert any(event["reason"] == "runner_result_discarded_after_cancel" for event in final.history)
+    assert any(event["reason"] == "runner_task_cancelled" for event in final.history)
 
 
 def test_requeue_blocks_exhausted_attempts_unless_forced():
@@ -171,6 +171,9 @@ class FakeAgent:
 
 class FakeLogger:
     def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
         pass
 
 

--- a/tests/test_queue_runtime_settings_v2.py
+++ b/tests/test_queue_runtime_settings_v2.py
@@ -7,8 +7,10 @@ from velocity_claw.core.queue import RunQueue
 
 
 class QueueSettings:
+    queue_max_concurrency = 5
     queue_max_attempts = 7
     queue_recover_on_startup = True
+    queue_shutdown_timeout_seconds = 2
 
 
 class FakeAgent:
@@ -18,6 +20,9 @@ class FakeAgent:
 
 class FakeLogger:
     def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
         pass
 
 
@@ -32,7 +37,7 @@ def test_production_queue_settings_apply_before_startup_scheduling(tmp_path: Pat
 
     app = FastAPI()
     app.state.settings = QueueSettings()
-    app.state.queue = RunQueue(db_path=str(db_path), max_attempts=3, recover_on_startup=False)
+    app.state.queue = RunQueue(db_path=str(db_path), max_concurrency=2, max_attempts=3, recover_on_startup=False)
     app.state.agent = FakeAgent()
     app.state.logger = FakeLogger()
 
@@ -41,6 +46,7 @@ def test_production_queue_settings_apply_before_startup_scheduling(tmp_path: Pat
     install_queue_persistence_v2(app)
 
     recovered = app.state.queue.get(job.job_id)
+    assert app.state.queue.max_concurrency == 5
     assert app.state.queue.max_attempts == 7
     assert app.state.queue.recover_on_startup is True
     assert recovered.status == "queued"

--- a/tests/test_worker_orchestration_v2.py
+++ b/tests/test_worker_orchestration_v2.py
@@ -1,0 +1,186 @@
+import asyncio
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.core.queue import RunQueue
+
+
+async def wait_for(predicate, timeout: float = 2.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("condition was not reached before timeout")
+
+
+def test_worker_pool_bounds_concurrency_and_refills_queued_jobs():
+    async def scenario():
+        queue = RunQueue(max_concurrency=2)
+        jobs = [queue.enqueue(f"task-{index}") for index in range(5)]
+        current = 0
+        maximum = 0
+        observed_slots = set()
+
+        async def runner(task, context):
+            nonlocal current, maximum
+            current += 1
+            maximum = max(maximum, current)
+            job = next(item for item in jobs if item.task == task)
+            observed_slots.add(job.worker_slot)
+            await asyncio.sleep(0.03)
+            current -= 1
+            return {"status": "completed", "task": task}
+
+        initially_scheduled = queue.schedule_pending(runner)
+        assert len(initially_scheduled) == 2
+        assert queue.tracked_task_count() == 2
+
+        await wait_for(lambda: all(job.status == "completed" for job in jobs))
+        await wait_for(lambda: queue.tracked_task_count() == 0)
+
+        assert maximum == 2
+        assert observed_slots == {"slot-1", "slot-2"}
+        assert queue.runtime_summary()["scheduling_capacity"] == 2
+
+    asyncio.run(scenario())
+
+
+def test_cancelling_queued_job_prevents_runner_execution():
+    async def scenario():
+        queue = RunQueue(max_concurrency=1)
+        first = queue.enqueue("first")
+        second = queue.enqueue("second")
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        calls = []
+
+        async def runner(task, context):
+            calls.append(task)
+            if task == "first":
+                first_started.set()
+                await release_first.wait()
+            return {"status": "completed"}
+
+        assert queue.schedule_pending(runner) == [first.job_id]
+        await first_started.wait()
+        cancelled = queue.cancel(second.job_id)
+        assert cancelled.status == "cancelled"
+
+        release_first.set()
+        await wait_for(lambda: first.status == "completed")
+        await wait_for(lambda: queue.tracked_task_count() == 0)
+
+        assert calls == ["first"]
+        assert second.status == "cancelled"
+        assert second.attempts == 0
+
+    asyncio.run(scenario())
+
+
+def test_cancelling_running_job_interrupts_runner_task():
+    async def scenario():
+        queue = RunQueue(max_concurrency=1)
+        job = queue.enqueue("long-running")
+        started = asyncio.Event()
+        interrupted = asyncio.Event()
+
+        async def runner(task, context):
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                interrupted.set()
+                raise
+
+        assert queue.schedule(job.job_id, runner) is True
+        await started.wait()
+        cancelled = queue.cancel(job.job_id)
+        assert cancelled.status == "cancelled"
+
+        await wait_for(interrupted.is_set)
+        await wait_for(lambda: queue.tracked_task_count() == 0)
+
+        assert job.status == "cancelled"
+        assert job.terminal_reason == "cancelled_by_operator"
+        assert job.worker_slot is None
+        assert any(event["reason"] == "runner_task_cancelled" for event in job.history)
+
+    asyncio.run(scenario())
+
+
+def test_drain_pauses_refill_and_resume_schedules_remaining_jobs():
+    async def scenario():
+        queue = RunQueue(max_concurrency=1)
+        first = queue.enqueue("first")
+        second = queue.enqueue("second")
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        calls = []
+
+        async def runner(task, context):
+            calls.append(task)
+            if task == "first":
+                first_started.set()
+                await release_first.wait()
+            return {"status": "completed"}
+
+        queue.schedule_pending(runner)
+        await first_started.wait()
+
+        drained = await queue.drain(timeout_seconds=0.01)
+        assert drained["status"] == "timeout"
+        assert drained["timed_out"] is True
+        assert queue.runtime_summary()["accepting_work"] is False
+
+        release_first.set()
+        await wait_for(lambda: first.status == "completed")
+        await wait_for(lambda: queue.tracked_task_count() == 0)
+        assert second.status == "queued"
+
+        resumed = queue.resume(runner)
+        assert resumed == [second.job_id]
+        await wait_for(lambda: second.status == "completed")
+        assert calls == ["first", "second"]
+
+    asyncio.run(scenario())
+
+
+def test_shutdown_cancels_workers_and_refuses_new_schedules():
+    async def scenario():
+        queue = RunQueue(max_concurrency=1)
+        job = queue.enqueue("shutdown-me")
+        started = asyncio.Event()
+
+        async def runner(task, context):
+            started.set()
+            await asyncio.Event().wait()
+
+        assert queue.schedule(job.job_id, runner) is True
+        await started.wait()
+
+        result = await queue.shutdown(timeout_seconds=1, cancel_running=True)
+        assert result["status"] == "stopped"
+        assert result["timed_out"] is False
+        assert job.status == "cancelled"
+        assert queue.runtime_summary()["accepting_work"] is False
+
+        new_job = queue.enqueue("after-shutdown")
+        assert queue.schedule(new_job.job_id, runner) is False
+
+    asyncio.run(scenario())
+
+
+def test_queue_settings_use_prefixed_environment(monkeypatch):
+    monkeypatch.setenv("VELOCITY_CLAW_ENV", "test")
+    monkeypatch.setenv("VELOCITY_CLAW_QUEUE_MAX_CONCURRENCY", "4")
+    monkeypatch.setenv("VELOCITY_CLAW_QUEUE_MAX_ATTEMPTS", "9")
+    monkeypatch.setenv("VELOCITY_CLAW_QUEUE_RECOVER_ON_STARTUP", "false")
+    monkeypatch.setenv("VELOCITY_CLAW_QUEUE_SHUTDOWN_TIMEOUT_SECONDS", "25")
+
+    settings = Settings()
+
+    assert settings.queue_max_concurrency == 4
+    assert settings.queue_max_attempts == 9
+    assert settings.queue_recover_on_startup is False
+    assert settings.queue_shutdown_timeout_seconds == 25

--- a/velocity_claw/api/app.py
+++ b/velocity_claw/api/app.py
@@ -46,6 +46,8 @@ def _prepare_forced_retry(queue, job) -> None:
 
 
 def install_queue_persistence_v2(app: FastAPI) -> None:
+    from velocity_claw.core.queue_tracking import install_direct_run_tracking
+
     settings = getattr(app.state, "settings", None)
     if settings is not None and hasattr(app.state.queue, "configure_runtime"):
         app.state.queue.configure_runtime(
@@ -53,6 +55,7 @@ def install_queue_persistence_v2(app: FastAPI) -> None:
             max_attempts=getattr(settings, "queue_max_attempts", 3),
             recover_on_startup=getattr(settings, "queue_recover_on_startup", True),
         )
+    install_direct_run_tracking(app.state.queue)
 
     async def startup_queue_recovery() -> None:
         scheduled = app.state.queue.resume(app.state.agent.run_task)

--- a/velocity_claw/api/app.py
+++ b/velocity_claw/api/app.py
@@ -49,12 +49,13 @@ def install_queue_persistence_v2(app: FastAPI) -> None:
     settings = getattr(app.state, "settings", None)
     if settings is not None and hasattr(app.state.queue, "configure_runtime"):
         app.state.queue.configure_runtime(
+            max_concurrency=getattr(settings, "queue_max_concurrency", app.state.queue.max_concurrency),
             max_attempts=getattr(settings, "queue_max_attempts", 3),
             recover_on_startup=getattr(settings, "queue_recover_on_startup", True),
         )
 
     async def startup_queue_recovery() -> None:
-        scheduled = app.state.queue.schedule_pending(app.state.agent.run_task)
+        scheduled = app.state.queue.resume(app.state.agent.run_task)
         app.state.queue_startup_schedule = {
             "scheduled_job_ids": scheduled,
             "scheduled_count": len(scheduled),
@@ -63,7 +64,14 @@ def install_queue_persistence_v2(app: FastAPI) -> None:
         if scheduled:
             app.state.logger.info("Recovered and scheduled %s persisted queue jobs", len(scheduled))
 
+    async def shutdown_queue_workers() -> None:
+        timeout = getattr(settings, "queue_shutdown_timeout_seconds", 10) if settings is not None else 10
+        app.state.queue_shutdown = await app.state.queue.shutdown(timeout_seconds=timeout, cancel_running=True)
+        if app.state.queue_shutdown.get("timed_out"):
+            app.state.logger.warning("Queue shutdown timed out with %s pending tasks", app.state.queue_shutdown["pending_tasks"])
+
     app.router.add_event_handler("startup", startup_queue_recovery)
+    app.router.add_event_handler("shutdown", shutdown_queue_workers)
 
     @app.get("/queue/v2/runtime")
     def queue_runtime_v2():
@@ -82,6 +90,29 @@ def install_queue_persistence_v2(app: FastAPI) -> None:
             "scheduled_count": len(scheduled),
             "queue": app.state.queue.runtime_summary(),
         }
+
+    @app.post("/queue/v2/pause")
+    def queue_pause_v2():
+        return {"status": "ok", "queue": app.state.queue.pause()}
+
+    @app.post("/queue/v2/resume")
+    async def queue_resume_v2():
+        scheduled = app.state.queue.resume(app.state.agent.run_task)
+        return {
+            "status": "ok",
+            "scheduled_job_ids": scheduled,
+            "scheduled_count": len(scheduled),
+            "queue": app.state.queue.runtime_summary(),
+        }
+
+    @app.post("/queue/v2/drain")
+    async def queue_drain_v2(timeout_seconds: float = 10.0):
+        if timeout_seconds < 0 or timeout_seconds > 3600:
+            raise HTTPException(
+                status_code=400,
+                detail={"status": "failed", "error": "invalid_timeout", "detail": "timeout_seconds must be between 0 and 3600"},
+            )
+        return await app.state.queue.drain(timeout_seconds=timeout_seconds)
 
     @app.post("/queue/v2/{job_id}/requeue")
     async def queue_requeue_v2(job_id: str, force: bool = False):
@@ -259,6 +290,7 @@ def create_app() -> FastAPI:
     app.state.api_error_handlers_installed = True
     app.state.version_endpoint_installed = True
     app.state.queue_persistence_v2_installed = True
+    app.state.queue_orchestration_v2_installed = True
     app.state.approval_v2_installed = True
     app.state.run_detail_v2_installed = True
     app.state.diagnostics_v2_installed = True

--- a/velocity_claw/api/diagnostics_v2.py
+++ b/velocity_claw/api/diagnostics_v2.py
@@ -20,8 +20,14 @@ def _queue_summary(
         "completed": sum(1 for job in queue_jobs if job.get("status") == "completed"),
         "failed": sum(1 for job in queue_jobs if job.get("status") == "failed"),
         "cancelled": sum(1 for job in queue_jobs if job.get("status") == "cancelled"),
+        "orchestrator": runtime.get("orchestrator"),
+        "accepting_work": runtime.get("accepting_work", True),
         "active_workers": active_workers,
         "scheduled_workers": runtime.get("scheduled_workers", 0),
+        "tracked_tasks": runtime.get("tracked_tasks", 0),
+        "active_slots": runtime.get("active_slots", {}),
+        "available_slots": runtime.get("available_slots"),
+        "scheduling_capacity": runtime.get("scheduling_capacity"),
         "max_concurrency": runtime.get("max_concurrency", max_concurrency),
         "max_attempts": runtime.get("max_attempts"),
         "persistence_enabled": runtime.get("persistence_enabled", False),
@@ -55,6 +61,8 @@ def _risk_flags(*, settings: Any, release_state: dict[str, Any], queue: dict[str
         flags.append({"level": "medium", "code": "release_not_ready", "message": "Release readiness is not green."})
     if queue.get("failed", 0) > 0:
         flags.append({"level": "medium", "code": "queue_failures", "message": "Queue has failed jobs."})
+    if not queue.get("accepting_work", True):
+        flags.append({"level": "info", "code": "queue_not_accepting_work", "message": "Queue orchestration is paused or draining."})
     recovery = queue.get("startup_recovery") or {}
     if recovery.get("recovered_running", 0) > 0:
         flags.append({"level": "info", "code": "queue_restart_recovery", "message": "Interrupted queue jobs were recovered after restart."})
@@ -109,6 +117,8 @@ def build_diagnostics_v2(
             "queue_queued": queue["queued"],
             "queue_failed": queue["failed"],
             "queue_scheduled": queue["scheduled_workers"],
+            "queue_tracked_tasks": queue["tracked_tasks"],
+            "queue_accepting_work": queue["accepting_work"],
             "queue_recovered_running": (queue.get("startup_recovery") or {}).get("recovered_running", 0),
             "approvals_pending": len(approvals),
             "provider_failures": providers["failed"],
@@ -149,6 +159,9 @@ def build_diagnostics_v2(
             "dashboard_v2": "/dashboard/v2",
             "diagnostics_v2": "/diagnostics/v2",
             "queue_runtime_v2": "/queue/v2/runtime",
+            "queue_pause_v2": "/queue/v2/pause",
+            "queue_resume_v2": "/queue/v2/resume",
+            "queue_drain_v2": "/queue/v2/drain",
             "ops_console": "/ops/console",
             "runs": "/runs",
             "approvals": "/approvals",

--- a/velocity_claw/config/settings.py
+++ b/velocity_claw/config/settings.py
@@ -90,6 +90,10 @@ class Settings:
     provider_max_retries: int = 2
     provider_retry_backoff_ms: int = 250
     provider_health_cooldown_seconds: int = 30
+    queue_max_concurrency: int = 2
+    queue_max_attempts: int = 3
+    queue_recover_on_startup: bool = True
+    queue_shutdown_timeout_seconds: int = 10
 
     def __post_init__(self):
         self.env = get_env("ENV", self.env).strip().lower()
@@ -127,6 +131,10 @@ class Settings:
         self.provider_max_retries = parse_int("PROVIDER_MAX_RETRIES", get_env("PROVIDER_MAX_RETRIES"), self.provider_max_retries, min_value=0, max_value=10)
         self.provider_retry_backoff_ms = parse_int("PROVIDER_RETRY_BACKOFF_MS", get_env("PROVIDER_RETRY_BACKOFF_MS"), self.provider_retry_backoff_ms, min_value=0)
         self.provider_health_cooldown_seconds = parse_int("PROVIDER_HEALTH_COOLDOWN_SECONDS", get_env("PROVIDER_HEALTH_COOLDOWN_SECONDS"), self.provider_health_cooldown_seconds, min_value=0)
+        self.queue_max_concurrency = parse_int("QUEUE_MAX_CONCURRENCY", get_env("QUEUE_MAX_CONCURRENCY"), self.queue_max_concurrency, min_value=1, max_value=64)
+        self.queue_max_attempts = parse_int("QUEUE_MAX_ATTEMPTS", get_env("QUEUE_MAX_ATTEMPTS"), self.queue_max_attempts, min_value=1, max_value=100)
+        self.queue_recover_on_startup = parse_bool(get_env("QUEUE_RECOVER_ON_STARTUP"), self.queue_recover_on_startup)
+        self.queue_shutdown_timeout_seconds = parse_int("QUEUE_SHUTDOWN_TIMEOUT_SECONDS", get_env("QUEUE_SHUTDOWN_TIMEOUT_SECONDS"), self.queue_shutdown_timeout_seconds, min_value=0, max_value=3600)
         self.validate()
 
     def validate(self) -> None:
@@ -154,7 +162,6 @@ class Settings:
     @property
     def safe_mode_prompt(self) -> str:
         from velocity_claw.prompts.safe_mode import SAFE_MODE_PROMPT
-
         return SAFE_MODE_PROMPT
 
 

--- a/velocity_claw/core/queue.py
+++ b/velocity_claw/core/queue.py
@@ -64,6 +64,10 @@ class RunQueue:
         self._semaphore = asyncio.Semaphore(self.max_concurrency)
         self._active_jobs: set[str] = set()
         self._scheduled_jobs: set[str] = set()
+        self._job_tasks: dict[str, asyncio.Task] = {}
+        self._active_slots: dict[str, str] = {}
+        self._accepting_work = True
+        self._last_runner: Optional[Runner] = None
         self._startup_recovery_applied = False
         self.startup_recovery: dict[str, Any] = self._empty_recovery_summary()
         if self.db_path:
@@ -88,9 +92,17 @@ class RunQueue:
     def configure_runtime(
         self,
         *,
+        max_concurrency: int | None = None,
         max_attempts: int | None = None,
         recover_on_startup: bool | None = None,
     ) -> dict[str, Any]:
+        if max_concurrency is not None:
+            configured = max(1, int(max_concurrency))
+            if configured != self.max_concurrency:
+                if self._job_tasks or self._active_jobs:
+                    raise RuntimeError("Queue concurrency cannot change while workers are active")
+                self.max_concurrency = configured
+                self._semaphore = asyncio.Semaphore(self.max_concurrency)
         if max_attempts is not None:
             self.max_attempts = max(1, int(max_attempts))
         if recover_on_startup is not None:
@@ -298,14 +310,23 @@ class RunQueue:
     def scheduled_count(self) -> int:
         return len(self._scheduled_jobs)
 
+    def tracked_task_count(self) -> int:
+        return sum(1 for task in self._job_tasks.values() if not task.done())
+
     def runtime_summary(self) -> dict[str, Any]:
         counts: dict[str, int] = {}
         for job in self.jobs.values():
             counts[job.status] = counts.get(job.status, 0) + 1
         return {
+            "orchestrator": "v2",
             "counts": counts,
+            "accepting_work": self._accepting_work,
             "active_workers": self.active_count(),
             "scheduled_workers": self.scheduled_count(),
+            "tracked_tasks": self.tracked_task_count(),
+            "active_slots": dict(sorted(self._active_slots.items(), key=lambda item: item[1])),
+            "available_slots": max(0, self.max_concurrency - self.active_count()),
+            "scheduling_capacity": max(0, self.max_concurrency - self.tracked_task_count()),
             "max_concurrency": self.max_concurrency,
             "max_attempts": self.max_attempts,
             "persistence_enabled": bool(self.db_path),
@@ -313,19 +334,52 @@ class RunQueue:
             "startup_recovery": dict(self.startup_recovery),
         }
 
+    def pause(self) -> dict[str, Any]:
+        self._accepting_work = False
+        return self.runtime_summary()
+
+    def resume(self, runner: Optional[Runner] = None) -> list[str]:
+        self._accepting_work = True
+        if runner is not None:
+            self._last_runner = runner
+        if self._last_runner is None:
+            return []
+        return self.schedule_pending(self._last_runner)
+
+    def _cancel_task(self, task: asyncio.Task) -> None:
+        if task.done():
+            return
+        try:
+            task_loop = task.get_loop()
+            try:
+                current_loop = asyncio.get_running_loop()
+            except RuntimeError:
+                current_loop = None
+            if current_loop is task_loop:
+                task.cancel()
+            else:
+                task_loop.call_soon_threadsafe(task.cancel)
+        except RuntimeError:
+            pass
+
     def cancel(self, job_id: str) -> Optional[QueueJob]:
         job = self.jobs.get(job_id)
         if not job:
             return None
         if job.status in TERMINAL_STATUSES:
             return job
+        was_running = job.status == "running"
         job.status = "cancelled"
         job.terminal_reason = "cancelled_by_operator"
-        job.worker_slot = None
+        if not was_running:
+            job.worker_slot = None
         job.scheduled_at = None
         job.updated_at = _now()
         self._append_history(job, "cancelled", job.terminal_reason)
         self._persist_job(job)
+        task = self._job_tasks.get(job_id)
+        if task is not None:
+            self._cancel_task(task)
         return job
 
     def requeue(self, job_id: str, *, force: bool = False) -> Optional[QueueJob]:
@@ -355,11 +409,40 @@ class RunQueue:
         self._persist_job(job)
         return job
 
+    def _allocate_worker_slot(self, job_id: str) -> str:
+        used = set(self._active_slots.values())
+        for index in range(1, self.max_concurrency + 1):
+            slot = f"slot-{index}"
+            if slot not in used:
+                self._active_slots[job_id] = slot
+                return slot
+        slot = f"slot-{len(used) + 1}"
+        self._active_slots[job_id] = slot
+        return slot
+
+    def _on_task_done(self, job_id: str, runner: Runner, task: asyncio.Task) -> None:
+        self._job_tasks.pop(job_id, None)
+        self._scheduled_jobs.discard(job_id)
+        job = self.jobs.get(job_id)
+        if job is not None:
+            if task.cancelled() and job.status == "queued":
+                job.status = "cancelled"
+                job.terminal_reason = "worker_task_cancelled_before_start"
+                self._append_history(job, "cancelled", job.terminal_reason)
+            if job.scheduled_at is not None:
+                job.scheduled_at = None
+                job.updated_at = _now()
+            self._persist_job(job)
+        if self._accepting_work:
+            self.schedule_pending(runner)
+
     def schedule(self, job_id: str, runner: Runner) -> bool:
         job = self.jobs.get(job_id)
-        if not job or job.status != "queued":
+        if not self._accepting_work or not job or job.status != "queued":
             return False
-        if job_id in self._scheduled_jobs or job_id in self._active_jobs:
+        if job_id in self._job_tasks or job_id in self._scheduled_jobs or job_id in self._active_jobs:
+            return False
+        if self.tracked_task_count() >= self.max_concurrency:
             return False
         if job.attempts >= self.max_attempts:
             job.status = "failed"
@@ -378,31 +461,31 @@ class RunQueue:
             self._persist_job(job)
             return False
 
+        self._last_runner = runner
         job.scheduled_at = _now()
         job.updated_at = job.scheduled_at
         self._append_history(job, "queued", "worker_task_scheduled")
         self._persist_job(job)
         self._scheduled_jobs.add(job_id)
-        loop.create_task(self._run_scheduled(job_id, runner))
+        task = loop.create_task(self._run_scheduled(job_id, runner), name=f"velocity-claw-job-{job_id}")
+        self._job_tasks[job_id] = task
+        task.add_done_callback(lambda completed, current_job=job_id: self._on_task_done(current_job, runner, completed))
         return True
 
     def schedule_pending(self, runner: Runner) -> list[str]:
-        scheduled = []
+        self._last_runner = runner
+        if not self._accepting_work:
+            return []
+        scheduled: list[str] = []
         for job_id in self.pending_job_ids():
+            if self.tracked_task_count() >= self.max_concurrency:
+                break
             if self.schedule(job_id, runner):
                 scheduled.append(job_id)
         return scheduled
 
     async def _run_scheduled(self, job_id: str, runner: Runner) -> Optional[QueueJob]:
-        try:
-            return await self.run_job(job_id, runner)
-        finally:
-            self._scheduled_jobs.discard(job_id)
-            job = self.jobs.get(job_id)
-            if job and job.scheduled_at is not None:
-                job.scheduled_at = None
-                job.updated_at = _now()
-                self._persist_job(job)
+        return await self.run_job(job_id, runner)
 
     async def run_job(self, job_id: str, runner: Runner) -> Optional[QueueJob]:
         job = self.jobs.get(job_id)
@@ -416,39 +499,89 @@ class RunQueue:
             self._persist_job(job)
             return job
 
-        async with self._semaphore:
-            if job.status != "queued":
-                return job
-            self._active_jobs.add(job.job_id)
-            job.status = "running"
-            job.attempts += 1
-            job.last_attempt_started_at = _now()
-            job.worker_slot = f"slot-{self.active_count()}"
-            job.updated_at = job.last_attempt_started_at
-            self._append_history(job, "running", f"attempt_{job.attempts}_started")
-            self._persist_job(job)
-            try:
-                result = await runner(job.task, job.context)
-                if job.status == "cancelled":
-                    self._append_history(job, "cancelled", "runner_result_discarded_after_cancel")
-                else:
-                    job.result = result
-                    job.status = "completed"
-                    job.error = None
-                    job.terminal_reason = "runner_completed"
-                    self._append_history(job, "completed", job.terminal_reason)
-            except Exception as exc:
-                if job.status == "cancelled":
-                    self._append_history(job, "cancelled", "runner_exception_after_cancel")
-                else:
-                    job.error = str(exc)
-                    job.status = "failed"
-                    job.terminal_reason = "runner_exception"
-                    self._append_history(job, "failed", job.terminal_reason)
-            finally:
-                job.worker_slot = None
-                job.scheduled_at = None
-                job.updated_at = _now()
-                self._active_jobs.discard(job.job_id)
+        try:
+            async with self._semaphore:
+                if job.status != "queued":
+                    return job
+                self._active_jobs.add(job.job_id)
+                job.status = "running"
+                job.attempts += 1
+                job.last_attempt_started_at = _now()
+                job.worker_slot = self._allocate_worker_slot(job.job_id)
+                job.updated_at = job.last_attempt_started_at
+                self._append_history(job, "running", f"attempt_{job.attempts}_started")
                 self._persist_job(job)
+                try:
+                    result = await runner(job.task, job.context)
+                    if job.status == "cancelled":
+                        self._append_history(job, "cancelled", "runner_result_discarded_after_cancel")
+                    else:
+                        job.result = result
+                        job.status = "completed"
+                        job.error = None
+                        job.terminal_reason = "runner_completed"
+                        self._append_history(job, "completed", job.terminal_reason)
+                except asyncio.CancelledError:
+                    if job.status != "cancelled":
+                        job.status = "cancelled"
+                        job.terminal_reason = "worker_task_cancelled"
+                    self._append_history(job, "cancelled", "runner_task_cancelled")
+                except Exception as exc:
+                    if job.status == "cancelled":
+                        self._append_history(job, "cancelled", "runner_exception_after_cancel")
+                    else:
+                        job.error = str(exc)
+                        job.status = "failed"
+                        job.terminal_reason = "runner_exception"
+                        self._append_history(job, "failed", job.terminal_reason)
+                finally:
+                    job.worker_slot = None
+                    job.scheduled_at = None
+                    job.updated_at = _now()
+                    self._active_slots.pop(job.job_id, None)
+                    self._active_jobs.discard(job.job_id)
+                    self._persist_job(job)
+                return job
+        except asyncio.CancelledError:
+            if job.status != "cancelled":
+                job.status = "cancelled"
+                job.terminal_reason = "worker_task_cancelled_before_start"
+            job.worker_slot = None
+            job.scheduled_at = None
+            job.updated_at = _now()
+            self._active_slots.pop(job.job_id, None)
+            self._active_jobs.discard(job.job_id)
+            self._append_history(job, "cancelled", job.terminal_reason)
+            self._persist_job(job)
             return job
+
+    async def drain(self, timeout_seconds: float = 10.0) -> dict[str, Any]:
+        self._accepting_work = False
+        tasks = [task for task in self._job_tasks.values() if not task.done()]
+        if not tasks:
+            return {"status": "drained", "timed_out": False, "pending_tasks": 0, "queue": self.runtime_summary()}
+        _, pending = await asyncio.wait(tasks, timeout=max(0.0, float(timeout_seconds)))
+        return {
+            "status": "timeout" if pending else "drained",
+            "timed_out": bool(pending),
+            "pending_tasks": len(pending),
+            "queue": self.runtime_summary(),
+        }
+
+    async def shutdown(self, timeout_seconds: float = 10.0, *, cancel_running: bool = True) -> dict[str, Any]:
+        self._accepting_work = False
+        tasks = [task for task in self._job_tasks.values() if not task.done()]
+        if cancel_running:
+            for job_id in list(self._job_tasks):
+                self.cancel(job_id)
+        if tasks:
+            _, pending = await asyncio.wait(tasks, timeout=max(0.0, float(timeout_seconds)))
+        else:
+            pending = set()
+        return {
+            "status": "timeout" if pending else "stopped",
+            "timed_out": bool(pending),
+            "pending_tasks": len(pending),
+            "cancel_running": cancel_running,
+            "queue": self.runtime_summary(),
+        }

--- a/velocity_claw/core/queue_tracking.py
+++ b/velocity_claw/core/queue_tracking.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Any
+
+
+def install_direct_run_tracking(queue: Any) -> None:
+    """Make legacy direct ``run_job`` calls participate in orchestration v2.
+
+    The classic API route creates an asyncio task around ``run_job``. This adapter
+    registers that task in the same task registry used by ``schedule`` and refuses
+    to start it when tracked capacity is already full. The job then stays queued
+    and is picked up by the normal FIFO refill path.
+    """
+    if getattr(queue, "_direct_run_tracking_installed", False):
+        return
+
+    original_run_job = queue.run_job
+
+    async def tracked_run_job(job_id, runner):
+        job = queue.get(job_id)
+        current_task = asyncio.current_task()
+
+        if current_task is None or job_id in queue._job_tasks:
+            return await original_run_job(job_id, runner)
+
+        queue._last_runner = runner
+        if not queue._accepting_work or queue.tracked_task_count() >= queue.max_concurrency:
+            return job
+        if job is None or job.status != "queued":
+            return job
+
+        scheduled_at = datetime.now().isoformat()
+        job.scheduled_at = scheduled_at
+        job.updated_at = scheduled_at
+        queue._append_history(job, "queued", "legacy_worker_task_tracked")
+        queue._persist_job(job)
+        queue._scheduled_jobs.add(job_id)
+        queue._job_tasks[job_id] = current_task
+        current_task.add_done_callback(
+            lambda completed, current_job=job_id: queue._on_task_done(current_job, runner, completed)
+        )
+        return await original_run_job(job_id, runner)
+
+    queue.run_job = tracked_run_job
+    queue._direct_run_tracking_installed = True


### PR DESCRIPTION
## Summary

Implements issue #30: bounded worker orchestration with explicit lifecycle control.

Changes:
- track concrete asyncio task handles per queue job
- cap scheduled tasks at configured concurrency instead of creating an unbounded waiting task set
- automatically refill worker capacity from the oldest queued jobs
- allocate deterministic reusable worker slots
- cancel scheduled and running coroutine tasks on operator cancellation
- add pause, resume, drain, and graceful shutdown lifecycle controls
- expose orchestration state through Queue runtime and Diagnostics v2
- add prefixed queue concurrency, retry, recovery, and shutdown settings
- add Queue v2 lifecycle endpoints
- document the worker orchestration model in `docs/QUEUE.md`
- add concurrency, cancellation, drain, shutdown, settings, API, and legacy-route regression tests

Review fix:
- existing `/queue/submit` still creates a raw task around `run_job`
- production installation now registers that task in the shared worker registry
- legacy submissions therefore respect capacity, participate in drain/shutdown, support real cancellation, and trigger FIFO refill

Validation:
- complete pytest suite: passed
- package validation: passed
- wheel and source build: passed
- build-artifacts workflow: passed
- P1 review thread: fixed and resolved

Closes #30 when merged.