### PR TITLE
Complete execution profiles v2 policy enforcement

### DIFF
--- a/docs/EXECUTION_PROFILES.md
+++ b/docs/EXECUTION_PROFILES.md
@@ -1,0 +1,82 @@
+# Execution profiles v2
+
+Velocity Claw uses two independent security layers:
+
+1. the selected execution profile decides whether a tool is allowed, approval-gated, or denied;
+2. runtime settings and security validation decide whether the allowed action can execute now.
+
+Approval never overrides a hard profile deny or a disabled runtime capability.
+
+## Policy modes
+
+- `allow` — the profile grants the tool and no profile approval is required;
+- `approval` — the profile grants the tool only after an approval decision;
+- `deny` — the profile does not grant the tool; approval cannot elevate it.
+
+Unknown tools default to `deny` for every profile.
+
+## Tool matrix
+
+| Tool group | safe | dev | owner |
+| --- | --- | --- | --- |
+| analysis, filesystem read, code navigation | allow | allow | allow |
+| git inspection | allow | allow | allow |
+| patch preview | allow | allow | allow |
+| test runner | allow | allow | allow |
+| filesystem write | deny | allow | allow |
+| patch apply | deny | allow | allow |
+| shell | deny | approval | allow |
+| git write | deny | deny | allow |
+| HTTP GET/POST | deny | deny | allow |
+
+## Runtime constraints
+
+Profile access is necessary but not sufficient:
+
+- `shell.run` is blocked when `SHELL_ENABLED=false`;
+- `git.inspect` and `git.run` are blocked when `GIT_ENABLED=false`;
+- HTTP tools remain restricted by `ALLOWED_HOSTS` and URL validation;
+- workspace path restrictions and command allowlists remain active;
+- dry-run changes execution output but does not bypass policy or validation.
+
+The API distinguishes:
+
+- `allowed`: the profile grants the capability;
+- `allowed_now`: the tool can execute with current approval and runtime state;
+- `blocked`: profile or runtime policy prevents execution;
+- `policy_mode`: `allow`, `approval`, or `deny`.
+
+## Approval behavior
+
+`dev.shell.run` pauses before execution. After approval, the same step still passes:
+
+- the stored run profile;
+- runtime capability checks;
+- command/path/URL/git security validation;
+- normal executor validation.
+
+The next approval-gated step creates a new approval boundary. One approval does not approve the rest of the plan.
+
+Steps with `args.require_approval=true` remain approval-gated in any profile that otherwise grants the tool.
+
+A denied tool returns a failed step with a policy explanation. It does not create a misleading approval request.
+
+## Run profile stability
+
+Each run stores its execution profile. Approval continuation uses that stored profile, not the current process setting. Changing the server from `dev` to `owner` after an approval request therefore cannot silently elevate the paused run.
+
+## Operator endpoints
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /profiles` | All profiles, capabilities, and tool modes |
+| `GET /profiles/active` | Active profile, effective tool policy, and runtime constraints |
+| `GET /profiles/explain/{tool}` | Explanation for one tool; replace dots with `__` |
+| `POST /approvals/explain` | Approval or deny explanation for a proposed step |
+
+Examples:
+
+```text
+GET /profiles/explain/shell__run
+GET /profiles/explain/git__run
+```

--- a/tests/test_approval_resume_profile_guard_v2.py
+++ b/tests/test_approval_resume_profile_guard_v2.py
@@ -1,0 +1,176 @@
+import asyncio
+import json
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.core.agent import VelocityClawAgent
+from velocity_claw.core.step_guard import StepExecutionGuard
+from velocity_claw.security.access import ApprovalManager, ExecutionProfileManager
+
+
+class FakeMemory:
+    def __init__(self, run):
+        self.run = run
+        self.saved_steps = []
+        self.saved_artifacts = []
+        self.statuses = []
+        self.notes = []
+        self.approval_events = []
+
+    def load_run(self, run_id):
+        return self.run if run_id == self.run["run_id"] else None
+
+    def save_step(self, run_id, result):
+        self.saved_steps.append((run_id, result))
+
+    def save_artifact(self, run_id, name, content, step_id=None, artifact_type="text"):
+        self.saved_artifacts.append((run_id, name, content, step_id, artifact_type))
+
+    def update_run_status(self, run_id, status):
+        self.statuses.append((run_id, status))
+
+    def save_project_note(self, note_type, content):
+        self.notes.append((note_type, content))
+
+    def save_approval_decision(self, run_id, step_id, decision, actor=None, reason=None, payload=None):
+        self.approval_events.append((run_id, step_id, decision, payload))
+
+
+class FakeSecurity:
+    def __init__(self):
+        self.calls = []
+
+    def get_profile(self, name):
+        return name
+
+    def validate_command(self, command, profile):
+        self.calls.append(("shell", command, profile))
+
+    def validate_path(self, path, profile, write=False):
+        self.calls.append(("path", path, profile, write))
+
+    def validate_url(self, url, profile):
+        self.calls.append(("url", url, profile))
+
+    def validate_git_command(self, command, profile):
+        self.calls.append(("git", command, profile))
+
+
+class FakeExecutor:
+    def __init__(self):
+        self.calls = []
+
+    async def execute_step(self, step, context):
+        self.calls.append(step.get("tool"))
+        return {
+            "id": step.get("id"),
+            "title": step.get("title"),
+            "tool": step.get("tool"),
+            "args": step.get("args", {}),
+            "status": "success",
+            "result": {"ok": True},
+            "error": None,
+        }
+
+
+class FakeLogger:
+    def error(self, *args, **kwargs):
+        pass
+
+
+def make_agent(run_profile, steps, *, current_profile="owner"):
+    settings = Settings(
+        env="test",
+        execution_profile=current_profile,
+        shell_enabled=True,
+        git_enabled=True,
+    )
+    run = {
+        "run_id": "run-1",
+        "task": "Guarded continuation",
+        "status": "awaiting_approval",
+        "execution_profile": run_profile,
+        "steps": [],
+        "artifacts": [
+            {
+                "name": "run_plan",
+                "content": json.dumps({"task": "Guarded continuation", "steps": steps}),
+            }
+        ],
+    }
+    agent = VelocityClawAgent.__new__(VelocityClawAgent)
+    agent.settings = settings
+    agent.logger = FakeLogger()
+    agent.memory = FakeMemory(run)
+    agent.profile_manager = ExecutionProfileManager(settings)
+    agent.approvals = ApprovalManager(settings)
+    agent.security = FakeSecurity()
+    agent.executor = FakeExecutor()
+    agent.step_guard = StepExecutionGuard(
+        profile_manager=agent.profile_manager,
+        security=agent.security,
+        executor=agent.executor,
+        profile_selector=agent._get_profile_for_tool,
+        logger=agent.logger,
+    )
+    return agent
+
+
+def shell_step(step_id):
+    return {
+        "id": step_id,
+        "title": f"Shell {step_id}",
+        "tool": "shell.run",
+        "args": {"command": "pwd"},
+    }
+
+
+def test_resume_uses_stored_dev_profile_not_current_owner_profile():
+    async def scenario():
+        agent = make_agent("dev", [shell_step(1)], current_profile="owner")
+
+        result = await agent.resume_after_approval("run-1", 1)
+
+        assert result["status"] == "completed"
+        assert agent.executor.calls == ["shell.run"]
+        executed = result["executed"][0]
+        assert executed["policy"] == {
+            "profile": "dev",
+            "mode": "approval",
+            "approved": True,
+        }
+        assert agent.memory.statuses[-1] == ("run-1", "completed")
+
+    asyncio.run(scenario())
+
+
+def test_legacy_approval_cannot_override_stored_safe_profile_deny():
+    async def scenario():
+        agent = make_agent("safe", [shell_step(1)], current_profile="owner")
+
+        result = await agent.resume_after_approval("run-1", 1)
+
+        assert result["status"] == "failed"
+        assert agent.executor.calls == []
+        assert "denied by execution profile safe" in result["executed"][0]["error"]
+        assert agent.memory.statuses[-1] == ("run-1", "failed")
+
+    asyncio.run(scenario())
+
+
+def test_continuation_reopens_approval_for_next_dev_shell_step():
+    async def scenario():
+        agent = make_agent("dev", [shell_step(1), shell_step(2)], current_profile="owner")
+
+        result = await agent.resume_after_approval("run-1", 1)
+
+        assert result["status"] == "awaiting_approval"
+        assert result["boundary_step_id"] == 2
+        assert agent.executor.calls == ["shell.run"]
+        assert result["executed"][0]["id"] == 1
+        assert agent.memory.statuses[-1] == ("run-1", "awaiting_approval")
+        assert agent.memory.approval_events[-1][1:3] == (2, "requested")
+        approval_payload = agent.memory.approval_events[-1][3]
+        assert approval_payload["profile"] == "dev"
+        assert approval_payload["policy_mode"] == "approval"
+
+    asyncio.run(scenario())

--- a/tests/test_execution_profiles_v2.py
+++ b/tests/test_execution_profiles_v2.py
@@ -1,10 +1,28 @@
 from velocity_claw.config.settings import Settings
-from velocity_claw.security.access import ExecutionProfileManager
+from velocity_claw.security.access import ApprovalManager, ExecutionProfileManager
 from velocity_claw.security.profile_explain import classify_tool
 
 
-def make_manager(profile="safe"):
-    return ExecutionProfileManager(Settings(env="test", execution_profile=profile))
+def make_manager(profile="safe", *, shell_enabled=False, git_enabled=False):
+    return ExecutionProfileManager(
+        Settings(
+            env="test",
+            execution_profile=profile,
+            shell_enabled=shell_enabled,
+            git_enabled=git_enabled,
+        )
+    )
+
+
+def make_approvals(profile="safe", *, shell_enabled=False, git_enabled=False):
+    return ApprovalManager(
+        Settings(
+            env="test",
+            execution_profile=profile,
+            shell_enabled=shell_enabled,
+            git_enabled=git_enabled,
+        )
+    )
 
 
 def test_classify_tool_maps_known_tools_to_category_risk_and_capability():
@@ -18,57 +36,123 @@ def test_classify_tool_maps_known_tools_to_category_risk_and_capability():
     assert patch["risk_level"] == "medium"
     assert patch["capability"] == "patch_engine"
 
+    preview = classify_tool("patch.preview")
+    assert preview["category"] == "patch_preview"
+    assert preview["risk_level"] == "low"
+    assert preview["capability"] is None
+
     unknown = classify_tool("custom.tool")
     assert unknown["category"] == "unknown"
     assert unknown["risk_level"] == "unknown"
     assert unknown["capability"] is None
 
 
-def test_safe_profile_explains_blocked_shell_access():
-    explanation = make_manager("safe").explain_tool_access("shell.run")
+def test_safe_profile_explains_hard_denied_shell_access():
+    explanation = make_manager("safe", shell_enabled=True).explain_tool_access("shell.run")
 
     assert explanation["profile"] == "safe"
     assert explanation["tool"] == "shell.run"
     assert explanation["allowed"] is False
+    assert explanation["allowed_now"] is False
+    assert explanation["blocked"] is True
+    assert explanation["policy_mode"] == "deny"
     assert explanation["category"] == "shell"
     assert explanation["risk_level"] == "high"
     assert explanation["required_capability"] == "shell"
-    assert "does not grant" in explanation["reason"]
-    assert explanation["approval_hint"] == "approval_required_or_strongly_recommended"
+    assert "denied" in explanation["reason"]
+    assert explanation["approval_hint"] == "approval_cannot_override_profile_deny"
     assert explanation["profile_capabilities"]["shell"] is False
 
 
-def test_dev_profile_allows_shell_but_blocks_git_write():
-    manager = make_manager("dev")
+def test_dev_profile_shell_is_approval_gated_and_git_write_is_denied():
+    manager = make_manager("dev", shell_enabled=True, git_enabled=True)
 
     shell = manager.explain_tool_access("shell.run")
     assert shell["allowed"] is True
-    assert shell["profile_capabilities"]["shell"] is True
+    assert shell["allowed_now"] is False
+    assert shell["blocked"] is False
+    assert shell["policy_mode"] == "approval"
+    assert shell["approval_hint"] == "approval_required"
 
     git_write = manager.explain_tool_access("git.run")
     assert git_write["allowed"] is False
+    assert git_write["blocked"] is True
     assert git_write["category"] == "git_write"
     assert git_write["required_capability"] == "git_write"
     assert git_write["risk_level"] == "high"
 
 
-def test_owner_profile_allows_network_and_git_write():
-    manager = make_manager("owner")
+def test_owner_profile_allows_network_and_git_when_runtime_enabled():
+    manager = make_manager("owner", shell_enabled=True, git_enabled=True)
 
     git_write = manager.explain_tool_access("git.run")
     network = manager.explain_tool_access("http.get")
 
     assert git_write["allowed"] is True
+    assert git_write["allowed_now"] is True
     assert git_write["profile_capabilities"]["git_write"] is True
     assert network["allowed"] is True
-    assert network["category"] == "network"
+    assert network["allowed_now"] is True
+    assert network["category"] == "network_read"
     assert network["required_capability"] == "network"
 
 
-def test_git_inspect_remains_low_risk_read_for_safe_profile():
-    explanation = make_manager("safe").explain_tool_access("git.inspect")
+def test_git_inspect_is_profile_granted_but_runtime_blocked_when_git_disabled():
+    explanation = make_manager("safe", git_enabled=False).explain_tool_access("git.inspect")
 
     assert explanation["allowed"] is True
+    assert explanation["allowed_now"] is False
+    assert explanation["blocked"] is True
     assert explanation["category"] == "git_read"
     assert explanation["risk_level"] == "low"
-    assert explanation["required_capability"] is None
+    assert "GIT_ENABLED=false" in explanation["reason"]
+
+
+def test_capability_matrix_exposes_modes_and_runtime_constraints():
+    matrix = make_manager("dev", shell_enabled=True, git_enabled=False).get_capability_matrix()
+
+    assert matrix["profile"] == "dev"
+    assert matrix["policy"]["tool_modes"]["shell.run"] == "approval"
+    assert matrix["policy"]["tool_modes"]["git.run"] == "deny"
+    assert matrix["policy"]["unknown_tool_mode"] == "deny"
+    assert matrix["runtime_constraints"]["shell_enabled"] is True
+    assert matrix["runtime_constraints"]["git_enabled"] is False
+    assert matrix["policy"]["effective_tools"]["shell.run"]["requires_approval"] is True
+
+
+def test_approval_manager_does_not_offer_approval_for_hard_deny():
+    decision = make_approvals("safe", shell_enabled=True).explain_requirement(
+        {"tool": "shell.run", "args": {"command": "pwd"}}
+    )
+
+    assert decision["required"] is False
+    assert decision["blocked"] is True
+    assert decision["policy_mode"] == "deny"
+    assert decision["recommended_action"] == "change_profile_or_runtime_then_replan"
+    assert decision["approval_label"] == "denied:shell.run"
+
+
+def test_dev_shell_requires_approval_only_when_runtime_enabled():
+    step = {"tool": "shell.run", "args": {"command": "pwd"}}
+
+    enabled = make_approvals("dev", shell_enabled=True).explain_requirement(step)
+    assert enabled["required"] is True
+    assert enabled["blocked"] is False
+    assert enabled["triggers"] == ["dev_profile_approval_mode"]
+
+    disabled = make_approvals("dev", shell_enabled=False).explain_requirement(step)
+    assert disabled["required"] is False
+    assert disabled["blocked"] is True
+    assert disabled["runtime_blocked"] is True
+    assert "SHELL_ENABLED=false" in disabled["reason"]
+
+
+def test_owner_explicit_approval_is_still_enforced():
+    decision = make_approvals("owner", shell_enabled=True).explain_requirement(
+        {"tool": "shell.run", "args": {"command": "pwd", "require_approval": True}}
+    )
+
+    assert decision["required"] is True
+    assert decision["blocked"] is False
+    assert decision["triggers"] == ["explicit_require_approval"]
+    assert decision["policy_mode"] == "allow"

--- a/tests/test_step_guard_v2.py
+++ b/tests/test_step_guard_v2.py
@@ -1,0 +1,157 @@
+import asyncio
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.core.step_guard import StepExecutionGuard
+from velocity_claw.security.access import ExecutionProfileManager
+
+
+class FakeSecurity:
+    def __init__(self, fail=False):
+        self.fail = fail
+        self.calls = []
+
+    def get_profile(self, name):
+        return name
+
+    def validate_command(self, command, profile):
+        self.calls.append(("shell", command, profile))
+        if self.fail:
+            raise ValueError("security blocked command")
+
+    def validate_path(self, path, profile, write=False):
+        self.calls.append(("path", path, profile, write))
+        if self.fail:
+            raise ValueError("security blocked path")
+
+    def validate_url(self, url, profile):
+        self.calls.append(("url", url, profile))
+        if self.fail:
+            raise ValueError("security blocked url")
+
+    def validate_git_command(self, command, profile):
+        self.calls.append(("git", command, profile))
+        if self.fail:
+            raise ValueError("security blocked git")
+
+
+class FakeExecutor:
+    def __init__(self):
+        self.calls = []
+
+    async def execute_step(self, step, context):
+        self.calls.append((step, context))
+        return {
+            "id": step.get("id"),
+            "title": step.get("title"),
+            "tool": step.get("tool"),
+            "args": step.get("args", {}),
+            "status": "success",
+            "result": {"ok": True},
+            "error": None,
+        }
+
+
+class FakeLogger:
+    def error(self, *args, **kwargs):
+        pass
+
+
+def make_guard(profile, *, shell_enabled=True, git_enabled=True, security=None):
+    settings = Settings(
+        env="test",
+        execution_profile=profile,
+        shell_enabled=shell_enabled,
+        git_enabled=git_enabled,
+    )
+    executor = FakeExecutor()
+    guard = StepExecutionGuard(
+        profile_manager=ExecutionProfileManager(settings),
+        security=security or FakeSecurity(),
+        executor=executor,
+        profile_selector=lambda tool: "workspace_write" if tool == "shell.run" else "read_only",
+        logger=FakeLogger(),
+    )
+    return guard, executor
+
+
+def shell_step():
+    return {"id": 1, "title": "Run pwd", "tool": "shell.run", "args": {"command": "pwd"}}
+
+
+def test_dev_shell_stops_at_approval_boundary_before_security_or_executor():
+    async def scenario():
+        security = FakeSecurity()
+        guard, executor = make_guard("dev", security=security)
+
+        outcome = await guard.execute(shell_step(), {}, "dev", approved=False)
+
+        assert outcome["state"] == "approval_required"
+        assert outcome["step_result"] is None
+        assert security.calls == []
+        assert executor.calls == []
+
+    asyncio.run(scenario())
+
+
+def test_approved_dev_shell_still_passes_security_then_executes():
+    async def scenario():
+        security = FakeSecurity()
+        guard, executor = make_guard("dev", security=security)
+
+        outcome = await guard.execute(shell_step(), {"source": "resume"}, "dev", approved=True)
+
+        assert outcome["state"] == "executed"
+        assert outcome["step_result"]["status"] == "success"
+        assert outcome["step_result"]["policy"] == {
+            "profile": "dev",
+            "mode": "approval",
+            "approved": True,
+        }
+        assert security.calls == [("shell", "pwd", "workspace_write")]
+        assert len(executor.calls) == 1
+
+    asyncio.run(scenario())
+
+
+def test_approval_cannot_override_safe_profile_hard_deny():
+    async def scenario():
+        security = FakeSecurity()
+        guard, executor = make_guard("safe", security=security)
+
+        outcome = await guard.execute(shell_step(), {}, "safe", approved=True)
+
+        assert outcome["state"] == "blocked"
+        assert outcome["step_result"]["status"] == "failed"
+        assert "denied by execution profile safe" in outcome["step_result"]["error"]
+        assert security.calls == []
+        assert executor.calls == []
+
+    asyncio.run(scenario())
+
+
+def test_runtime_disable_cannot_be_overridden_by_approval():
+    async def scenario():
+        guard, executor = make_guard("dev", shell_enabled=False)
+
+        outcome = await guard.execute(shell_step(), {}, "dev", approved=True)
+
+        assert outcome["state"] == "blocked"
+        assert "SHELL_ENABLED=false" in outcome["step_result"]["error"]
+        assert executor.calls == []
+
+    asyncio.run(scenario())
+
+
+def test_security_failure_is_structured_and_executor_is_not_called():
+    async def scenario():
+        security = FakeSecurity(fail=True)
+        guard, executor = make_guard("owner", security=security)
+
+        outcome = await guard.execute(shell_step(), {}, "owner", approved=False)
+
+        assert outcome["state"] == "security_failed"
+        assert outcome["step_result"]["status"] == "failed"
+        assert outcome["step_result"]["error"] == "security blocked command"
+        assert executor.calls == []
+
+    asyncio.run(scenario())

--- a/velocity_claw/core/agent.py
+++ b/velocity_claw/core/agent.py
@@ -13,6 +13,7 @@ from velocity_claw.security.policy import SecurityManager
 from velocity_claw.security.access import ExecutionProfileManager, ApprovalManager
 from velocity_claw.core.auto_fix import AutoFixLoop
 from velocity_claw.core.modes import build_mode_task, HIGH_LEVEL_MODES
+from velocity_claw.core.step_guard import StepExecutionGuard
 
 
 class VelocityClawAgent:
@@ -27,6 +28,13 @@ class VelocityClawAgent:
         self.security = SecurityManager(settings)
         self.profile_manager = ExecutionProfileManager(settings)
         self.approvals = ApprovalManager(settings)
+        self.step_guard = StepExecutionGuard(
+            profile_manager=self.profile_manager,
+            security=self.security,
+            executor=self.executor,
+            profile_selector=self._get_profile_for_tool,
+            logger=self.logger,
+        )
         self.auto_fix = AutoFixLoop(self.executor.patch, self.executor.test_runner, self.executor.code_nav)
 
     def _get_profile_for_tool(self, tool: str) -> str:
@@ -37,6 +45,12 @@ class VelocityClawAgent:
         if tool in ["fs.write", "fs.append", "fs.replace", "shell.run", "patch.apply", "test.run"]:
             return "workspace_write"
         return "read_only"
+
+    def _profile_for_run(self, run: Dict) -> str:
+        stored = str(run.get("execution_profile") or "").strip().lower()
+        if stored in {"safe", "dev", "owner"}:
+            return stored
+        return self.settings.execution_profile
 
     def _build_planning_context(self, context: Optional[Dict], task: str = "") -> Dict:
         merged = dict(context or {})
@@ -175,64 +189,30 @@ class VelocityClawAgent:
             self.memory.save_artifact(run_id, "resume_context", json.dumps(resume_context, ensure_ascii=False), artifact_type="resume_context")
             self.memory.save_project_note("plan_summary", f"Planned {len(plan.get('steps', []))} steps for task: {task}")
             results = []
+            profile_name = self.settings.execution_profile
             for step in plan["steps"]:
                 step_id = step["id"]
                 self.logger.info("Run %s: Executing step %s", run_id, step_id)
                 started_at = datetime.now().isoformat()
-                profile_name = self.settings.execution_profile
-                if self.approvals.requires_approval(step, profile_name):
-                    return self._pause_for_approval(run_id, task, step, started_at, profile_name, results, boundary_type="initial_pause")
+                outcome = await self.step_guard.execute(
+                    step,
+                    context or {},
+                    profile_name,
+                    approved=False,
+                    started_at=started_at,
+                )
+                if outcome["state"] == "approval_required":
+                    return self._pause_for_approval(
+                        run_id,
+                        task,
+                        step,
+                        started_at,
+                        profile_name,
+                        results,
+                        boundary_type="initial_pause",
+                    )
 
-                if not self.profile_manager.is_tool_allowed(step.get("tool", ""), profile_name):
-                    completed_at = datetime.now().isoformat()
-                    step_result = {
-                        "id": step_id,
-                        "title": step["title"],
-                        "tool": step.get("tool"),
-                        "args": step.get("args", {}),
-                        "status": "failed",
-                        "result": None,
-                        "error": f"Tool {step.get('tool')} is not allowed in profile {profile_name}",
-                        "started_at": started_at,
-                        "completed_at": completed_at,
-                    }
-                    results.append(step_result)
-                    self.memory.save_step(run_id, step_result)
-                    break
-
-                profile = self.security.get_profile(self._get_profile_for_tool(step.get("tool", "")))
-                try:
-                    if step["tool"] == "shell.run":
-                        self.security.validate_command(step["args"].get("command", ""), profile)
-                    elif step["tool"] == "fs.read":
-                        self.security.validate_path(step["args"].get("path", ""), profile, write=False)
-                    elif step["tool"] in ["fs.write", "fs.append", "fs.replace"]:
-                        self.security.validate_path(step["args"].get("path", ""), profile, write=True)
-                    elif step["tool"] in ["http.get", "http.post"]:
-                        self.security.validate_url(step["args"].get("url", ""), profile)
-                    elif step["tool"] == "git.run":
-                        self.security.validate_git_command(step["args"].get("command", ""), profile)
-                except Exception as e:
-                    completed_at = datetime.now().isoformat()
-                    self.logger.error("Run %s: Security validation failed for step %s: %s", run_id, step_id, e)
-                    step_result = {
-                        "id": step_id,
-                        "title": step["title"],
-                        "tool": step.get("tool"),
-                        "args": step.get("args", {}),
-                        "status": "failed",
-                        "result": None,
-                        "error": str(e),
-                        "started_at": started_at,
-                        "completed_at": completed_at,
-                    }
-                    results.append(step_result)
-                    self.memory.save_step(run_id, step_result)
-                    break
-
-                step_result = await self.executor.execute_step(step, context or {})
-                step_result["started_at"] = started_at
-                step_result["completed_at"] = datetime.now().isoformat()
+                step_result = outcome["step_result"]
                 results.append(step_result)
                 self.memory.save_step(run_id, step_result)
                 self._persist_artifacts(run_id, step_result)
@@ -389,20 +369,34 @@ class VelocityClawAgent:
             return {"status": "manual_resume_required", "reason": "step_boundary_missing"}
 
         executed = []
-        profile_name = self.settings.execution_profile
+        profile_name = self._profile_for_run(run)
         for index, step in enumerate(steps[start_index:], start=start_index):
             started_at = datetime.now().isoformat()
-            if index > start_index and self.approvals.requires_approval(step, profile_name):
-                pause = self._pause_for_approval(run_id, run["task"], step, started_at, profile_name, [], boundary_type="continuation_pause")
+            outcome = await self.step_guard.execute(
+                step,
+                {},
+                profile_name,
+                approved=index == start_index,
+                started_at=started_at,
+            )
+            if outcome["state"] == "approval_required":
+                pause = self._pause_for_approval(
+                    run_id,
+                    run["task"],
+                    step,
+                    started_at,
+                    profile_name,
+                    [],
+                    boundary_type="continuation_pause",
+                )
                 return {
                     "status": "awaiting_approval",
                     "boundary_step_id": step.get("id"),
                     "executed": executed,
                     "pause": pause,
                 }
-            result = await self.executor.execute_step(step, {})
-            result["started_at"] = result.get("started_at") or started_at
-            result["completed_at"] = datetime.now().isoformat()
+
+            result = outcome["step_result"]
             self.memory.save_step(run_id, result)
             self._persist_artifacts(run_id, result)
             executed.append(result)

--- a/velocity_claw/core/step_guard.py
+++ b/velocity_claw/core/step_guard.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Callable
+
+
+class StepExecutionGuard:
+    def __init__(
+        self,
+        *,
+        profile_manager: Any,
+        security: Any,
+        executor: Any,
+        profile_selector: Callable[[str], str],
+        logger: Any,
+    ):
+        self.profile_manager = profile_manager
+        self.security = security
+        self.executor = executor
+        self.profile_selector = profile_selector
+        self.logger = logger
+
+    def evaluate(self, step: dict, profile_name: str, *, approved: bool = False) -> dict:
+        args = step.get("args", {}) or {}
+        return self.profile_manager.evaluate_tool(
+            step.get("tool", ""),
+            profile_name,
+            approved=approved,
+            explicit_approval=args.get("require_approval") is True,
+        )
+
+    def _validate_security(self, step: dict) -> None:
+        tool = step.get("tool", "")
+        args = step.get("args", {}) or {}
+        access_profile = self.security.get_profile(self.profile_selector(tool))
+        if tool == "shell.run":
+            self.security.validate_command(args.get("command", ""), access_profile)
+        elif tool == "fs.read":
+            self.security.validate_path(args.get("path", ""), access_profile, write=False)
+        elif tool in {"fs.write", "fs.append", "fs.replace"}:
+            self.security.validate_path(args.get("path", ""), access_profile, write=True)
+        elif tool in {"http.get", "http.post"}:
+            self.security.validate_url(args.get("url", ""), access_profile)
+        elif tool == "git.run":
+            self.security.validate_git_command(args.get("command", ""), access_profile)
+
+    def _failed_result(self, step: dict, started_at: str, error: str, policy: dict) -> dict:
+        return {
+            "id": step.get("id"),
+            "title": step.get("title", "unknown"),
+            "tool": step.get("tool"),
+            "args": step.get("args", {}),
+            "status": "failed",
+            "result": {"policy": policy},
+            "error": error,
+            "started_at": started_at,
+            "completed_at": datetime.now().isoformat(),
+        }
+
+    async def execute(
+        self,
+        step: dict,
+        context: dict,
+        profile_name: str,
+        *,
+        approved: bool = False,
+        started_at: str | None = None,
+    ) -> dict:
+        started_at = started_at or datetime.now().isoformat()
+        policy = self.evaluate(step, profile_name, approved=approved)
+
+        if policy["blocked"]:
+            return {
+                "state": "blocked",
+                "policy": policy,
+                "step_result": self._failed_result(step, started_at, policy["reason"], policy),
+            }
+        if policy["requires_approval"]:
+            return {
+                "state": "approval_required",
+                "policy": policy,
+                "step_result": None,
+            }
+
+        try:
+            self._validate_security(step)
+        except Exception as exc:
+            self.logger.error(
+                "Security validation failed for step %s under profile %s: %s",
+                step.get("id"),
+                profile_name,
+                exc,
+            )
+            return {
+                "state": "security_failed",
+                "policy": policy,
+                "step_result": self._failed_result(step, started_at, str(exc), policy),
+            }
+
+        result = await self.executor.execute_step(step, context)
+        result["started_at"] = result.get("started_at") or started_at
+        result["completed_at"] = datetime.now().isoformat()
+        result["policy"] = {
+            "profile": policy["profile"],
+            "mode": policy["mode"],
+            "approved": policy["approved"],
+        }
+        return {
+            "state": "executed",
+            "policy": policy,
+            "step_result": result,
+        }

--- a/velocity_claw/security/access.py
+++ b/velocity_claw/security/access.py
@@ -4,7 +4,17 @@ from dataclasses import asdict, dataclass
 from typing import Optional
 
 from velocity_claw.config.settings import Settings
-from velocity_claw.security.profile_explain import explain_tool_access as build_tool_access_explanation
+from velocity_claw.security.profile_explain import (
+    classify_tool,
+    explain_tool_access as build_tool_access_explanation,
+)
+from velocity_claw.security.profile_policy_v2 import (
+    APPROVAL,
+    DENY,
+    evaluate_tool_policy,
+    get_tool_mode,
+    profile_mode_summary,
+)
 
 
 class AccessControl:
@@ -43,7 +53,7 @@ class ExecutionProfileManager:
                 git_write=False,
                 network=False,
                 approval_workflow=True,
-                description="Restrictive profile for safe inspection and tightly controlled actions.",
+                description="Inspection-first profile. Read and test tools are allowed; mutation, shell, git write, and network tools are hard denied.",
             ),
             "dev": ExecutionProfile(
                 "dev",
@@ -54,7 +64,7 @@ class ExecutionProfileManager:
                 git_write=False,
                 network=False,
                 approval_workflow=True,
-                description="Development-focused profile with editing, testing, and limited shell workflows.",
+                description="Development profile. Workspace edits and tests are allowed, shell requires approval, git write and network remain denied.",
             ),
             "owner": ExecutionProfile(
                 "owner",
@@ -65,16 +75,21 @@ class ExecutionProfileManager:
                 git_write=True,
                 network=True,
                 approval_workflow=True,
-                description="Expanded trusted profile with broader tool access and auditability.",
+                description="Owner profile. All registered tools are available; explicit approval requests remain enforceable and all actions stay audited.",
             ),
         }
 
     def get_profile(self, name: Optional[str] = None) -> ExecutionProfile:
-        key = name or self.settings.execution_profile
+        key = (name or self.settings.execution_profile or "safe").strip().lower()
         return self._profiles.get(key, self._profiles["safe"])
 
     def list_profiles(self) -> dict:
-        return {name: asdict(profile) for name, profile in self._profiles.items()}
+        profiles = {}
+        for name, profile in self._profiles.items():
+            payload = asdict(profile)
+            payload["policy"] = profile_mode_summary(name)
+            profiles[name] = payload
+        return profiles
 
     def get_capability_matrix(self, profile_name: Optional[str] = None) -> dict:
         profile = self.get_profile(profile_name)
@@ -90,28 +105,38 @@ class ExecutionProfileManager:
                 "network": profile.network,
                 "approval_workflow": profile.approval_workflow,
             },
+            "policy": profile_mode_summary(profile.name),
         }
 
-    def is_tool_allowed(self, tool: str, profile_name: Optional[str] = None) -> bool:
+    def get_tool_mode(self, tool: str, profile_name: Optional[str] = None) -> str:
         profile = self.get_profile(profile_name)
-        if tool in {"fs.write", "fs.append", "fs.replace"}:
-            return profile.filesystem_write
-        if tool in {"patch.apply", "patch.preview"}:
-            return profile.patch_engine
-        if tool == "test.run":
-            return profile.test_runner
-        if tool == "shell.run":
-            return profile.shell
-        if tool in {"git.run", "git.inspect"}:
-            return profile.git_write or tool == "git.inspect"
-        if tool in {"http.get", "http.post"}:
-            return profile.network
-        return True
+        return get_tool_mode(profile.name, tool)
+
+    def evaluate_tool(
+        self,
+        tool: str,
+        profile_name: Optional[str] = None,
+        *,
+        approved: bool = False,
+        explicit_approval: bool = False,
+    ) -> dict:
+        profile = self.get_profile(profile_name)
+        decision = evaluate_tool_policy(
+            profile_name=profile.name,
+            tool=tool,
+            approved=approved,
+            explicit_approval=explicit_approval,
+        )
+        decision["classification"] = classify_tool(tool)
+        return decision
+
+    def is_tool_allowed(self, tool: str, profile_name: Optional[str] = None) -> bool:
+        return bool(self.evaluate_tool(tool, profile_name)["granted"])
 
     def explain_tool_access(self, tool: str, profile_name: Optional[str] = None) -> dict:
         profile = self.get_profile(profile_name)
-        allowed = self.is_tool_allowed(tool, profile.name)
-        return build_tool_access_explanation(profile, tool, allowed)
+        policy = self.evaluate_tool(tool, profile.name)
+        return build_tool_access_explanation(profile, tool, policy["granted"], policy=policy)
 
 
 class ApprovalManager:
@@ -121,29 +146,33 @@ class ApprovalManager:
 
     def requires_approval(self, step: dict, profile_name: Optional[str] = None) -> bool:
         decision = self.explain_requirement(step, profile_name)
-        return decision["required"]
+        return bool(decision["required"])
 
     def explain_requirement(self, step: dict, profile_name: Optional[str] = None) -> dict:
         profile = self.profile_manager.get_profile(profile_name)
-        tool = step.get("tool")
-        args = step.get("args", {})
-        triggers = []
-        risk_level = "low"
+        tool = step.get("tool") or ""
+        args = step.get("args", {}) or {}
+        explicit = args.get("require_approval") is True
+        policy = self.profile_manager.evaluate_tool(
+            tool,
+            profile.name,
+            approved=False,
+            explicit_approval=explicit,
+        )
+        classification = policy["classification"]
+        triggers: list[str] = []
 
-        if args.get("require_approval") is True:
-            triggers.append("explicit_require_approval")
+        if not policy["blocked"]:
+            if policy["mode"] == APPROVAL:
+                triggers.append(f"{profile.name}_profile_approval_mode")
+            if explicit:
+                triggers.append("explicit_require_approval")
+
+        required = bool(policy["requires_approval"] and not policy["blocked"])
+        blocked = bool(policy["blocked"])
+        risk_level = classification.get("risk_level") or "unknown"
+        if blocked:
             risk_level = "high"
-
-        if profile.approval_workflow:
-            if profile.name == "safe" and tool in {"patch.apply", "shell.run", "git.run", "fs.write", "fs.append", "fs.replace"}:
-                triggers.append("safe_profile_sensitive_write_or_exec")
-                risk_level = "high"
-            elif profile.name == "dev" and tool in {"git.run", "shell.run"}:
-                triggers.append("dev_profile_exec_or_git_write")
-                risk_level = "medium"
-            elif profile.name == "owner" and tool in {"shell.run", "git.run"} and args.get("require_approval") is True:
-                triggers.append("owner_profile_explicit_approval")
-                risk_level = "medium"
 
         path = args.get("path") or args.get("cwd")
         command = args.get("command")
@@ -152,19 +181,21 @@ class ApprovalManager:
             "path": path,
             "command": command,
         }
-        required = bool(triggers)
-        next_step_hint = self._build_next_step_hint(tool, summary)
-        operator_hint = self._build_operator_hint(required, risk_level, tool)
-        recommended_action = self._build_recommended_action(required, risk_level)
-        approval_label = self._build_approval_label(required, risk_level, tool)
+        next_step_hint = self._build_next_step_hint(tool, summary, blocked=blocked)
+        operator_hint = self._build_operator_hint(required, blocked, risk_level, tool)
+        recommended_action = self._build_recommended_action(required, blocked, risk_level)
+        approval_label = self._build_approval_label(required, blocked, risk_level, tool)
         return {
             "required": required,
+            "blocked": blocked,
+            "allowed_now": policy["allowed_now"],
             "profile": profile.name,
             "tool": tool,
-            "risk_level": risk_level if required else "low",
+            "policy_mode": policy["mode"],
+            "risk_level": risk_level if (required or blocked) else "low",
             "triggers": triggers,
             "summary": summary,
-            "reason": self._build_reason(profile.name, tool, triggers),
+            "reason": policy["reason"],
             "recommended_action": recommended_action,
             "operator_hint": operator_hint,
             "next_step_hint": next_step_hint,
@@ -177,12 +208,15 @@ class ApprovalManager:
             explanation["reason"] = reason
         return {
             "required": explanation["required"],
+            "blocked": explanation["blocked"],
+            "allowed_now": explanation["allowed_now"],
             "reason": explanation["reason"],
             "decision": None,
             "decided_by": None,
             "decided_at": None,
             "profile": explanation["profile"],
             "tool": explanation["tool"],
+            "policy_mode": explanation["policy_mode"],
             "risk_level": explanation["risk_level"],
             "triggers": explanation["triggers"],
             "summary": explanation["summary"],
@@ -192,30 +226,27 @@ class ApprovalManager:
             "approval_label": explanation["approval_label"],
         }
 
-    def _build_reason(self, profile_name: str, tool: Optional[str], triggers: list[str]) -> str:
-        if not triggers:
-            return "Approval not required."
-        return f"Approval required for tool {tool} under profile {profile_name}: {', '.join(triggers)}"
-
-    def _build_recommended_action(self, required: bool, risk_level: str) -> str:
+    def _build_recommended_action(self, required: bool, blocked: bool, risk_level: str) -> str:
+        if blocked:
+            return "change_profile_or_replan"
         if not required:
             return "continue"
         if risk_level == "high":
             return "review_then_approve_or_reject"
-        if risk_level == "medium":
-            return "quick_review"
-        return "continue"
+        return "quick_review"
 
-    def _build_operator_hint(self, required: bool, risk_level: str, tool: Optional[str]) -> str:
+    def _build_operator_hint(self, required: bool, blocked: bool, risk_level: str, tool: Optional[str]) -> str:
+        if blocked:
+            return f"{tool} is hard denied by this profile; approval cannot override the policy."
         if not required:
             return "No operator action required."
         if risk_level == "high":
             return f"High-risk approval for {tool}. Review path/command details before approving."
-        if risk_level == "medium":
-            return f"Review {tool} briefly before continuing."
-        return f"Approval gate present for {tool}."
+        return f"Review {tool} before continuing."
 
-    def _build_next_step_hint(self, tool: Optional[str], summary: dict) -> str:
+    def _build_next_step_hint(self, tool: Optional[str], summary: dict, *, blocked: bool = False) -> str:
+        if blocked:
+            return "Replan with an allowed tool or switch to an explicitly authorized profile."
         path = summary.get("path")
         command = summary.get("command")
         if tool == "patch.apply" and path:
@@ -228,7 +259,9 @@ class ApprovalManager:
             return f"If approved, execution continues against {path}."
         return "If approved, the paused run will continue to the gated step."
 
-    def _build_approval_label(self, required: bool, risk_level: str, tool: Optional[str]) -> str:
+    def _build_approval_label(self, required: bool, blocked: bool, risk_level: str, tool: Optional[str]) -> str:
+        if blocked:
+            return f"denied:{tool or 'unknown'}"
         if not required:
             return "not_required"
         return f"{risk_level}:{tool or 'unknown'}"

--- a/velocity_claw/security/access.py
+++ b/velocity_claw/security/access.py
@@ -10,7 +10,6 @@ from velocity_claw.security.profile_explain import (
 )
 from velocity_claw.security.profile_policy_v2 import (
     APPROVAL,
-    DENY,
     evaluate_tool_policy,
     get_tool_mode,
     profile_mode_summary,
@@ -91,8 +90,20 @@ class ExecutionProfileManager:
             profiles[name] = payload
         return profiles
 
+    def _runtime_block_reason(self, tool: str) -> str | None:
+        if tool == "shell.run" and not self.settings.shell_enabled:
+            return "Shell execution is disabled by runtime setting SHELL_ENABLED=false."
+        if tool in {"git.run", "git.inspect"} and not self.settings.git_enabled:
+            return "Git execution is disabled by runtime setting GIT_ENABLED=false."
+        return None
+
     def get_capability_matrix(self, profile_name: Optional[str] = None) -> dict:
         profile = self.get_profile(profile_name)
+        policy = profile_mode_summary(profile.name)
+        policy["effective_tools"] = {
+            tool: self.evaluate_tool(tool, profile.name)
+            for tool in policy["tool_modes"]
+        }
         return {
             "profile": profile.name,
             "description": profile.description,
@@ -105,7 +116,13 @@ class ExecutionProfileManager:
                 "network": profile.network,
                 "approval_workflow": profile.approval_workflow,
             },
-            "policy": profile_mode_summary(profile.name),
+            "runtime_constraints": {
+                "shell_enabled": self.settings.shell_enabled,
+                "git_enabled": self.settings.git_enabled,
+                "dry_run": self.settings.dry_run,
+                "allowed_hosts": list(self.settings.allowed_hosts),
+            },
+            "policy": policy,
         }
 
     def get_tool_mode(self, tool: str, profile_name: Optional[str] = None) -> str:
@@ -127,6 +144,15 @@ class ExecutionProfileManager:
             approved=approved,
             explicit_approval=explicit_approval,
         )
+        decision["profile_blocked"] = decision["blocked"]
+        decision["runtime_blocked"] = False
+        runtime_reason = self._runtime_block_reason(tool)
+        if runtime_reason and not decision["profile_blocked"]:
+            decision["blocked"] = True
+            decision["runtime_blocked"] = True
+            decision["requires_approval"] = False
+            decision["allowed_now"] = False
+            decision["reason"] = runtime_reason
         decision["classification"] = classify_tool(tool)
         return decision
 
@@ -145,8 +171,7 @@ class ApprovalManager:
         self.profile_manager = ExecutionProfileManager(settings)
 
     def requires_approval(self, step: dict, profile_name: Optional[str] = None) -> bool:
-        decision = self.explain_requirement(step, profile_name)
-        return bool(decision["required"])
+        return bool(self.explain_requirement(step, profile_name)["required"])
 
     def explain_requirement(self, step: dict, profile_name: Optional[str] = None) -> dict:
         profile = self.profile_manager.get_profile(profile_name)
@@ -161,7 +186,6 @@ class ApprovalManager:
         )
         classification = policy["classification"]
         triggers: list[str] = []
-
         if not policy["blocked"]:
             if policy["mode"] == APPROVAL:
                 triggers.append(f"{profile.name}_profile_approval_mode")
@@ -170,24 +194,17 @@ class ApprovalManager:
 
         required = bool(policy["requires_approval"] and not policy["blocked"])
         blocked = bool(policy["blocked"])
-        risk_level = classification.get("risk_level") or "unknown"
-        if blocked:
-            risk_level = "high"
-
-        path = args.get("path") or args.get("cwd")
-        command = args.get("command")
+        risk_level = "high" if blocked else classification.get("risk_level") or "unknown"
         summary = {
             "tool": tool,
-            "path": path,
-            "command": command,
+            "path": args.get("path") or args.get("cwd"),
+            "command": args.get("command"),
         }
-        next_step_hint = self._build_next_step_hint(tool, summary, blocked=blocked)
-        operator_hint = self._build_operator_hint(required, blocked, risk_level, tool)
-        recommended_action = self._build_recommended_action(required, blocked, risk_level)
-        approval_label = self._build_approval_label(required, blocked, risk_level, tool)
         return {
             "required": required,
             "blocked": blocked,
+            "profile_blocked": policy.get("profile_blocked", blocked),
+            "runtime_blocked": policy.get("runtime_blocked", False),
             "allowed_now": policy["allowed_now"],
             "profile": profile.name,
             "tool": tool,
@@ -196,10 +213,10 @@ class ApprovalManager:
             "triggers": triggers,
             "summary": summary,
             "reason": policy["reason"],
-            "recommended_action": recommended_action,
-            "operator_hint": operator_hint,
-            "next_step_hint": next_step_hint,
-            "approval_label": approval_label,
+            "recommended_action": self._build_recommended_action(required, blocked, risk_level),
+            "operator_hint": self._build_operator_hint(required, blocked, risk_level, tool),
+            "next_step_hint": self._build_next_step_hint(tool, summary, blocked=blocked),
+            "approval_label": self._build_approval_label(required, blocked, risk_level, tool),
         }
 
     def build_record(self, step: dict, reason: str | None = None, profile_name: Optional[str] = None) -> dict:
@@ -207,37 +224,22 @@ class ApprovalManager:
         if reason:
             explanation["reason"] = reason
         return {
-            "required": explanation["required"],
-            "blocked": explanation["blocked"],
-            "allowed_now": explanation["allowed_now"],
-            "reason": explanation["reason"],
+            **explanation,
             "decision": None,
             "decided_by": None,
             "decided_at": None,
-            "profile": explanation["profile"],
-            "tool": explanation["tool"],
-            "policy_mode": explanation["policy_mode"],
-            "risk_level": explanation["risk_level"],
-            "triggers": explanation["triggers"],
-            "summary": explanation["summary"],
-            "recommended_action": explanation["recommended_action"],
-            "operator_hint": explanation["operator_hint"],
-            "next_step_hint": explanation["next_step_hint"],
-            "approval_label": explanation["approval_label"],
         }
 
     def _build_recommended_action(self, required: bool, blocked: bool, risk_level: str) -> str:
         if blocked:
-            return "change_profile_or_replan"
+            return "change_profile_or_runtime_then_replan"
         if not required:
             return "continue"
-        if risk_level == "high":
-            return "review_then_approve_or_reject"
-        return "quick_review"
+        return "review_then_approve_or_reject" if risk_level == "high" else "quick_review"
 
     def _build_operator_hint(self, required: bool, blocked: bool, risk_level: str, tool: Optional[str]) -> str:
         if blocked:
-            return f"{tool} is hard denied by this profile; approval cannot override the policy."
+            return f"{tool} is blocked by profile or runtime policy; approval cannot override the block."
         if not required:
             return "No operator action required."
         if risk_level == "high":
@@ -246,7 +248,7 @@ class ApprovalManager:
 
     def _build_next_step_hint(self, tool: Optional[str], summary: dict, *, blocked: bool = False) -> str:
         if blocked:
-            return "Replan with an allowed tool or switch to an explicitly authorized profile."
+            return "Replan with an allowed tool or enable an explicitly authorized profile/runtime capability."
         path = summary.get("path")
         command = summary.get("command")
         if tool == "patch.apply" and path:

--- a/velocity_claw/security/profile_explain.py
+++ b/velocity_claw/security/profile_explain.py
@@ -4,41 +4,53 @@ from typing import Any
 
 
 TOOL_CATEGORIES = {
+    "analysis": "analysis",
     "fs.read": "filesystem_read",
     "fs.write": "filesystem_write",
     "fs.append": "filesystem_write",
     "fs.replace": "filesystem_write",
-    "patch.preview": "patch",
+    "patch.preview": "patch_preview",
     "patch.apply": "patch",
     "test.run": "test",
     "shell.run": "shell",
     "git.inspect": "git_read",
     "git.run": "git_write",
-    "http.get": "network",
-    "http.post": "network",
+    "http.get": "network_read",
+    "http.post": "network_write",
+    "code.find_symbol": "code_read",
+    "code.read_symbol": "code_read",
+    "code.list_imports": "code_read",
 }
 
 RISK_BY_CATEGORY = {
+    "analysis": "low",
     "filesystem_read": "low",
     "filesystem_write": "medium",
+    "patch_preview": "low",
     "patch": "medium",
     "test": "low",
     "shell": "high",
     "git_read": "low",
     "git_write": "high",
-    "network": "medium",
+    "network_read": "medium",
+    "network_write": "high",
+    "code_read": "low",
     "unknown": "unknown",
 }
 
 CAPABILITY_BY_CATEGORY = {
+    "analysis": None,
     "filesystem_read": None,
     "filesystem_write": "filesystem_write",
+    "patch_preview": None,
     "patch": "patch_engine",
     "test": "test_runner",
     "shell": "shell",
     "git_read": None,
     "git_write": "git_write",
-    "network": "network",
+    "network_read": "network",
+    "network_write": "network",
+    "code_read": None,
     "unknown": None,
 }
 
@@ -53,31 +65,44 @@ def classify_tool(tool: str) -> dict[str, Any]:
     }
 
 
-def explain_tool_access(profile: Any, tool: str, allowed: bool) -> dict[str, Any]:
+def explain_tool_access(
+    profile: Any,
+    tool: str,
+    allowed: bool,
+    *,
+    policy: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     classification = classify_tool(tool)
     category = classification["category"]
     capability = classification["capability"]
     profile_name = getattr(profile, "name", "unknown")
+    policy = policy or {}
+    mode = policy.get("mode", "allow" if allowed else "deny")
 
-    if allowed:
-        reason = "Tool is allowed by this execution profile."
+    if policy.get("blocked"):
+        reason = policy.get("reason") or f"Tool is denied by profile '{profile_name}'."
+        approval_hint = "approval_cannot_override_profile_deny"
+    elif policy.get("requires_approval"):
+        reason = policy.get("reason") or f"Tool requires approval in profile '{profile_name}'."
+        approval_hint = "approval_required"
+    elif allowed:
+        reason = policy.get("reason") or "Tool is allowed by this execution profile."
+        approval_hint = "approval_not_required"
     elif capability:
         reason = f"Tool requires capability '{capability}', which profile '{profile_name}' does not grant."
+        approval_hint = "approval_cannot_override_profile_deny"
     else:
         reason = f"Tool category '{category}' is not explicitly granted by profile '{profile_name}'."
-
-    approval_hint = "approval_not_required"
-    if getattr(profile, "approval_workflow", False):
-        if classification["risk_level"] == "high":
-            approval_hint = "approval_required_or_strongly_recommended"
-        elif classification["risk_level"] == "medium":
-            approval_hint = "approval_recommended_for_sensitive_changes"
+        approval_hint = "approval_cannot_override_profile_deny"
 
     return {
         "profile": profile_name,
         "description": getattr(profile, "description", ""),
         "tool": tool,
         "allowed": allowed,
+        "allowed_now": policy.get("allowed_now", allowed),
+        "blocked": policy.get("blocked", not allowed),
+        "policy_mode": mode,
         "category": category,
         "risk_level": classification["risk_level"],
         "required_capability": capability,

--- a/velocity_claw/security/profile_policy_v2.py
+++ b/velocity_claw/security/profile_policy_v2.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+ALLOW = "allow"
+APPROVAL = "approval"
+DENY = "deny"
+VALID_MODES = {ALLOW, APPROVAL, DENY}
+
+READ_TOOLS = {
+    "analysis",
+    "fs.read",
+    "code.find_symbol",
+    "code.read_symbol",
+    "code.list_imports",
+    "git.inspect",
+    "patch.preview",
+}
+
+PROFILE_TOOL_MODES: dict[str, dict[str, str]] = {
+    "safe": {
+        **{tool: ALLOW for tool in READ_TOOLS},
+        "test.run": ALLOW,
+        "fs.write": DENY,
+        "fs.append": DENY,
+        "fs.replace": DENY,
+        "patch.apply": DENY,
+        "shell.run": DENY,
+        "git.run": DENY,
+        "http.get": DENY,
+        "http.post": DENY,
+    },
+    "dev": {
+        **{tool: ALLOW for tool in READ_TOOLS},
+        "test.run": ALLOW,
+        "fs.write": ALLOW,
+        "fs.append": ALLOW,
+        "fs.replace": ALLOW,
+        "patch.apply": ALLOW,
+        "shell.run": APPROVAL,
+        "git.run": DENY,
+        "http.get": DENY,
+        "http.post": DENY,
+    },
+    "owner": {
+        **{tool: ALLOW for tool in READ_TOOLS},
+        "test.run": ALLOW,
+        "fs.write": ALLOW,
+        "fs.append": ALLOW,
+        "fs.replace": ALLOW,
+        "patch.apply": ALLOW,
+        "shell.run": ALLOW,
+        "git.run": ALLOW,
+        "http.get": ALLOW,
+        "http.post": ALLOW,
+    },
+}
+
+
+def get_tool_mode(profile_name: str, tool: str) -> str:
+    profile_modes = PROFILE_TOOL_MODES.get(profile_name, PROFILE_TOOL_MODES["safe"])
+    return profile_modes.get(tool, DENY)
+
+
+def evaluate_tool_policy(
+    *,
+    profile_name: str,
+    tool: str,
+    approved: bool = False,
+    explicit_approval: bool = False,
+) -> dict[str, Any]:
+    mode = get_tool_mode(profile_name, tool)
+    blocked = mode == DENY
+    profile_requires_approval = mode == APPROVAL
+    explicit_gate = bool(explicit_approval and not blocked)
+    requires_approval = bool(not approved and (profile_requires_approval or explicit_gate))
+    allowed_now = bool(not blocked and not requires_approval)
+    granted = not blocked
+
+    if blocked:
+        reason = f"Tool {tool} is denied by execution profile {profile_name}."
+    elif requires_approval:
+        source = "profile policy" if profile_requires_approval else "explicit step request"
+        reason = f"Tool {tool} requires approval under {source}."
+    elif approved and (profile_requires_approval or explicit_gate):
+        reason = f"Tool {tool} is allowed after recorded approval."
+    else:
+        reason = f"Tool {tool} is allowed by execution profile {profile_name}."
+
+    return {
+        "profile": profile_name,
+        "tool": tool,
+        "mode": mode,
+        "granted": granted,
+        "allowed_now": allowed_now,
+        "blocked": blocked,
+        "requires_approval": requires_approval,
+        "approved": bool(approved),
+        "explicit_approval": bool(explicit_approval),
+        "reason": reason,
+    }
+
+
+def profile_mode_summary(profile_name: str) -> dict[str, Any]:
+    modes = PROFILE_TOOL_MODES.get(profile_name, PROFILE_TOOL_MODES["safe"])
+    counts = {ALLOW: 0, APPROVAL: 0, DENY: 0}
+    for mode in modes.values():
+        counts[mode] = counts.get(mode, 0) + 1
+    return {
+        "profile": profile_name,
+        "tool_modes": dict(sorted(modes.items())),
+        "mode_counts": counts,
+        "unknown_tool_mode": DENY,
+    }


### PR DESCRIPTION
## Summary

Completes issue #20 with an explicit operational trust matrix and closes an approval-continuation security gap.

Changes:
- define per-tool profile modes: `allow`, `approval`, and `deny`
- default unknown tools to hard deny
- distinguish profile grants from effective runtime availability
- align shell/git access with `SHELL_ENABLED` and `GIT_ENABLED`
- make `dev.shell.run` approval-gated
- keep safe mutation/shell/git/network tools hard denied
- keep owner access broad while enforcing explicit step approvals
- prevent approval from overriding profile or runtime denies
- use one `StepExecutionGuard` for normal runs and approval continuation
- preserve the run's stored execution profile during continuation
- re-run security validation after approval before executor dispatch
- create a fresh approval boundary for each later gated step
- expose effective tool policies and runtime constraints through profile APIs
- add operator documentation and focused policy, guard, and continuation tests

Validation targets:
- complete pytest suite
- package validation
- dependency audit
- wheel/source build

Closes #20 when merged.