### PR TITLE
Complete Dashboard v2 run filtering and inspection

### DIFF
--- a/docs/DASHBOARD_V2.md
+++ b/docs/DASHBOARD_V2.md
@@ -1,0 +1,57 @@
+# Dashboard v2 operator guide
+
+`GET /dashboard/v2` is the primary HTML operations view for Velocity Claw.
+
+## Run list
+
+The Recent runs table shows:
+
+- run id;
+- task;
+- status badge;
+- execution profile;
+- creation time;
+- operator links.
+
+The run id and the `inspect` action open the existing HTML run inspector at:
+
+```text
+/runs/<run_id>/view
+```
+
+That page exposes the run summary, step table, failures, planning and resume context, approval history, forensics, and artifact previews without requiring an operator to read raw JSON.
+
+Structured JSON remains available through `detail v2`, `artifacts json`, `forensics`, and `report` links.
+
+## Filters
+
+The Recent runs table can be filtered in the browser by:
+
+- status;
+- execution profile.
+
+Both filters are combined. The visible result counter updates immediately, and the Clear button restores the complete recent-run list.
+
+If no run matches the selected combination, Dashboard v2 displays an explicit no-match state instead of an empty table.
+
+## Run profile metadata
+
+New runs persist their execution profile as a run-level metadata artifact named:
+
+```text
+run_execution_profile
+```
+
+The memory layer projects this value as `execution_profile` in both `load_run()` and `list_recent_runs()`.
+
+Existing databases require no schema migration. Historical runs created before profile tracking are displayed as:
+
+```text
+unknown
+```
+
+## Security
+
+All task, run id, status, profile, error, and artifact-derived values rendered by Dashboard v2 are HTML escaped.
+
+Dashboard v2 remains protected by the same API-key middleware as other non-health production routes.

--- a/tests/test_dashboard_filters_v2.py
+++ b/tests/test_dashboard_filters_v2.py
@@ -1,0 +1,92 @@
+from velocity_claw.api.dashboard_v2 import render_dashboard_v2
+
+
+def render(runs):
+    return render_dashboard_v2(
+        execution_profile="safe",
+        safe_mode=True,
+        trusted_mode=False,
+        release_state={"readiness": "ready", "score": 5, "total_checks": 5},
+        console={"queue": {"running": 0, "failed": 0}, "approvals": {"pending": 0}},
+        recent_runs=runs,
+        approvals=[],
+        queue_jobs=[],
+        metrics={"tasks_total": 2},
+        provider_observability={"summary": {"failed_routes": 0}},
+        provider_health={},
+        last_failed=None,
+    )
+
+
+def test_dashboard_renders_status_and_profile_filters():
+    html = render(
+        [
+            {
+                "run_id": "run-safe",
+                "task": "Successful task",
+                "status": "completed",
+                "execution_profile": "safe",
+                "created_at": "2026-06-22T08:00:00",
+            },
+            {
+                "run_id": "run-dev",
+                "task": "Failed task",
+                "status": "failed",
+                "execution_profile": "dev",
+                "created_at": "2026-06-22T08:01:00",
+            },
+        ]
+    )
+
+    assert "id='run-status-filter'" in html
+    assert "id='run-profile-filter'" in html
+    assert "<option value='completed'>completed</option>" in html
+    assert "<option value='failed'>failed</option>" in html
+    assert "<option value='dev'>dev</option>" in html
+    assert "<option value='safe'>safe</option>" in html
+    assert "data-status='completed' data-profile='safe'" in html
+    assert "data-status='failed' data-profile='dev'" in html
+    assert "Visible: <b id='run-visible-count'>2</b> / 2" in html
+    assert "No runs match the selected status and profile." in html
+
+
+def test_dashboard_links_run_ids_to_html_inspector():
+    html = render(
+        [
+            {
+                "run_id": "run-123",
+                "task": "Inspect artifacts",
+                "status": "completed",
+                "execution_profile": "owner",
+                "created_at": "2026-06-22T08:00:00",
+            }
+        ]
+    )
+
+    assert "href='/runs/run-123/view'" in html
+    assert ">inspect</a>" in html
+    assert "detail json" in html
+    assert "artifacts json" in html
+
+
+def test_dashboard_escapes_run_content_and_handles_empty_state():
+    html = render(
+        [
+            {
+                "run_id": "unsafe<script>",
+                "task": "<img src=x onerror=alert(1)>",
+                "status": "running",
+                "execution_profile": "unknown",
+                "created_at": None,
+            }
+        ]
+    )
+
+    assert "<script>" not in html
+    assert "<img src=x" not in html
+    assert "unsafe&lt;script&gt;" in html
+    assert "&lt;img src=x onerror=alert(1)&gt;" in html
+
+    empty_html = render([])
+    assert "No runs recorded yet." in empty_html
+    assert "Visible: <b id='run-visible-count'>0</b> / 0" in empty_html

