### PR TITLE
Persist execution profile on runs without Dashboard conflicts

### DIFF
--- a/tests/test_run_profile_schema_v2.py
+++ b/tests/test_run_profile_schema_v2.py
@@ -1,0 +1,77 @@
+import sqlite3
+from pathlib import Path
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.memory.context_v2 import ProjectContextV2  # noqa: F401 - installs profile schema
+from velocity_claw.memory.store import MemoryStore
+
+
+def build_settings(tmp_path: Path, monkeypatch, profile: str = "dev") -> Settings:
+    monkeypatch.setenv("VELOCITY_CLAW_ENV", "test")
+    monkeypatch.setenv("VELOCITY_CLAW_MEMORY_DB_PATH", str(tmp_path / "memory.db"))
+    monkeypatch.setenv("VELOCITY_CLAW_EXECUTION_PROFILE", profile)
+    return Settings()
+
+
+def test_existing_runs_table_is_migrated_without_losing_rows(tmp_path: Path, monkeypatch):
+    settings = build_settings(tmp_path, monkeypatch, profile="safe")
+    with sqlite3.connect(settings.memory_db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE runs (
+                run_id TEXT PRIMARY KEY,
+                task TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                completed_at DATETIME
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO runs (run_id, task, status) VALUES (?, ?, ?)",
+            ("legacy-run", "Legacy task", "completed"),
+        )
+
+    memory = MemoryStore(settings)
+
+    with sqlite3.connect(settings.memory_db_path) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(runs)").fetchall()}
+        profile = conn.execute(
+            "SELECT execution_profile FROM runs WHERE run_id = ?",
+            ("legacy-run",),
+        ).fetchone()[0]
+
+    assert "execution_profile" in columns
+    assert profile == "unknown"
+    assert memory.load_run("legacy-run")["execution_profile"] == "unknown"
+
+
+def test_new_run_persists_active_execution_profile(tmp_path: Path, monkeypatch):
+    memory = MemoryStore(build_settings(tmp_path, monkeypatch, profile="dev"))
+
+    run_id = memory.create_run("Inspect dashboard")
+    summary = memory.list_recent_runs(limit=10)[0]
+    loaded = memory.load_run(run_id)
+
+    assert summary["execution_profile"] == "dev"
+    assert loaded["execution_profile"] == "dev"
+    assert all(artifact.get("name") != "run_execution_profile" for artifact in loaded["artifacts"])
+
+
+def test_explicit_profile_override_is_normalized(tmp_path: Path, monkeypatch):
+    memory = MemoryStore(build_settings(tmp_path, monkeypatch, profile="safe"))
+
+    run_id = memory.create_run("Owner operation", execution_profile=" OWNER ")
+
+    assert memory.load_run(run_id)["execution_profile"] == "owner"
+
+
+def test_recent_runs_are_enriched_in_one_compatible_response(tmp_path: Path, monkeypatch):
+    memory = MemoryStore(build_settings(tmp_path, monkeypatch, profile="safe"))
+    safe_run = memory.create_run("Safe run")
+    owner_run = memory.create_run("Owner run", execution_profile="owner")
+
+    summaries = {item["run_id"]: item for item in memory.list_recent_runs(limit=10)}
+
+    assert summaries[safe_run]["execution_profile"] == "safe"
+    assert summaries[owner_run]["execution_profile"] == "owner"

--- a/velocity_claw/memory/__init__.py
+++ b/velocity_claw/memory/__init__.py
@@ -1,1 +1,8 @@
 """Velocity Claw memory package."""
+
+from velocity_claw.memory.run_profile_schema import install_run_profile_schema
+from velocity_claw.memory.store import MemoryStore
+
+install_run_profile_schema(MemoryStore)
+
+__all__ = ["MemoryStore"]

--- a/velocity_claw/memory/context_v2.py
+++ b/velocity_claw/memory/context_v2.py
@@ -13,6 +13,10 @@ from velocity_claw.memory.context_v2_runtime import (
     normalize_tokens,
     task_similarity,
 )
+from velocity_claw.memory.run_profile_schema import install_run_profile_schema
+from velocity_claw.memory.store import MemoryStore
+
+install_run_profile_schema(MemoryStore)
 
 __all__ = [
     "ACTIVE_RUN_STATUSES",

--- a/velocity_claw/memory/context_v2.py
+++ b/velocity_claw/memory/context_v2.py
@@ -13,10 +13,6 @@ from velocity_claw.memory.context_v2_runtime import (
     normalize_tokens,
     task_similarity,
 )
-from velocity_claw.memory.run_profile_schema import install_run_profile_schema
-from velocity_claw.memory.store import MemoryStore
-
-install_run_profile_schema(MemoryStore)
 
 __all__ = [
     "ACTIVE_RUN_STATUSES",

--- a/velocity_claw/memory/run_profile_schema.py
+++ b/velocity_claw/memory/run_profile_schema.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+
+UNKNOWN_PROFILE = "unknown"
+
+
+def normalize_profile(value: Any) -> str:
+    profile = str(value or "").strip().lower()
+    return profile or UNKNOWN_PROFILE
+
+
+def install_run_profile_schema(memory_cls: type) -> None:
+    """Persist execution profile directly on the existing ``runs`` table.
+
+    The installer is applied before ``MemoryStore`` instances are created. Existing
+    databases are migrated in place with a non-destructive column addition, while
+    historical rows are exposed as ``unknown``.
+    """
+    if getattr(memory_cls, "_run_profile_schema_installed", False):
+        return
+
+    original_ensure_tables = memory_cls._ensure_tables
+    original_create_run = memory_cls.create_run
+    original_load_run = memory_cls.load_run
+    original_list_recent_runs = memory_cls.list_recent_runs
+
+    def _ensure_tables(self) -> None:
+        original_ensure_tables(self)
+        if not getattr(self, "enabled", False):
+            return
+        with sqlite3.connect(self.db_path) as conn:
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(runs)").fetchall()}
+            if "execution_profile" not in columns:
+                conn.execute(
+                    "ALTER TABLE runs ADD COLUMN execution_profile TEXT NOT NULL DEFAULT 'unknown'"
+                )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_runs_execution_profile_created_at "
+                "ON runs(execution_profile, created_at)"
+            )
+
+    def create_run(self, task: str, execution_profile: str | None = None) -> str:
+        run_id = original_create_run(self, task)
+        if not getattr(self, "enabled", False):
+            return run_id
+        profile = normalize_profile(
+            execution_profile or getattr(getattr(self, "settings", None), "execution_profile", None)
+        )
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "UPDATE runs SET execution_profile = ? WHERE run_id = ?",
+                (profile, run_id),
+            )
+        return run_id
+
+    def load_run(self, run_id: str):
+        run = original_load_run(self, run_id)
+        if run is None:
+            return None
+        profile = UNKNOWN_PROFILE
+        if getattr(self, "enabled", False):
+            with sqlite3.connect(self.db_path) as conn:
+                row = conn.execute(
+                    "SELECT execution_profile FROM runs WHERE run_id = ?",
+                    (run_id,),
+                ).fetchone()
+            if row:
+                profile = normalize_profile(row[0])
+        run["execution_profile"] = profile
+        return run
+
+    def list_recent_runs(self, limit: int = 20):
+        runs = original_list_recent_runs(self, limit=limit)
+        if not runs or not getattr(self, "enabled", False):
+            for run in runs:
+                run["execution_profile"] = normalize_profile(run.get("execution_profile"))
+            return runs
+
+        run_ids = [run.get("run_id") for run in runs if run.get("run_id")]
+        placeholders = ",".join("?" for _ in run_ids)
+        profiles: dict[str, str] = {}
+        if run_ids:
+            with sqlite3.connect(self.db_path) as conn:
+                rows = conn.execute(
+                    f"SELECT run_id, execution_profile FROM runs WHERE run_id IN ({placeholders})",
+                    run_ids,
+                ).fetchall()
+            profiles = {run_id: normalize_profile(profile) for run_id, profile in rows}
+
+        for run in runs:
+            run["execution_profile"] = profiles.get(run.get("run_id"), UNKNOWN_PROFILE)
+        return runs
+
+    memory_cls._ensure_tables = _ensure_tables
+    memory_cls.create_run = create_run
+    memory_cls.load_run = load_run
+    memory_cls.list_recent_runs = list_recent_runs
+    memory_cls._run_profile_schema_installed = True


### PR DESCRIPTION
## Summary

Resolves the useful non-duplicated part of stale conflicting Dashboard PRs #119 and #122 without merging either branch.

Changes:
- migrate the existing `runs` table with an `execution_profile` column
- preserve historical rows as `unknown`
- persist the active profile for every new run
- support an explicit profile override for compatibility and tests
- expose the profile through `load_run()` and `list_recent_runs()`
- install the schema extension for all `MemoryStore` imports
- avoid service artifacts and avoid a parallel run-profile table
- add migration, persistence, normalization, compatibility, and artifact-isolation tests

The Dashboard v2 filters and step inspector are already merged through PR #123. After this PR is green and merged, #119 and #122 can be closed as superseded, removing the conflict warning shown in GitHub.

Validation targets:
- complete pytest suite
- package validation
- dependency audit
- wheel/source build