### PR TITLE
Complete Dashboard v2 run filters and step inspector

### DIFF
--- a/tests/test_dashboard_runs_v2.py
+++ b/tests/test_dashboard_runs_v2.py
@@ -1,0 +1,98 @@
+from velocity_claw.api.dashboard_filters import compact_step_inspector, filter_runs, run_profile
+from velocity_claw.api.dashboard_runs_v2 import render_dashboard_runs_v2
+from velocity_claw.api.dashboard_v2 import render_dashboard_v2
+
+
+def sample_runs():
+    return [
+        {
+            "run_id": "run-safe",
+            "task": "Safe completed run",
+            "status": "completed",
+            "created_at": "2026-06-22T08:00:00",
+            "context": {"execution_profile": "safe"},
+            "steps": [
+                {"id": 1, "title": "Inspect", "tool": "git.inspect", "status": "completed", "result": {"branch": "master"}},
+                {"id": 2, "title": "Test", "tool": "test.run", "status": "failed", "error": "assertion failed", "result": "x" * 300},
+            ],
+            "artifacts": [{"name": "test_output"}],
+        },
+        {
+            "run_id": "run-owner",
+            "task": "Owner failed run",
+            "status": "failed",
+            "created_at": "2026-06-22T08:05:00",
+            "execution_profile": "owner",
+            "steps": [],
+            "artifacts": [],
+        },
+    ]
+
+
+def test_filter_runs_by_status_and_profile():
+    runs = sample_runs()
+
+    assert [run["run_id"] for run in filter_runs(runs, status="completed")] == ["run-safe"]
+    assert [run["run_id"] for run in filter_runs(runs, profile="owner")] == ["run-owner"]
+    assert [run["run_id"] for run in filter_runs(runs, status="failed", profile="owner")] == ["run-owner"]
+    assert filter_runs(runs, status="running") == []
+
+
+def test_run_profile_supports_direct_and_context_values():
+    runs = sample_runs()
+
+    assert run_profile(runs[0]) == "safe"
+    assert run_profile(runs[1]) == "owner"
+    assert run_profile({}) is None
+
+
+def test_compact_step_inspector_limits_result_preview():
+    inspector = compact_step_inspector(sample_runs()[0])
+
+    assert inspector["run_id"] == "run-safe"
+    assert inspector["profile"] == "safe"
+    assert inspector["step_count"] == 2
+    assert inspector["artifact_count"] == 1
+    assert inspector["steps"][1]["error"] == "assertion failed"
+    assert len(inspector["steps"][1]["result_preview"]) == 240
+    assert inspector["steps"][1]["result_preview"].endswith("...")
+
+
+def test_runs_inspector_renders_filters_and_selected_steps():
+    runs = sample_runs()
+    html = render_dashboard_runs_v2(
+        runs=runs,
+        status="completed",
+        profile="safe",
+        selected_run=runs[0],
+    )
+
+    assert "Runs and steps inspector" in html
+    assert "Filtered runs: 1 of 2" in html
+    assert "run-safe" in html
+    assert "run-owner" not in html
+    assert "git.inspect" in html
+    assert "assertion failed" in html
+    assert "/runs/run-safe/artifacts/v2" in html
+    assert "option value='completed' selected" in html
+    assert "option value='safe' selected" in html
+
+
+def test_main_dashboard_links_to_runs_inspector():
+    html = render_dashboard_v2(
+        execution_profile="safe",
+        safe_mode=True,
+        trusted_mode=False,
+        release_state={"readiness": "ready", "score": 1, "total_checks": 1},
+        console={"queue": {}, "approvals": {}},
+        recent_runs=sample_runs()[:1],
+        approvals=[],
+        queue_jobs=[],
+        metrics={},
+        provider_observability={"summary": {}},
+        provider_health={},
+        last_failed=None,
+    )
+
+    assert "/dashboard/v2/runs" in html
+    assert "/dashboard/v2/runs?run_id=run-safe" in html

--- a/velocity_claw/api/app.py
+++ b/velocity_claw/api/app.py
@@ -12,6 +12,8 @@ from velocity_claw.api.approval_v2 import (
     reject_with_guard,
 )
 from velocity_claw.api.auth import install_api_key_auth
+from velocity_claw.api.dashboard_filters import VALID_PROFILES, VALID_RUN_STATUSES, normalize_filter
+from velocity_claw.api.dashboard_runs_v2 import render_dashboard_runs_v2
 from velocity_claw.api.dashboard_v2 import render_dashboard_v2
 from velocity_claw.api.diagnostics_v2 import build_diagnostics_v2
 from velocity_claw.api.errors import install_api_error_handlers
@@ -276,6 +278,33 @@ def install_dashboard_v2(app: FastAPI) -> None:
             provider_observability=provider_observability,
             provider_health=provider_health,
             last_failed=last_failed,