--- a/tests/test_run_profile_v2.py
+++ b/tests/test_run_profile_v2.py
@@ -1,0 +1,51 @@
+import sqlite3
+from pathlib import Path
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.memory.context_v2 import ProjectContextV2  # noqa: F401 - installs MemoryStore profile support
+from velocity_claw.memory.store import MemoryStore
+
+
+def build_memory(tmp_path: Path, monkeypatch, profile: str = "dev") -> MemoryStore:
+    monkeypatch.setenv("VELOCITY_CLAW_ENV", "test")
+    monkeypatch.setenv("VELOCITY_CLAW_MEMORY_DB_PATH", str(tmp_path / "memory.db"))
+    monkeypatch.setenv("VELOCITY_CLAW_EXECUTION_PROFILE", profile)
+    return MemoryStore(Settings())
+
+
+def test_run_profile_is_persisted_and_exposed(tmp_path: Path, monkeypatch):
+    memory = build_memory(tmp_path, monkeypatch, profile="dev")
+
+    run_id = memory.create_run("Inspect dashboard filters")
+    summary = memory.list_recent_runs(limit=10)[0]
+    loaded = memory.load_run(run_id)
+
+    assert summary["execution_profile"] == "dev"
+    assert loaded["execution_profile"] == "dev"
+    metadata = [item for item in loaded["artifacts"] if item["name"] == "run_execution_profile"]
+    assert len(metadata) == 1
+    assert metadata[0]["artifact_type"] == "metadata"
+    assert metadata[0]["content"] == "dev"
+
+
+def test_explicit_profile_override_is_normalized(tmp_path: Path, monkeypatch):
+    memory = build_memory(tmp_path, monkeypatch, profile="safe")
+
+    run_id = memory.create_run("Owner workflow", execution_profile=" OWNER ")
+
+    assert memory.load_run(run_id)["execution_profile"] == "owner"
+
+
+def test_legacy_run_without_profile_is_exposed_as_unknown(tmp_path: Path, monkeypatch):
+    memory = build_memory(tmp_path, monkeypatch, profile="safe")
+    legacy_id = "legacy-run"
+    with sqlite3.connect(memory.db_path) as conn:
+        conn.execute(
+            "INSERT INTO runs (run_id, task, status) VALUES (?, ?, ?)",
+            (legacy_id, "Legacy task", "completed"),
+        )
+
+    summaries = {item["run_id"]: item for item in memory.list_recent_runs(limit=20)}
+
+    assert summaries[legacy_id]["execution_profile"] == "unknown"
+    assert memory.load_run(legacy_id)["execution_profile"] == "unknown"

--- a/velocity_claw/api/dashboard_v2.py
+++ b/velocity_claw/api/dashboard_v2.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from html import escape
 from typing import Any
 
@@ -10,9 +11,14 @@ def html_escape(value: Any) -> str:
     return escape(str(value if value is not None else ""), quote=True)
 
 
