### PR TITLE
Use repo-aware memory signals in planner prompts

### DIFF
--- a/docs/PROJECT_MEMORY.md
+++ b/docs/PROJECT_MEMORY.md
@@ -18,6 +18,8 @@ Planning and resume artifacts include `project_memory_v2`. The agent also projec
 - `recent_failed_tasks` for related failures;
 - `memory_signals_v2` for reuse and inspection hints.
 
+The Planner consumes `memory_signals_v2` directly. A prior successful related run produces an explicit reuse directive, while a related failure strengthens inspection-first planning before edits.
+
 Related runs are ranked by meaningful term overlap and recency rather than exact full-task substring matching. The current active run is removed before context reaches the Planner.
 
 Existing API responses remain compatible:

--- a/tests/test_planner_memory_signals_v2.py
+++ b/tests/test_planner_memory_signals_v2.py
@@ -1,0 +1,57 @@
+from velocity_claw.planner.planner import Planner
+
+
+class DummyRouter:
+    async def route(self, task_type, prompt):
+        return {"text": '{"task":"x","steps":[]}'}
+
+
+def make_prompt(signals):
+    planner = Planner(DummyRouter())
+    return planner._build_plan_prompt(
+        "Fix queue cancellation",
+        {
+            "project_root": ".",
+            "planning_context": {
+                "project_facts": {"knowledge.queue.path": "velocity_claw/core/queue.py"},
+                "recent_run_tasks": ["Repair queue worker cancellation"],
+                "recent_failed_tasks": ["Queue worker cancellation regression"],
+                "memory_signals_v2": signals,
+            },
+        },
+    )
+
+
+def test_prompt_includes_reuse_signal_and_prior_success_directive():
+    prompt = make_prompt(
+        {
+            "related_run_count": 2,
+            "reuse_prior_success": True,
+            "inspect_before_edit": False,
+        }
+    )
+
+    assert "Repo-aware memory signals" in prompt
+    assert '"reuse_prior_success": true' in prompt
+    assert "successful" in prompt.lower() or "успешного" in prompt.lower()
+
+
+def test_prompt_includes_failure_inspection_directive():
+    prompt = make_prompt(
+        {
+            "related_run_count": 3,
+            "reuse_prior_success": False,
+            "inspect_before_edit": True,
+        }
+    )
+
+    assert '"inspect_before_edit": true' in prompt
+    assert "inspection-first" in prompt
+    assert "failure context" in prompt
+
+
+def test_prompt_omits_v2_directives_when_signals_are_empty():
+    prompt = make_prompt({})
+
+    assert "Repo-aware memory signals" not in prompt
+    assert '"inspect_before_edit": true' not in prompt

--- a/velocity_claw/planner/planner.py
+++ b/velocity_claw/planner/planner.py
@@ -125,6 +125,13 @@ class Planner:
             if recent_notes:
                 compact_notes = [f"{item.get('note_type')}: {item.get('content')}" for item in recent_notes[:5]]
                 instructions.append(f"Recent project notes: {json.dumps(compact_notes, ensure_ascii=False)}")
+            memory_signals = planning_context.get("memory_signals_v2") or {}
+            if memory_signals:
+                instructions.append(f"Repo-aware memory signals: {json.dumps(memory_signals, ensure_ascii=False)}")
+                if memory_signals.get("reuse_prior_success"):
+                    instructions.append("Переиспользуй проверенные результаты похожего успешного запуска и не повторяй то же исследование без признаков устаревания или противоречия.")
+                if memory_signals.get("inspect_before_edit"):
+                    instructions.append("Есть связанные прошлые ошибки: перед редактированием обязательно проверь актуальное состояние через inspection-first шаги и учти прежний failure context.")
             last_failed = planning_context.get("last_failed_run")
             if last_failed:
                 instructions.append(f"Last failed run: {json.dumps(last_failed, ensure_ascii=False)}")


### PR DESCRIPTION
## Summary

Small follow-up to merged PR #118.

Changes:
- read `memory_signals_v2` directly in the Planner prompt
- add an explicit reuse directive when a related successful run exists
- strengthen inspection-first planning when related failures exist
- keep the existing compact projections (`project_facts`, `recent_notes`, related tasks) instead of duplicating the full `project_memory_v2` payload
- document the prompt behavior
- add focused planner contract tests

This carries forward the only non-duplicated improvement from superseded PR #120.

Validation targets:
- complete pytest suite
- package validation
- dependency audit
- package build