### PR TITLE
Add repo-aware planning and memory v2

### DIFF
--- a/tests/test_repo_memory_v2.py
+++ b/tests/test_repo_memory_v2.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.memory import MemoryStore
+from velocity_claw.memory.relevance import similarity, tokenize
+from velocity_claw.planner.planner import Planner
+
+
+class DummyRouter:
+    async def route(self, task_type, prompt):
+        return {"text": '{"task":"x","steps":[]}'}
+
+
+def make_memory(tmp_path: Path, monkeypatch) -> MemoryStore:
+    monkeypatch.setenv("VELOCITY_CLAW_ENV", "test")
+    monkeypatch.setenv("VELOCITY_CLAW_MEMORY_DB_PATH", str(tmp_path / "memory.db"))
+    return MemoryStore(Settings())
+
+
+def test_similarity_matches_related_tasks_without_full_substring():
+    score = similarity(
+        "Improve queue worker cancellation and concurrency",
+        "Fix concurrency limits for cancelled queue workers",
+    )
+
+    assert score >= 0.5
+    assert "concurrency" in tokenize("Concurrency controls")
+    assert similarity("queue worker", "telegram authorization") == 0.0
+
+
+def test_reusable_knowledge_is_separated_from_run_trace(tmp_path: Path, monkeypatch):
+    memory = make_memory(tmp_path, monkeypatch)
+    memory.save_project_fact("package_manager", "pip")
+    memory.save_project_note("task", "Inspect package manager")
+    memory.save_project_note("run_summary", "Run completed")
+    memory.save_reusable_knowledge("architecture", "FastAPI production wrapper installs API hardening")
+    memory.save_reusable_knowledge("constraint", "Shell execution stays disabled by default")
+    memory.save_reusable_knowledge("architecture", "FastAPI production wrapper installs API hardening")
+
+    context = memory.build_repo_context_summary(limit=10)
+    knowledge = context["project_knowledge_v2"]
+
+    assert context["memory_model"] == "repo-aware-v2"
+    assert knowledge["facts"]["package_manager"] == "pip"
+    assert [item["note_type"] for item in knowledge["reusable_notes"]] == ["constraint", "architecture"]
+    assert len(knowledge["reusable_notes"]) == 2
+    assert all(item["note_type"] not in {"task", "run_summary"} for item in knowledge["reusable_notes"])
+
+
+def test_related_runs_are_ranked_and_current_running_run_is_excluded(tmp_path: Path, monkeypatch):
+    memory = make_memory(tmp_path, monkeypatch)
+
+    related = memory.create_run("Fix queue cancellation and worker concurrency")
+    memory.update_run_status(related, "completed")
+
+    failed = memory.create_run("Queue worker concurrency regression")
+    memory.update_run_status(failed, "failed")
+
+    unrelated = memory.create_run("Update Telegram welcome message")
+    memory.update_run_status(unrelated, "completed")
+
+    current = memory.create_run("Improve queue worker cancellation")
+    memory.save_project_fact("last_task", "Improve queue worker cancellation")
+
+    planning = memory.build_planning_context(limit=5)
+    ranked_ids = [item["run_id"] for item in planning["related_runs"]]
+
+    assert planning["memory_model"] == "repo-aware-v2"
+    assert planning["avoid_rediscovery"] is True
+    assert current not in ranked_ids
+    assert unrelated not in ranked_ids
+    assert ranked_ids[0] in {related, failed}
+    assert failed in [item["run_id"] for item in planning["related_failed_runs"]]
+
+
+def test_resume_context_replaces_literal_matching_with_ranked_related_runs(tmp_path: Path, monkeypatch):
+    memory = make_memory(tmp_path, monkeypatch)
+    run_id = memory.create_run("Repair dependency audit release workflow")
+    memory.update_run_status(run_id, "completed")
+    memory.save_reusable_knowledge("decision", "Release validation runs before tag creation")
+
+    context = memory.build_resume_context("Fix release workflow dependency audit")
+
+    assert context["memory_model"] == "repo-aware-v2"
+    assert context["related_runs"][0]["run_id"] == run_id
+    assert context["related_runs"][0]["similarity"] > 0
+    assert context["project_knowledge"]["reusable_notes"][0]["note_type"] == "decision"
+    assert "Reuse saved facts" in context["reuse_hint"]
+
+
+def test_planner_prompt_includes_repo_aware_signals():
+    planner = Planner(DummyRouter())
+    prompt = planner._build_plan_prompt(
+        "Fix queue cancellation",
+        {
+            "project_root": ".",
+            "planning_context": {
+                "memory_model": "repo-aware-v2",
+                "project_knowledge": {
+                    "facts": {"framework": "FastAPI"},
+                    "reusable_notes": [{"note_type": "constraint", "content": "Do not bypass auth"}],
+                    "signals": {},
+                },
+                "related_runs": [{"run_id": "run-1", "task": "Queue cancellation regression", "status": "completed", "similarity": 0.75}],
+                "related_failed_runs": [],
+                "avoid_rediscovery": True,
+            },
+        },
+    )
+
+    assert "Reusable project knowledge" in prompt
+    assert "Related prior runs ranked by relevance" in prompt
+    assert "Avoid rediscovery" in prompt
+    assert "Do not bypass auth" in prompt