+def _css_token(value: Any) -> str:
+    token = re.sub(r"[^a-z0-9_-]+", "-", str(value or "unknown").strip().lower())
+    return token.strip("-") or "unknown"
+
+
 def status_badge(status: str) -> str:
-    normalized = (status or "unknown").lower()
-    return f"<span class='badge badge-{html_escape(normalized)}'>{html_escape(status or 'unknown')}</span>"
+    normalized = _css_token(status)
+    return f"<span class='badge badge-{normalized}'>{html_escape(status or 'unknown')}</span>"
 
 
 def number_card(label: str, value: Any) -> str:
@@ -22,11 +28,11 @@ def number_card(label: str, value: Any) -> str:
 def run_links(run_id: Any) -> str:
     safe_run_id = html_escape(run_id)
     return (
-        f"<a href='/runs/{safe_run_id}/detail/v2'>detail v2</a> · "
-        f"<a href='/runs/{safe_run_id}/artifacts/v2'>artifacts</a> · "
+        f"<a href='/runs/{safe_run_id}/view'>inspect</a> · "
+        f"<a href='/runs/{safe_run_id}/detail/v2'>detail json</a> · "
+        f"<a href='/runs/{safe_run_id}/artifacts/v2'>artifacts json</a> · "
         f"<a href='/runs/{safe_run_id}/forensics'>forensics</a> · "
-        f"<a href='/runs/{safe_run_id}/report'>report</a> · "
-        f"<a href='/runs/{safe_run_id}/view'>classic</a>"
+        f"<a href='/runs/{safe_run_id}/report'>report</a>"
     )
 
 
@@ -35,8 +41,15 @@ def approval_links(run_id: Any, step_id: Any) -> str:
     safe_step_id = html_escape(step_id)
     return (
         f"<a href='/approvals/v2/{safe_run_id}/{safe_step_id}'>review</a> · "
-        f"<a href='/runs/{safe_run_id}/detail/v2'>run detail</a>"
+        f"<a href='/runs/{safe_run_id}/view'>inspect run</a>"
     )
+
+
+def _filter_options(values: list[str], label: str) -> str:
+    options = [f"<option value=''>All {html_escape(label)}</option>"]
+    for value in sorted({item for item in values if item}):
+        options.append(f"<option value='{html_escape(value)}'>{html_escape(value)}</option>")
+    return "".join(options)
 
 
 def dashboard_risk_flags(*, trusted_mode: bool, release_state: dict[str, Any], queue_summary: dict[str, Any], approvals: list[dict[str, Any]], provider_summary: dict[str, Any], last_failed: dict[str, Any] | None) -> list[dict[str, str]]:
@@ -98,13 +111,20 @@ def render_dashboard_v2(
     )
 
     run_rows = []
+    run_statuses: list[str] = []
+    run_profiles: list[str] = []
     for run in recent_runs:
         run_id = run.get("run_id", "")