+        )
+
+    @app.get("/dashboard/v2/runs", response_class=HTMLResponse)
+    def dashboard_runs_v2(status: str | None = None, profile: str | None = None, run_id: str | None = None):
+        status_filter = normalize_filter(status)
+        profile_filter = normalize_filter(profile)
+        if status_filter and status_filter not in VALID_RUN_STATUSES:
+            raise HTTPException(status_code=400, detail={"status": "failed", "error": "invalid_status_filter", "detail": sorted(VALID_RUN_STATUSES)})
+        if profile_filter and profile_filter not in VALID_PROFILES:
+            raise HTTPException(status_code=400, detail={"status": "failed", "error": "invalid_profile_filter", "detail": sorted(VALID_PROFILES)})
+
+        runs = []
+        for summary in app.state.agent.memory.list_recent_runs(limit=100):
+            full = app.state.agent.memory.load_run(summary.get("run_id"))
+            runs.append(full or summary)
+
+        selected = None
+        if run_id:
+            selected = app.state.agent.memory.load_run(run_id)
+            if not selected:
+                raise HTTPException(status_code=404, detail={"status": "failed", "error": "not_found", "detail": "Run not found"})
+
+        return render_dashboard_runs_v2(
+            runs=runs,
+            status=status_filter,
+            profile=profile_filter,
+            selected_run=selected,
         )
 
 

--- a/velocity_claw/api/dashboard_runs_v2.py
+++ b/velocity_claw/api/dashboard_runs_v2.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from html import escape
+from typing import Any
+from urllib.parse import urlencode
+
+from velocity_claw.api.dashboard_filters import compact_step_inspector, filter_runs, run_profile
+from velocity_claw.api.dashboard_v2 import status_badge
+
+
+def _e(value: Any) -> str:
+    return escape(str(value if value is not None else ""), quote=True)
+
+
+def _option(value: str, selected: str | None) -> str:
+    mark = " selected" if selected == value else ""
+    return f"<option value='{_e(value)}'{mark}>{_e(value or 'all')}</option>"
+
+
+def _run_link(run_id: Any, label: str, *, status: str | None, profile: str | None) -> str:
+    params = {"run_id": str(run_id)}
+    if status:
+        params["status"] = status
+    if profile:
+        params["profile"] = profile
+    return f"<a href='/dashboard/v2/runs?{urlencode(params)}'>{_e(label)}</a>"
+
+
+def render_dashboard_runs_v2(
+    *,
+    runs: list[dict[str, Any]],
+    status: str | None = None,
+    profile: str | None = None,
+    selected_run: dict[str, Any] | None = None,
+) -> str:
+    filtered = filter_runs(runs, status=status, profile=profile)
+    inspector = compact_step_inspector(selected_run)
+
+    rows = []
+    for run in filtered:
+        run_id = run.get("run_id")
+        rows.append(
+            "<tr>"
+            f"<td><code>{_e(run_id)}</code></td>"
+            f"<td>{_e(run.get('task'))}</td>"
+            f"<td>{status_badge(str(run.get('status') or 'unknown'))}</td>"
+            f"<td>{_e(run_profile(run) or 'unknown')}</td>"
+            f"<td>{_e(run.get('created_at'))}</td>"
+            f"<td>{_run_link(run_id, 'inspect', status=status, profile=profile)} · "
+            f"<a href='/runs/{_e(run_id)}/detail/v2'>detail</a> · "
+            f"<a href='/runs/{_e(run_id)}/artifacts/v2'>artifacts</a></td>"
+            "</tr>"
+        )
+
+    inspector_html = "<p class='muted'>Select a run to inspect its steps.</p>"
+    if inspector:
+        step_rows = []
+        for step in inspector["steps"]:
+            step_rows.append(
+                "<tr>"
+                f"<td>{_e(step.get('id'))}</td>"
+                f"<td>{_e(step.get('title'))}</td>"
+                f"<td><code>{_e(step.get('tool'))}</code></td>"
+                f"<td>{status_badge(str(step.get('status') or 'unknown'))}</td>"
+                f"<td>{_e(step.get('error') or '')}</td>"
+                f"<td><pre>{_e(step.get('result_preview') or '')}</pre></td>"
+                "</tr>"
+            )
+        inspector_html = (
+            f"<p><code>{_e(inspector['run_id'])}</code> — {_e(inspector['task'])} "
+            f"{status_badge(str(inspector.get('status') or 'unknown'))}</p>"
+            f"<p class='muted'>Profile: {_e(inspector.get('profile') or 'unknown')} · "
+            f"Steps: {_e(inspector['step_count'])} · Artifacts: {_e(inspector['artifact_count'])}</p>"
+            "<table><thead><tr><th>ID</th><th>Title</th><th>Tool</th><th>Status</th><th>Error</th><th>Result preview</th></tr></thead><tbody>"
+            f"{''.join(step_rows) or '<tr><td colspan=\'6\'>No steps recorded.</td></tr>'}"
+            "</tbody></table>"
+            f"<p><a href='/runs/{_e(inspector['run_id'])}/detail/v2'>Open full run detail</a> · "
+            f"<a href='/runs/{_e(inspector['run_id'])}/artifacts/v2'>Open artifact index</a></p>"
+        )
+
+    return f"""
+<!doctype html>
+<html lang='en'>
+<head>
+  <meta charset='utf-8'>
+  <meta name='viewport' content='width=device-width, initial-scale=1'>
+  <title>Velocity Claw Runs Inspector</title>
+  <style>
+    :root {{ color-scheme:dark; --bg:#0f172a; --panel:#111827; --muted:#94a3b8; --text:#e5e7eb; --line:#263244; --accent:#38bdf8; }}
+    body {{ margin:0; font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Arial,sans-serif; background:var(--bg); color:var(--text); }}
+    main {{ max-width:1400px; margin:0 auto; padding:28px; }}
+    a {{ color:var(--accent); text-decoration:none; }}
+    .card {{ background:var(--panel); border:1px solid var(--line); border-radius:16px; padding:16px; margin-top:18px; }}
+    .muted {{ color:var(--muted); }}
+    form {{ display:flex; flex-wrap:wrap; gap:12px; align-items:end; }}
+    label {{ display:grid; gap:6px; color:var(--muted); }}
+    select,button {{ background:#020617; color:var(--text); border:1px solid var(--line); border-radius:8px; padding:8px 10px; }}
+    table {{ width:100%; border-collapse:collapse; }}
+    th,td {{ border-bottom:1px solid var(--line); padding:10px; text-align:left; vertical-align:top; }}
+    th {{ color:var(--muted); font-size:13px; }}
+    code,pre {{ background:#020617; border:1px solid var(--line); border-radius:8px; padding:2px 6px; }}
+    pre {{ white-space:pre-wrap; max-width:480px; margin:0; }}
+    .badge {{ display:inline-block; border:1px solid var(--line); border-radius:999px; padding:2px 8px; font-size:12px; }}
+    .badge-completed,.badge-ok,.badge-ready {{ border-color:#22c55e; color:#86efac; }}
+    .badge-failed,.badge-error {{ border-color:#ef4444; color:#fca5a5; }}
+    .badge-running,.badge-pending,.badge-paused,.badge-pending_approval {{ border-color:#f59e0b; color:#fcd34d; }}
+  </style>
+</head>
+<body><main>
+  <p><a href='/dashboard/v2'>← Dashboard v2</a></p>
+  <h1>Runs and steps inspector</h1>
+  <p class='muted'>Filtered runs: {_e(len(filtered))} of {_e(len(runs))}</p>
+  <section class='card'>
+    <form method='get' action='/dashboard/v2/runs'>
+      <label>Status<select name='status'>{_option('', status)}{''.join(_option(item, status) for item in ['running','completed','failed','cancelled','paused','pending_approval'])}</select></label>
+      <label>Profile<select name='profile'>{_option('', profile)}{''.join(_option(item, profile) for item in ['safe','dev','owner'])}</select></label>
+      <button type='submit'>Apply filters</button>
+      <a href='/dashboard/v2/runs'>Clear</a>
+    </form>
+  </section>
+  <section class='card'>
+    <h2>Runs</h2>
+    <table><thead><tr><th>Run ID</th><th>Task</th><th>Status</th><th>Profile</th><th>Created</th><th>Actions</th></tr></thead><tbody>
+      {''.join(rows) or "<tr><td colspan='6'>No runs match the selected filters.</td></tr>"}
+    </tbody></table>
+  </section>
+  <section class='card'><h2>Step inspector</h2>{inspector_html}</section>
+</main></body></html>
+""".strip()