--- a/velocity_claw/memory/__init__.py
+++ b/velocity_claw/memory/__init__.py
@@ -1,1 +1,8 @@
 """Velocity Claw memory package."""
+
+from velocity_claw.memory.repo_context import install_repo_aware_memory_v2
+from velocity_claw.memory.store import MemoryStore
+
+install_repo_aware_memory_v2(MemoryStore)
+
+__all__ = ["MemoryStore"]

--- a/velocity_claw/memory/relevance.py
+++ b/velocity_claw/memory/relevance.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+STOP_WORDS = {
+    "the", "and", "for", "from", "with", "into", "that", "this", "task", "run", "retry", "fix",
+    "update", "add", "create", "implement", "для", "что", "это", "как", "или", "при", "про",
+}
+
+
+def tokenize(value: str | None) -> set[str]:
+    text = (value or "").lower().replace("_", " ").replace("-", " ")
+    tokens = re.findall(r"[a-zа-яё0-9.]{3,}", text, flags=re.IGNORECASE)
+    return {token for token in tokens if token not in STOP_WORDS and not token.isdigit()}
+
+
+def similarity(query: str, candidate: str) -> float:
+    query_tokens = tokenize(query)
+    candidate_tokens = tokenize(candidate)
+    if not query_tokens or not candidate_tokens:
+        return 0.0
+    overlap = query_tokens & candidate_tokens
+    if not overlap:
+        return 0.0
+    coverage = len(overlap) / len(query_tokens)
+    precision = len(overlap) / len(candidate_tokens)
+    return round((coverage * 0.7) + (precision * 0.3), 4)
+
+
+def compact_run(run: dict[str, Any], score: float | None = None) -> dict[str, Any]:
+    payload = {
+        "run_id": run.get("run_id"),
+        "task": run.get("task"),
+        "status": run.get("status"),
+        "created_at": run.get("created_at"),
+        "completed_at": run.get("completed_at"),
+    }
+    if score is not None:
+        payload["similarity"] = score
+    report = run.get("report") or {}
+    if report.get("executive_summary"):
+        payload["executive_summary"] = report["executive_summary"]
+    forensics = run.get("forensics") or {}
+    if forensics.get("failed_step"):
+        payload["failed_step"] = forensics["failed_step"]
+    return payload

--- a/velocity_claw/memory/repo_context.py
+++ b/velocity_claw/memory/repo_context.py
@@ -60,6 +60,8 @@ class RepoKnowledgeIndex:
     def related_runs(self, task: str, limit: int = 5, min_score: float = 0.18) -> list[dict[str, Any]]:
         ranked: list[tuple[float, dict[str, Any]]] = []
         for summary in self.memory.list_recent_runs(limit=100):
+            if summary.get("status") == "running":
+                continue
             score = similarity(task, summary.get("task") or "")
             if score < min_score:
                 continue
@@ -133,8 +135,9 @@ def install_repo_aware_memory_v2(memory_cls: type) -> None:
 
     def build_planning_context(self, limit: int = 5, task: str | None = None):
         payload = original_planning(self, limit=limit)
-        if task:
-            payload.update(RepoKnowledgeIndex(self).build_planning_context(task, limit=limit))
+        current_task = task or self.load_project_fact("last_task")
+        if current_task:
+            payload.update(RepoKnowledgeIndex(self).build_planning_context(str(current_task), limit=limit))
         else:
             payload["project_knowledge"] = RepoKnowledgeIndex(self).build_project_knowledge(limit=max(limit, 5))
             payload["avoid_rediscovery"] = bool(payload["project_knowledge"]["facts"] or payload["project_knowledge"]["reusable_notes"])

--- a/velocity_claw/memory/repo_context.py
+++ b/velocity_claw/memory/repo_context.py
@@ -115,3 +115,46 @@ class RepoKnowledgeIndex:
             "recent_trace": self.trace_notes(limit=limit),
             "reuse_hint": "Reuse saved facts, decisions, constraints, and successful prior findings before repeating repository inspection.",
         }