+        status = str(run.get("status") or "unknown").lower()
+        profile = str(run.get("execution_profile") or "unknown").lower()
+        run_statuses.append(status)
+        run_profiles.append(profile)
         run_rows.append(
-            "<tr>"
-            f"<td><code>{html_escape(run_id)}</code></td>"
+            f"<tr class='run-row' data-status='{html_escape(status)}' data-profile='{html_escape(profile)}'>"
+            f"<td><a href='/runs/{html_escape(run_id)}/view'><code>{html_escape(run_id)}</code></a></td>"
             f"<td>{html_escape(run.get('task'))}</td>"
-            f"<td>{status_badge(str(run.get('status') or 'unknown'))}</td>"
+            f"<td>{status_badge(status)}</td>"
+            f"<td><code>{html_escape(profile)}</code></td>"
             f"<td>{html_escape(run.get('created_at'))}</td>"
             f"<td>{run_links(run_id)}</td>"
             "</tr>"
@@ -137,7 +157,7 @@ def render_dashboard_v2(
         )
 
     provider_rows = []
-    for provider, state in provider_health.items():
+    for provider, state in (provider_health or {}).items():
         provider_rows.append(
             "<tr>"
             f"<td>{html_escape(provider)}</td>"
@@ -149,7 +169,7 @@ def render_dashboard_v2(
             "</tr>"
         )
 
-    last_failed_block = "<p>No failed runs recorded.</p>"
+    last_failed_block = "<p class='empty-state'>No failed runs recorded.</p>"
     if last_failed:
         run_id = last_failed.get("run_id", "")
         last_failed_block = (
@@ -157,6 +177,10 @@ def render_dashboard_v2(
             f"{status_badge(str(last_failed.get('status') or 'failed'))} "
             f"{run_links(run_id)}</p>"
         )
+
+    status_options = _filter_options(run_statuses, "statuses")
+    profile_options = _filter_options(run_profiles, "profiles")
+    recorded_empty = "" if run_rows else "<tr id='runs-recorded-empty'><td colspan='6' class='empty-state'>No runs recorded yet.</td></tr>"
 
     return f"""
 <!doctype html>
@@ -167,31 +191,37 @@ def render_dashboard_v2(
   <title>Velocity Claw Dashboard v2</title>
   <style>
     :root {{ color-scheme: dark; --bg:#0f172a; --panel:#111827; --muted:#94a3b8; --text:#e5e7eb; --line:#263244; --accent:#38bdf8; }}
-    body {{ margin:0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Arial, sans-serif; background:var(--bg); color:var(--text); }}
+    body {{ margin:0; font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Arial,sans-serif; background:var(--bg); color:var(--text); }}
     main {{ max-width:1280px; margin:0 auto; padding:28px; }}
     header {{ display:flex; justify-content:space-between; gap:18px; align-items:flex-start; margin-bottom:24px; }}
     h1 {{ margin:0; font-size:32px; }}
     h2 {{ margin:0 0 12px; font-size:20px; }}
     a {{ color:var(--accent); text-decoration:none; }}
-    .muted {{ color:var(--muted); }}
-    .grid {{ display:grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap:14px; margin:18px 0; }}
+    .muted,.empty-state {{ color:var(--muted); }}
+    .grid {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:14px; margin:18px 0; }}
     .card {{ background:var(--panel); border:1px solid var(--line); border-radius:16px; padding:16px; box-shadow:0 8px 24px rgba(0,0,0,.18); }}
     .metric .label {{ color:var(--muted); font-size:13px; }}
     .metric .value {{ font-size:26px; font-weight:700; margin-top:6px; }}
     .section {{ margin-top:18px; }}
     table {{ width:100%; border-collapse:collapse; overflow:hidden; border-radius:12px; }}
-    th, td {{ border-bottom:1px solid var(--line); padding:10px; text-align:left; vertical-align:top; }}
+    th,td {{ border-bottom:1px solid var(--line); padding:10px; text-align:left; vertical-align:top; }}
     th {{ color:var(--muted); font-size:13px; font-weight:600; }}
-    code {{ background:#020617; border:1px solid var(--line); border-radius:8px; padding:2px 6px; }}
+    code,pre {{ background:#020617; border:1px solid var(--line); border-radius:8px; }}
+    code {{ padding:2px 6px; }}
+    pre {{ padding:12px; overflow:auto; }}
     .badge {{ display:inline-block; border:1px solid var(--line); border-radius:999px; padding:2px 8px; font-size:12px; }}
-    .badge-completed, .badge-ok, .badge-ready {{ border-color:#22c55e; color:#86efac; }}
-    .badge-failed, .badge-error, .badge-high {{ border-color:#ef4444; color:#fca5a5; }}
-    .badge-running, .badge-pending, .badge-cooldown, .badge-medium {{ border-color:#f59e0b; color:#fcd34d; }}
+    .badge-completed,.badge-success,.badge-passed,.badge-ok,.badge-ready {{ border-color:#22c55e; color:#86efac; }}
+    .badge-failed,.badge-error,.badge-high,.badge-rejected,.badge-cancelled {{ border-color:#ef4444; color:#fca5a5; }}
+    .badge-running,.badge-pending,.badge-pending_approval,.badge-awaiting_approval,.badge-cooldown,.badge-medium {{ border-color:#f59e0b; color:#fcd34d; }}
     .badge-info {{ border-color:#38bdf8; color:#7dd3fc; }}
-    .nav {{ display:flex; flex-wrap:wrap; gap:10px; margin-top:10px; }}
+    .nav,.filters {{ display:flex; flex-wrap:wrap; gap:10px; align-items:center; margin-top:10px; }}
     .nav a {{ background:#020617; border:1px solid var(--line); border-radius:999px; padding:8px 10px; }}
+    label {{ color:var(--muted); font-size:13px; }}
+    select,button {{ color:var(--text); background:#020617; border:1px solid var(--line); border-radius:9px; padding:8px 10px; }}
+    button {{ cursor:pointer; }}
     ul {{ margin:0; padding-left:20px; }}
     li {{ margin:7px 0; }}
+    @media (max-width:800px) {{ header {{ flex-direction:column; }} .table-wrap {{ overflow-x:auto; }} }}
   </style>
 </head>
 <body>
@@ -199,7 +229,7 @@ def render_dashboard_v2(
   <header>
     <div>
       <h1>Velocity Claw Dashboard v2</h1>
-      <p class='muted'>Operational overview for runs, approvals, queue, providers, and release readiness.</p>
+      <p class='muted'>Operational overview with filtered runs and direct HTML inspection of steps and artifacts.</p>
       <div class='nav'>
         <a href='/version'>version</a>
         <a href='/dashboard'>classic dashboard</a>
@@ -242,30 +272,42 @@ def render_dashboard_v2(
 
   <section class='card section'>
     <h2>Recent runs</h2>
-    <table><thead><tr><th>Run ID</th><th>Task</th><th>Status</th><th>Created</th><th>Links</th></tr></thead><tbody>
-      {''.join(run_rows) or "<tr><td colspan='5'>No runs recorded.</td></tr>"}
-    </tbody></table>
+    <div class='filters' aria-label='Run filters'>
+      <label for='run-status-filter'>Status</label>
+      <select id='run-status-filter'>{status_options}</select>
+      <label for='run-profile-filter'>Profile</label>
+      <select id='run-profile-filter'>{profile_options}</select>
+      <button type='button' id='run-filter-clear'>Clear</button>
+      <span class='muted'>Visible: <b id='run-visible-count'>{len(run_rows)}</b> / {len(run_rows)}</span>
+    </div>
+    <div class='table-wrap'>
+      <table id='runs-table'><thead><tr><th>Run ID</th><th>Task</th><th>Status</th><th>Profile</th><th>Created</th><th>Inspect</th></tr></thead><tbody>
+        {''.join(run_rows)}
+        {recorded_empty}
+        <tr id='runs-filter-empty' hidden><td colspan='6' class='empty-state'>No runs match the selected status and profile.</td></tr>
+      </tbody></table>
+    </div>
   </section>
 
   <section class='card section'>
     <h2>Pending approvals</h2>
-    <table><thead><tr><th>Run ID</th><th>Step</th><th>Title</th><th>Reason</th><th>Links</th></tr></thead><tbody>
-      {''.join(approval_rows) or "<tr><td colspan='5'>No pending approvals.</td></tr>"}
-    </tbody></table>
+    <div class='table-wrap'><table><thead><tr><th>Run ID</th><th>Step</th><th>Title</th><th>Reason</th><th>Links</th></tr></thead><tbody>
+      {''.join(approval_rows) or "<tr><td colspan='5' class='empty-state'>No pending approvals.</td></tr>"}
+    </tbody></table></div>
   </section>
 
   <section class='card section'>
     <h2>Queue</h2>
-    <table><thead><tr><th>Job ID</th><th>Task</th><th>Status</th><th>Attempts</th><th>Terminal reason</th></tr></thead><tbody>
-      {''.join(queue_rows) or "<tr><td colspan='5'>No queued jobs.</td></tr>"}
-    </tbody></table>
+    <div class='table-wrap'><table><thead><tr><th>Job ID</th><th>Task</th><th>Status</th><th>Attempts</th><th>Terminal reason</th></tr></thead><tbody>
+      {''.join(queue_rows) or "<tr><td colspan='5' class='empty-state'>No queued jobs.</td></tr>"}
+    </tbody></table></div>
   </section>
 
   <section class='card section'>
     <h2>Provider health</h2>
-    <table><thead><tr><th>Provider</th><th>Requests</th><th>Successes</th><th>Failures</th><th>State</th><th>Last error</th></tr></thead><tbody>
-      {''.join(provider_rows) or "<tr><td colspan='6'>No provider health data.</td></tr>"}
-    </tbody></table>
+    <div class='table-wrap'><table><thead><tr><th>Provider</th><th>Requests</th><th>Successes</th><th>Failures</th><th>State</th><th>Last error</th></tr></thead><tbody>
+      {''.join(provider_rows) or "<tr><td colspan='6' class='empty-state'>No provider health data.</td></tr>"}
+    </tbody></table></div>
   </section>
 
   <section class='card section'>
@@ -273,6 +315,30 @@ def render_dashboard_v2(
     <pre>{html_escape(metrics)}</pre>
   </section>
 </main>
+<script>
+(() => {{
+  const status = document.getElementById('run-status-filter');
+  const profile = document.getElementById('run-profile-filter');
+  const clear = document.getElementById('run-filter-clear');
+  const rows = Array.from(document.querySelectorAll('.run-row'));
+  const empty = document.getElementById('runs-filter-empty');
+  const count = document.getElementById('run-visible-count');
+  const apply = () => {{
+    let visible = 0;
+    rows.forEach((row) => {{
+      const show = (!status.value || row.dataset.status === status.value) && (!profile.value || row.dataset.profile === profile.value);
+      row.hidden = !show;
+      if (show) visible += 1;
+    }});
+    count.textContent = String(visible);
+    empty.hidden = rows.length === 0 || visible !== 0;
+  }};
+  status.addEventListener('change', apply);
+  profile.addEventListener('change', apply);
+  clear.addEventListener('click', () => {{ status.value = ''; profile.value = ''; apply(); }});
+  apply();
+}})();
+</script>
 </body>
 </html>
 """.strip()

--- a/velocity_claw/memory/context_v2.py
+++ b/velocity_claw/memory/context_v2.py
@@ -13,6 +13,10 @@ from velocity_claw.memory.context_v2_runtime import (
     normalize_tokens,
     task_similarity,
 )
+from velocity_claw.memory.run_profile_v2 import install_run_profile_v2
+from velocity_claw.memory.store import MemoryStore
+
+install_run_profile_v2(MemoryStore)
 
 __all__ = [
     "ACTIVE_RUN_STATUSES",

--- a/velocity_claw/memory/run_profile_v2.py
+++ b/velocity_claw/memory/run_profile_v2.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+
+PROFILE_ARTIFACT_NAME = "run_execution_profile"
+PROFILE_ARTIFACT_TYPE = "metadata"
+UNKNOWN_PROFILE = "unknown"
+
+
+def _normalize_profile(value: Any) -> str:
+    profile = str(value or "").strip().lower()
+    return profile or UNKNOWN_PROFILE
+
+
+def _profile_from_artifacts(artifacts: list[dict[str, Any]]) -> str:
+    for artifact in reversed(artifacts or []):
+        if artifact.get("name") == PROFILE_ARTIFACT_NAME:
+            return _normalize_profile(artifact.get("content"))
+    return UNKNOWN_PROFILE
+
+
+def _profiles_for_runs(memory: Any, run_ids: list[str]) -> dict[str, str]:
+    if not run_ids or not getattr(memory, "enabled", False):
+        return {}
+    placeholders = ",".join("?" for _ in run_ids)
+    query = (
+        "SELECT run_id, content FROM artifacts "
+        f"WHERE name = ? AND run_id IN ({placeholders}) ORDER BY id DESC"
+    )
+    profiles: dict[str, str] = {}
+    with sqlite3.connect(memory.db_path) as conn:
+        for run_id, content in conn.execute(query, [PROFILE_ARTIFACT_NAME, *run_ids]).fetchall():
+            profiles.setdefault(run_id, _normalize_profile(content))
+    return profiles
+
+
+def install_run_profile_v2(memory_cls: type) -> None:
+    """Add backward-compatible run profile metadata to ``MemoryStore``.
+
+    Profiles are persisted as run-level metadata artifacts, avoiding a destructive
+    schema change for existing installations. Historical runs without the artifact
+    are exposed as ``unknown``.
+    """
+    if getattr(memory_cls, "_run_profile_v2_installed", False):
+        return
+
+    original_create_run = memory_cls.create_run
+    original_load_run = memory_cls.load_run
+    original_list_recent_runs = memory_cls.list_recent_runs
+
+    def create_run(self, task: str, execution_profile: str | None = None) -> str:
+        run_id = original_create_run(self, task)
+        profile = _normalize_profile(execution_profile or getattr(self.settings, "execution_profile", None))
+        if getattr(self, "enabled", False):
+            self.save_artifact(
+                run_id,
+                PROFILE_ARTIFACT_NAME,
+                profile,
+                artifact_type=PROFILE_ARTIFACT_TYPE,
+            )
+        return run_id
+
+    def load_run(self, run_id: str):
+        run = original_load_run(self, run_id)
+        if run is not None:
+            run["execution_profile"] = _profile_from_artifacts(run.get("artifacts") or [])
+        return run
+
+    def list_recent_runs(self, limit: int = 20):
+        runs = original_list_recent_runs(self, limit=limit)
+        profiles = _profiles_for_runs(self, [item.get("run_id") for item in runs if item.get("run_id")])
+        for run in runs:
+            run["execution_profile"] = profiles.get(run.get("run_id"), UNKNOWN_PROFILE)
+        return runs
+
+    memory_cls.create_run = create_run
+    memory_cls.load_run = load_run
+    memory_cls.list_recent_runs = list_recent_runs
+    memory_cls._run_profile_v2_installed = True


### PR DESCRIPTION
## Summary

Completes issue #18 with a more usable operational run workflow.

Changes:
- persist the execution profile for new runs as backward-compatible run-level metadata
- expose `execution_profile` through `MemoryStore.load_run()` and `list_recent_runs()`
- display legacy runs without profile metadata as `unknown`
- add browser-side status and profile filters to Dashboard v2
- add visible-result counts, clear controls, and explicit no-match/empty states
- add a profile column and clearer status badges
- make run ids and the primary `inspect` action open the existing HTML run inspector
- retain structured detail, artifacts, forensics, and report JSON links
- harden CSS badge tokens and preserve HTML escaping for rendered run content
- add focused profile, filtering, escaping, and empty-state tests
- add an operator guide for Dashboard v2

The existing `/runs/{run_id}/view` page already provides the run detail page, step inspector, failures, planning/resume context, approval history, forensics, and artifact viewer required by the issue.

Validation targets:
- complete pytest suite
- package validation
- dependency audit
- wheel and source build

Closes #18 when merged.