--- a/velocity_claw/api/dashboard_v2.py
+++ b/velocity_claw/api/dashboard_v2.py
@@ -22,6 +22,7 @@ def number_card(label: str, value: Any) -> str:
 def run_links(run_id: Any) -> str:
     safe_run_id = html_escape(run_id)
     return (
+        f"<a href='/dashboard/v2/runs?run_id={safe_run_id}'>inspect</a> · "
         f"<a href='/runs/{safe_run_id}/detail/v2'>detail v2</a> · "
         f"<a href='/runs/{safe_run_id}/artifacts/v2'>artifacts</a> · "
         f"<a href='/runs/{safe_run_id}/forensics'>forensics</a> · "
@@ -203,6 +204,7 @@ def render_dashboard_v2(
       <div class='nav'>
         <a href='/version'>version</a>
         <a href='/dashboard'>classic dashboard</a>
+        <a href='/dashboard/v2/runs'>runs inspector</a>
         <a href='/diagnostics/v2'>diagnostics v2</a>
         <a href='/ops/console'>ops console</a>
         <a href='/runs'>runs json</a>


### PR DESCRIPTION
## Summary

Completes the remaining operator UX scope from issue #18.

Changes:
- add `GET /dashboard/v2/runs`
- filter recent runs by status and execution profile
- show filtered/total counts and clear empty states
- inspect selected run steps without reading raw JSON
- show tool, status, error, and bounded result previews per step
- keep links to full Run detail v2 and Artifact index v2
- add direct navigation from Dashboard v2 and per-run inspect links
- validate unsupported status/profile filters with structured `400` responses
- return `404` for an unknown selected run
- add focused filter, profile, preview, rendering, and navigation tests

Validation targets:
- complete pytest suite
- package validation
- dependency audit
- wheel/source build

Closes #18 when merged.