+
+
+def install_repo_aware_memory_v2(memory_cls: type) -> None:
+    if getattr(memory_cls, "_repo_aware_v2_installed", False):
+        return
+
+    original_repo_summary = memory_cls.build_repo_context_summary
+    original_planning = memory_cls.build_planning_context
+    original_resume = memory_cls.build_resume_context
+
+    def build_repo_context_summary(self, limit: int = 5):
+        payload = original_repo_summary(self, limit=limit)
+        payload["project_knowledge_v2"] = RepoKnowledgeIndex(self).build_project_knowledge(limit=max(limit, 5))
+        payload["memory_model"] = "repo-aware-v2"
+        return payload
+
+    def build_planning_context(self, limit: int = 5, task: str | None = None):
+        payload = original_planning(self, limit=limit)
+        if task:
+            payload.update(RepoKnowledgeIndex(self).build_planning_context(task, limit=limit))
+        else:
+            payload["project_knowledge"] = RepoKnowledgeIndex(self).build_project_knowledge(limit=max(limit, 5))
+            payload["avoid_rediscovery"] = bool(payload["project_knowledge"]["facts"] or payload["project_knowledge"]["reusable_notes"])
+        payload["memory_model"] = "repo-aware-v2"
+        return payload
+
+    def build_resume_context(self, task: str, limit: int = 5):
+        payload = original_resume(self, task, limit=limit)
+        payload.update(RepoKnowledgeIndex(self).build_resume_context(task, limit=limit))
+        payload["memory_model"] = "repo-aware-v2"
+        return payload
+
+    def save_reusable_knowledge(self, knowledge_type: str, content: str):
+        note_type = str(knowledge_type or "knowledge").strip().lower()
+        if note_type not in REUSABLE_NOTE_TYPES and not note_type.startswith("knowledge:"):
+            note_type = f"knowledge:{note_type}"
+        self.save_project_note(note_type, str(content).strip())
+
+    memory_cls.build_repo_context_summary = build_repo_context_summary
+    memory_cls.build_planning_context = build_planning_context
+    memory_cls.build_resume_context = build_resume_context
+    memory_cls.save_reusable_knowledge = save_reusable_knowledge
+    memory_cls._repo_aware_v2_installed = True

--- a/velocity_claw/memory/repo_context.py
+++ b/velocity_claw/memory/repo_context.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from velocity_claw.memory.relevance import compact_run, similarity, tokenize
+
+
+REUSABLE_NOTE_TYPES = {
+    "architecture",
+    "constraint",
+    "decision",
+    "dependency",
+    "convention",
+    "repository",
+    "project",
+    "knowledge",
+}
+
+TRACE_NOTE_TYPES = {
+    "task",
+    "plan_summary",
+    "run_summary",
+    "run_error",
+    "approval_pause",
+    "auto_fix",
+}
+
+
+class RepoKnowledgeIndex:
+    def __init__(self, memory: Any):
+        self.memory = memory
+
+    def reusable_notes(self, limit: int = 10) -> list[dict[str, Any]]:
+        notes = []
+        seen: set[tuple[str, str]] = set()
+        for note in self.memory.load_recent_project_notes(limit=max(limit * 5, 20)):
+            note_type = str(note.get("note_type") or "").strip().lower()
+            content = str(note.get("content") or "").strip()
+            if not content or note_type in TRACE_NOTE_TYPES:
+                continue
+            if note_type not in REUSABLE_NOTE_TYPES and not note_type.startswith("knowledge:"):
+                continue
+            key = (note_type, content.lower())
+            if key in seen:
+                continue
+            seen.add(key)
+            notes.append(note)
+            if len(notes) >= limit:
+                break
+        return notes
+
+    def trace_notes(self, limit: int = 10) -> list[dict[str, Any]]:
+        return [
+            note
+            for note in self.memory.load_recent_project_notes(limit=max(limit * 3, 20))
+            if str(note.get("note_type") or "").strip().lower() in TRACE_NOTE_TYPES
+        ][:limit]
+
+    def related_runs(self, task: str, limit: int = 5, min_score: float = 0.18) -> list[dict[str, Any]]:
+        ranked: list[tuple[float, dict[str, Any]]] = []
+        for summary in self.memory.list_recent_runs(limit=100):
+            score = similarity(task, summary.get("task") or "")
+            if score < min_score:
+                continue
+            full = self.memory.load_run(summary["run_id"]) or summary
+            ranked.append((score, compact_run(full, score=score)))
+        ranked.sort(key=lambda item: (item[0], item[1].get("created_at") or ""), reverse=True)
+        return [payload for _, payload in ranked[:limit]]
+
+    def recurring_signals(self, limit: int = 50) -> dict[str, Any]:
+        status_counts: Counter[str] = Counter()
+        topic_counts: Counter[str] = Counter()
+        failed_topics: Counter[str] = Counter()
+        for run in self.memory.list_recent_runs(limit=limit):
+            status = str(run.get("status") or "unknown")
+            status_counts[status] += 1
+            topics = tokenize(run.get("task") or "")
+            topic_counts.update(topics)
+            if status == "failed":
+                failed_topics.update(topics)
+        return {
+            "run_status_counts": dict(status_counts),
+            "recurring_topics": [token for token, count in topic_counts.most_common(8) if count > 1],
+            "recurring_failure_topics": [token for token, count in failed_topics.most_common(8) if count > 1],
+        }
+
+    def build_project_knowledge(self, limit: int = 10) -> dict[str, Any]:
+        facts = self.memory.list_project_facts()
+        notes = self.reusable_notes(limit=limit)
+        return {
+            "facts": facts,
+            "reusable_notes": notes,
+            "signals": self.recurring_signals(),
+            "counts": {"facts": len(facts), "reusable_notes": len(notes)},
+        }
+
+    def build_planning_context(self, task: str, limit: int = 5) -> dict[str, Any]:
+        knowledge = self.build_project_knowledge(limit=max(limit, 5))
+        related = self.related_runs(task, limit=limit)
+        return {
+            "project_knowledge": knowledge,
+            "related_runs": related,
+            "related_failed_runs": [run for run in related if run.get("status") == "failed"],
+            "avoid_rediscovery": bool(knowledge["facts"] or knowledge["reusable_notes"] or related),
+        }
+
+    def build_resume_context(self, task: str, limit: int = 5) -> dict[str, Any]:
+        related = self.related_runs(task, limit=limit)
+        return {
+            "task": task,
+            "project_knowledge": self.build_project_knowledge(limit=max(limit, 5)),
+            "related_runs": related,
+            "related_failed_runs": [run for run in related if run.get("status") == "failed"],
+            "recent_trace": self.trace_notes(limit=limit),
+            "reuse_hint": "Reuse saved facts, decisions, constraints, and successful prior findings before repeating repository inspection.",
+        }

--- a/velocity_claw/planner/planner.py
+++ b/velocity_claw/planner/planner.py
@@ -102,6 +102,7 @@ class Planner:
             "Не начинай план с patch.apply, fs.write, shell.run или git.run, если сначала можно понять ситуацию через inspection tools.",
             "Перед редактированием предпочитай сначала хотя бы один из шагов: git.inspect, code.find_symbol, code.read_symbol, test.run, fs.read или analysis.",
             "Если memory signals показывают repeated failures, pending approvals или свежий failure pattern, учитывай это прямо в порядке шагов.",
+            "Если repo-aware memory уже содержит проверенные facts, решения, ограничения или результаты похожих запусков, используй их и не повторяй то же исследование без причины.",
             f"Задача: {task}",
         ]
         if context.get("project_root"):
@@ -112,6 +113,17 @@ class Planner:
             project_facts = planning_context.get("project_facts") or {}
             if project_facts:
                 instructions.append(f"Project facts: {json.dumps(project_facts, ensure_ascii=False)}")
+            project_knowledge = planning_context.get("project_knowledge") or {}
+            if project_knowledge:
+                instructions.append(f"Reusable project knowledge: {json.dumps(project_knowledge, ensure_ascii=False)}")
+            related_runs = planning_context.get("related_runs") or []
+            if related_runs:
+                instructions.append(f"Related prior runs ranked by relevance: {json.dumps(related_runs[:5], ensure_ascii=False)}")
+            related_failed = planning_context.get("related_failed_runs") or []
+            if related_failed:
+                instructions.append(f"Related failed runs: {json.dumps(related_failed[:5], ensure_ascii=False)}")
+            if planning_context.get("avoid_rediscovery"):
+                instructions.append("Avoid rediscovery: prefer saved knowledge and prior successful findings; inspect again only when stale, missing, or contradicted.")
             recent_tasks = planning_context.get("recent_run_tasks") or []
             if recent_tasks:
                 instructions.append(f"Recent run tasks: {json.dumps(recent_tasks, ensure_ascii=False)}")


### PR DESCRIPTION
## Summary

Implements issue #32: stronger project-aware planning and reusable memory across runs.

Changes:
- add token-based task similarity instead of literal full-string matching
- rank related prior runs and include compact reports/failure context
- exclude the current running job from prior-run memory
- separate reusable project knowledge from noisy run trace notes
- deduplicate durable architecture, constraint, decision, dependency, convention, repository, and project notes
- add recurring topic and failure-topic signals
- preserve existing MemoryStore APIs through a compatibility layer
- expose `memory_model: repo-aware-v2` and project knowledge through existing context/resume surfaces
- teach the planner to reuse saved facts, decisions, constraints, and related-run findings before repeating inspection
- add contract tests for ranking, filtering, planner prompts, and resume context

Validation targets:
- complete pytest suite
- package validation
- dependency audit
- wheel and source build

Closes #32 when merged.