### PR TITLE
Add safe failed-run resume v2

### DIFF
--- a/docs/FAILED_RUN_RESUME.md
+++ b/docs/FAILED_RUN_RESUME.md
@@ -1,0 +1,103 @@
+# Failed-run resume v2
+
+Velocity Claw can continue a failed run inside the original trace instead of creating a new run and repeating all completed work.
+
+## Behavior
+
+A failed-run resume:
+
+- keeps the original `run_id`;
+- loads the persisted `run_plan`;
+- finds the first step whose latest attempt is still `failed`;
+- skips earlier completed steps;
+- retries the failed step and then executes the remaining plan;
+- reuses the persisted planning context;
+- uses the execution profile stored on the original run;
+- passes every resumed step through the normal profile, runtime, approval, and security guard;
+- stores every retry as a new step-attempt record;
+- preserves the previous failed attempt for forensics;
+- records resume boundary and summary artifacts.
+
+Resume is rejected when:
+
+- the run does not exist;
+- the run status is not `failed`;
+- the persisted plan is missing or invalid;
+- no effective failed step can be located;
+- another resume for the same run is already active in the process.
+
+## API
+
+### Preview
+
+```text
+GET /runs/{run_id}/resume/v2
+```
+
+The preview returns:
+
+- the failed step and plan index;
+- steps that will be skipped;
+- steps that remain;
+- stored execution profile;
+- next resume number;
+- next attempt number for the failed step;
+- whether a resume is already active.
+
+### Execute
+
+```text
+POST /runs/{run_id}/resume/v2
+Content-Type: application/json
+
+{
+  "actor": "operator",
+  "reason": "dependency was repaired"
+}
+```
+
+The endpoint may return:
+
+- `completed` — all resumed steps succeeded;
+- `failed` — a resumed step failed again;
+- `awaiting_approval` — a resumed step opened a new approval boundary.
+
+One approval applies only to the gated step. Later approval-gated steps pause again.
+
+## Step attempts
+
+The `steps` table is migrated in place with:
+
+- `attempt_no` — attempt number for that plan step;
+- `phase` — `initial` or `failed_resume`.
+
+Historical rows receive `attempt_no=1` and `phase=initial`.
+
+`MemoryStore.load_run()` preserves all attempt records. Run forensics and reports calculate the current effective state from the latest attempt for each `step_id`, while keeping older failures visible in attempt history.
+
+Run detail v2 exposes:
+
+- effective step status;
+- total attempt records;
+- attempt history grouped by step;
+- retried step IDs;
+- resume boundaries and summaries;
+- the resume endpoint link.
+
+## Approval continuation
+
+When a resumed step requires approval:
+
+1. a `pending_approval` attempt is stored with `phase=failed_resume`;
+2. Approval v2 resolves the latest attempt for that `step_id`;
+3. approval does not change the stored run profile;
+4. the step is validated and executed through the standard guard;
+5. execution continues from the approval boundary.
+
+Approval cannot override a profile deny, disabled runtime capability, invalid path, blocked URL, disallowed command, or unsafe git operation.
+
+## Resume versus retry
+
+Use failed-run **resume** when the persisted plan remains valid and completed work should be retained.
+
+Use the existing **retry** workflow when the task needs a new plan or materially different context. Retry creates a new run; resume continues the original run.

--- a/tests/test_approval_attempts_v2.py
+++ b/tests/test_approval_attempts_v2.py
@@ -1,0 +1,61 @@
+from velocity_claw.api import approval_v2
+from velocity_claw.api.approval_attempts_v2 import install_latest_step_lookup
+
+
+def run_with_attempts():
+    return {
+        "run_id": "run-1",
+        "status": "awaiting_approval",
+        "task": "Resume repair",
+        "steps": [
+            {
+                "record_id": 1,
+                "id": 2,
+                "title": "Repair",
+                "tool": "shell.run",
+                "status": "failed",
+                "error": "old failure",
+                "attempt_no": 1,
+                "phase": "initial",
+            },
+            {
+                "record_id": 2,
+                "id": 2,
+                "title": "Repair",
+                "tool": "shell.run",
+                "status": "pending_approval",
+                "result": {"risk_level": "high", "profile": "dev"},
+                "attempt_no": 2,
+                "phase": "failed_resume",
+            },
+        ],
+        "artifacts": [],
+        "approval_history": [
+            {"step_id": 2, "decision": "requested"},
+        ],
+    }
+
+
+def test_approval_guard_uses_latest_attempt_for_retried_step():
+    install_latest_step_lookup(approval_v2)
+
+    detail = approval_v2.build_approval_detail(run_with_attempts(), 2)
+
+    assert detail["can_decide"] is True
+    assert detail["current_status"] == "pending_approval"
+    assert detail["step"]["attempt_no"] == 2
+    assert detail["step"]["phase"] == "failed_resume"
+    assert detail["step"]["error"] is None
+
+
+def test_latest_non_pending_attempt_blocks_duplicate_decision():
+    install_latest_step_lookup(approval_v2)
+    run = run_with_attempts()
+    run["steps"][-1]["status"] = "approved"
+    run["approval_history"].append({"step_id": 2, "decision": "approved"})
+
+    guard = approval_v2.evaluate_approval_decision(run, 2)
+
+    assert guard.allowed is False
+    assert guard.reason == "already_approved"
+    assert guard.current_status == "approved"

--- a/tests/test_approval_attempts_v2.py
+++ b/tests/test_approval_attempts_v2.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from velocity_claw.api import approval_v2
 from velocity_claw.api.approval_attempts_v2 import install_latest_step_lookup
 
@@ -25,6 +27,7 @@ def run_with_attempts():
                 "tool": "shell.run",
                 "status": "pending_approval",
                 "result": {"risk_level": "high", "profile": "dev"},
+                "error": None,
                 "attempt_no": 2,
                 "phase": "failed_resume",
             },
@@ -59,3 +62,42 @@ def test_latest_non_pending_attempt_blocks_duplicate_decision():
     assert guard.allowed is False
     assert guard.reason == "already_approved"
     assert guard.current_status == "approved"
+
+
+def test_approval_v2_routes_failed_resume_to_agent_approval_wrapper():
+    class Memory:
+        def __init__(self):
+            self.run = run_with_attempts()
+
+        def load_run(self, run_id):
+            return self.run
+
+    class Agent:
+        def __init__(self):
+            self.memory = Memory()
+            self.calls = []
+
+        async def approve_step(self, run_id, step_id, actor="owner", reason=None):
+            self.calls.append((run_id, step_id, actor, reason))
+            return {
+                "decision": "approved",
+                "resume": {"status": "completed", "run_id": run_id},
+            }
+
+    async def scenario():
+        install_latest_step_lookup(approval_v2)
+        agent = Agent()
+
+        result = await approval_v2.approve_with_guard(
+            agent,
+            "run-1",
+            2,
+            actor="operator",
+            reason="reviewed",
+        )
+
+        assert result["status"] == "ok"
+        assert agent.calls == [("run-1", 2, "operator", "reviewed")]
+        assert result["decision"]["resume"]["status"] == "completed"
+
+    asyncio.run(scenario())

--- a/tests/test_failed_run_resume_api_v2.py
+++ b/tests/test_failed_run_resume_api_v2.py
@@ -1,0 +1,97 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from velocity_claw.api.failed_run_resume_v2 import install_failed_run_resume_v2
+from velocity_claw.core.failed_run_resume import FailedRunResumeError
+
+
+class MinimalMemory:
+    def load_run(self, run_id):
+        return None
+
+
+class MinimalAgent:
+    def __init__(self):
+        self.memory = MinimalMemory()
+
+    async def resume_after_approval(self, run_id, step_id):
+        return {"status": "legacy"}
+
+
+class PreviewAgent(MinimalAgent):
+    def get_failed_run_resume_state(self, run_id):
+        return {
+            "run_id": run_id,
+            "resumable": True,
+            "from_step_id": 2,
+            "remaining_step_ids": [2, 3],
+        }
+
+    async def resume_failed_run(self, run_id, actor="operator", reason=None):
+        return {
+            "status": "completed",
+            "run_id": run_id,
+            "actor": actor,
+            "reason": reason,
+        }
+
+
+def build_client(agent):
+    app = FastAPI()
+    app.state.agent = agent
+    install_failed_run_resume_v2(app)
+    return TestClient(app)
+
+
+def test_resume_preview_and_execution_endpoints():
+    agent = PreviewAgent()
+    client = build_client(agent)
+    agent.get_failed_run_resume_state = PreviewAgent.get_failed_run_resume_state.__get__(agent)
+    agent.resume_failed_run = PreviewAgent.resume_failed_run.__get__(agent)
+
+    preview = client.get("/runs/run-1/resume/v2")
+    executed = client.post(
+        "/runs/run-1/resume/v2",
+        json={"actor": "owner", "reason": "dependency repaired"},
+    )
+
+    assert preview.status_code == 200
+    assert preview.json()["resume"]["from_step_id"] == 2
+    assert executed.status_code == 200
+    assert executed.json()["resume"] == {
+        "status": "completed",
+        "run_id": "run-1",
+        "actor": "owner",
+        "reason": "dependency repaired",
+    }
+
+
+def test_resume_preview_maps_missing_run_to_404():
+    agent = MinimalAgent()
+    client = build_client(agent)
+
+    def missing(run_id):
+        raise FailedRunResumeError("run_not_found", "Run not found.", status_code=404)
+
+    agent.get_failed_run_resume_state = missing
+    response = client.get("/runs/missing/resume/v2")
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["error"] == "run_not_found"
+
+
+def test_resume_execution_maps_conflict_to_409():
+    agent = MinimalAgent()
+    client = build_client(agent)
+
+    async def conflict(run_id, actor="operator", reason=None):
+        raise FailedRunResumeError(
+            "resume_in_progress",
+            "A resume is already in progress.",
+        )
+
+    agent.resume_failed_run = conflict
+    response = client.post("/runs/run-1/resume/v2", json={})
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["error"] == "resume_in_progress"

--- a/tests/test_failed_run_resume_attempt_numbers_v2.py
+++ b/tests/test_failed_run_resume_attempt_numbers_v2.py
@@ -1,0 +1,27 @@
+from velocity_claw.core.failed_run_resume import FailedRunResumer
+
+
+def test_approved_resume_reuses_pending_attempt_number():
+    records = [
+        {"id": 2, "status": "failed", "attempt_no": 1, "phase": "initial"},
+        {"id": 2, "status": "approved", "attempt_no": 2, "phase": "failed_resume"},
+    ]
+
+    attempt = FailedRunResumer._attempt_for_step(
+        records,
+        2,
+        reuse_approval_attempt=True,
+    )
+
+    assert attempt == 2
+
+
+def test_non_approval_retry_increments_latest_attempt_number():
+    records = [
+        {"id": 2, "status": "failed", "attempt_no": 1, "phase": "initial"},
+        {"id": 2, "status": "failed", "attempt_no": 2, "phase": "failed_resume"},
+    ]
+
+    attempt = FailedRunResumer._attempt_for_step(records, 2)
+
+    assert attempt == 3

--- a/tests/test_failed_run_resume_v2.py
+++ b/tests/test_failed_run_resume_v2.py
@@ -1,0 +1,255 @@
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.core.failed_run_resume import (
+    FailedRunResumeError,
+    install_failed_run_resume_instance,
+)
+from velocity_claw.memory import MemoryStore
+
+
+class FakeGuard:
+    def __init__(self, *, approval_step=None, fail_step=None, wait_event=None, release_event=None):
+        self.approval_step = approval_step
+        self.fail_step = fail_step
+        self.wait_event = wait_event
+        self.release_event = release_event
+        self.calls = []
+
+    async def execute(self, step, context, profile_name, *, approved=False, started_at=None):
+        self.calls.append(
+            {
+                "id": step.get("id"),
+                "context": context,
+                "profile": profile_name,
+                "approved": approved,
+            }
+        )
+        if self.wait_event is not None:
+            self.wait_event.set()
+            await self.release_event.wait()
+        if step.get("id") == self.approval_step and not approved:
+            return {
+                "state": "approval_required",
+                "policy": {"profile": profile_name, "mode": "approval"},
+                "step_result": None,
+            }
+        status = "failed" if step.get("id") == self.fail_step else "success"
+        result = {
+            "id": step.get("id"),
+            "title": step.get("title"),
+            "tool": step.get("tool"),
+            "args": step.get("args", {}),
+            "status": status,
+            "result": {"ok": status == "success"},
+            "error": "resume failed" if status == "failed" else None,
+            "started_at": started_at,
+            "completed_at": started_at,
+            "policy": {
+                "profile": profile_name,
+                "mode": "allow",
+                "approved": approved,
+            },
+        }
+        return {"state": "executed", "policy": result["policy"], "step_result": result}
+
+
+class FakeApprovals:
+    def build_record(self, step, profile_name=None):
+        return {
+            "required": True,
+            "profile": profile_name,
+            "tool": step.get("tool"),
+            "policy_mode": "approval",
+            "reason": "resume approval required",
+        }
+
+
+class FakeAgent:
+    def __init__(self, memory, guard):
+        self.memory = memory
+        self.step_guard = guard
+        self.approvals = FakeApprovals()
+        self.persisted = []
+
+    def _profile_for_run(self, run):
+        return run.get("execution_profile") or "safe"
+
+    def _persist_artifacts(self, run_id, step_result):
+        self.persisted.append((run_id, step_result.get("id")))
+
+    async def resume_after_approval(self, run_id, step_id):
+        return {"status": "legacy_resume", "run_id": run_id, "step_id": step_id}
+
+
+def make_memory(tmp_path: Path, monkeypatch, profile="owner"):
+    monkeypatch.setenv("VELOCITY_CLAW_ENV", "test")
+    monkeypatch.setenv("VELOCITY_CLAW_MEMORY_DB_PATH", str(tmp_path / "memory.db"))
+    monkeypatch.setenv("VELOCITY_CLAW_EXECUTION_PROFILE", profile)
+    monkeypatch.setenv("VELOCITY_CLAW_SHELL_ENABLED", "true")
+    monkeypatch.setenv("VELOCITY_CLAW_GIT_ENABLED", "true")
+    return MemoryStore(Settings())
+
+
+def plan_steps():
+    return [
+        {"id": 1, "title": "Inspect", "tool": "analysis", "args": {"prompt": "inspect"}},
+        {"id": 2, "title": "Repair", "tool": "analysis", "args": {"prompt": "repair"}},
+        {"id": 3, "title": "Verify", "tool": "analysis", "args": {"prompt": "verify"}},
+    ]
+
+
+def seed_failed_run(memory):
+    run_id = memory.create_run("Resume original trace")
+    memory.save_artifact(
+        run_id,
+        "run_plan",
+        json.dumps({"task": "Resume original trace", "steps": plan_steps()}),
+        artifact_type="plan",
+    )
+    memory.save_artifact(
+        run_id,
+        "planning_context",
+        json.dumps({"project_root": ".", "original": True}),
+        artifact_type="planning_context",
+    )
+    memory.save_step(
+        run_id,
+        {
+            **plan_steps()[0],
+            "status": "success",
+            "result": {"inspected": True},
+            "error": None,
+        },
+    )
+    memory.save_step(
+        run_id,
+        {
+            **plan_steps()[1],
+            "status": "failed",
+            "result": None,
+            "error": "initial failure",
+        },
+    )
+    memory.update_run_status(run_id, "failed")
+    return run_id
+
+
+def test_preview_identifies_failed_boundary_and_skipped_steps(tmp_path: Path, monkeypatch):
+    memory = make_memory(tmp_path, monkeypatch)
+    run_id = seed_failed_run(memory)
+    agent = FakeAgent(memory, FakeGuard())
+    install_failed_run_resume_instance(agent)
+
+    preview = agent.get_failed_run_resume_state(run_id)
+
+    assert preview["resumable"] is True
+    assert preview["from_step_id"] == 2
+    assert preview["remaining_step_ids"] == [2, 3]
+    assert preview["skipped_completed_step_ids"] == [1]
+    assert preview["next_attempt_no"] == 2
+    assert preview["execution_profile"] == "owner"
+
+
+def test_resume_retries_failed_step_and_continues_same_run(tmp_path: Path, monkeypatch):
+    async def scenario():
+        memory = make_memory(tmp_path, monkeypatch)
+        run_id = seed_failed_run(memory)
+        guard = FakeGuard()
+        agent = FakeAgent(memory, guard)
+        install_failed_run_resume_instance(agent)
+
+        result = await agent.resume_failed_run(run_id, actor="owner", reason="fixed dependency")
+        run = memory.load_run(run_id)
+
+        assert result["status"] == "completed"
+        assert result["run_id"] == run_id
+        assert [item["id"] for item in result["executed"]] == [2, 3]
+        assert [item["id"] for item in guard.calls] == [2, 3]
+        assert all(item["context"]["original"] is True for item in guard.calls)
+        assert run["status"] == "completed"
+        assert len(run["steps"]) == 4
+        assert run["forensics"]["failed_step"] is None
+        assert run["forensics"]["step_attempts"]["retried_steps"] == ["2"]
+        assert any(item["artifact_type"] == "resume_boundary" for item in run["artifacts"])
+        assert any(item["artifact_type"] == "resume_summary" for item in run["artifacts"])
+        retried = [item for item in run["steps"] if item["id"] == 2]
+        assert [item["status"] for item in retried] == ["failed", "success"]
+        assert [item["attempt_no"] for item in retried] == [1, 2]
+        assert retried[-1]["phase"] == "failed_resume"
+
+    asyncio.run(scenario())
+
+
+def test_resume_failure_stays_failed_and_preserves_attempt_history(tmp_path: Path, monkeypatch):
+    async def scenario():
+        memory = make_memory(tmp_path, monkeypatch)
+        run_id = seed_failed_run(memory)
+        agent = FakeAgent(memory, FakeGuard(fail_step=2))
+        install_failed_run_resume_instance(agent)
+
+        result = await agent.resume_failed_run(run_id)
+        run = memory.load_run(run_id)
+
+        assert result["status"] == "failed"
+        assert run["status"] == "failed"
+        attempts = [item for item in run["steps"] if item["id"] == 2]
+        assert len(attempts) == 2
+        assert attempts[-1]["attempt_no"] == 2
+        assert attempts[-1]["error"] == "resume failed"
+        assert run["forensics"]["failed_step"]["id"] == 2
+
+    asyncio.run(scenario())
+
+
+def test_second_resume_is_rejected_while_first_is_running(tmp_path: Path, monkeypatch):
+    async def scenario():
+        memory = make_memory(tmp_path, monkeypatch)
+        run_id = seed_failed_run(memory)
+        started = asyncio.Event()
+        release = asyncio.Event()
+        agent = FakeAgent(memory, FakeGuard(wait_event=started, release_event=release))
+        install_failed_run_resume_instance(agent)
+
+        first = asyncio.create_task(agent.resume_failed_run(run_id))
+        await started.wait()
+        with pytest.raises(FailedRunResumeError) as exc:
+            await agent.resume_failed_run(run_id)
+        assert exc.value.code == "resume_in_progress"
+        release.set()
+        assert (await first)["status"] == "completed"
+
+    asyncio.run(scenario())
+
+
+def test_resume_approval_continues_through_wrapped_approval_path(tmp_path: Path, monkeypatch):
+    async def scenario():
+        memory = make_memory(tmp_path, monkeypatch, profile="dev")
+        run_id = seed_failed_run(memory)
+        guard = FakeGuard(approval_step=2)
+        agent = FakeAgent(memory, guard)
+        install_failed_run_resume_instance(agent)
+
+        paused = await agent.resume_failed_run(run_id)
+        assert paused["status"] == "awaiting_approval"
+        assert paused["boundary_step_id"] == 2
+
+        memory.update_step_status(run_id, 2, "approved", result={"decision": "approved"})
+        continued = await agent.resume_after_approval(run_id, 2)
+        run = memory.load_run(run_id)
+
+        assert continued["status"] == "completed"
+        assert [item["id"] for item in continued["executed"]] == [2, 3]
+        assert guard.calls[-2]["approved"] is True
+        assert run["status"] == "completed"
+        attempts = [item for item in run["steps"] if item["id"] == 2]
+        assert attempts[0]["status"] == "failed"
+        assert attempts[1]["status"] == "approved"
+        assert attempts[-1]["status"] == "success"
+        assert all(item["phase"] == "failed_resume" for item in attempts[1:])
+
+    asyncio.run(scenario())

--- a/tests/test_run_detail_resume_v2.py
+++ b/tests/test_run_detail_resume_v2.py
@@ -1,0 +1,98 @@
+import json
+
+from velocity_claw.api.run_detail_v2 import build_run_detail_v2, build_step_index
+
+
+def resumed_run():
+    return {
+        "run_id": "resumed-run",
+        "task": "Resume failed workflow",
+        "status": "completed",
+        "execution_profile": "dev",
+        "created_at": "start",
+        "completed_at": "end",
+        "steps": [
+            {
+                "record_id": 1,
+                "id": 1,
+                "title": "Inspect",
+                "tool": "analysis",
+                "status": "success",
+                "attempt_no": 1,
+                "phase": "initial",
+            },
+            {
+                "record_id": 2,
+                "id": 2,
+                "title": "Repair",
+                "tool": "analysis",
+                "status": "failed",
+                "error": "first failure",
+                "attempt_no": 1,
+                "phase": "initial",
+            },
+            {
+                "record_id": 3,
+                "id": 2,
+                "title": "Repair",
+                "tool": "analysis",
+                "status": "success",
+                "attempt_no": 2,
+                "phase": "failed_resume",
+            },
+        ],
+        "artifacts": [
+            {
+                "name": "run_plan",
+                "artifact_type": "plan",
+                "step_id": None,
+                "content": json.dumps({"steps": [{"id": 1}, {"id": 2}]}),
+            },
+            {
+                "name": "failed_resume_boundary_1",
+                "artifact_type": "resume_boundary",
+                "step_id": 2,
+                "content": json.dumps({"resume_number": 1, "from_step_id": 2}),
+            },
+            {
+                "name": "failed_resume_summary_1",
+                "artifact_type": "resume_summary",
+                "step_id": 2,
+                "content": json.dumps({"resume_number": 1, "status": "completed"}),
+            },
+        ],
+        "approval_history": [],
+        "report": {"executive_summary": "Run completed after resume."},
+        "forensics": {
+            "failed_step": None,
+            "pending_approval_step": None,
+            "last_step": {"id": 2, "status": "success"},
+            "artifact_counts_by_type": {"plan": 1, "resume_boundary": 1, "resume_summary": 1},
+            "step_attempts": {"retried_steps": ["2"]},
+        },
+    }
+
+
+def test_step_index_separates_effective_steps_from_attempt_records():
+    index = build_step_index(resumed_run())
+
+    assert index["total"] == 2
+    assert index["total_attempt_records"] == 3
+    assert index["status_counts"] == {"success": 2}
+    assert index["failed_steps"] == []
+    assert index["attempt_summary"]["retried_steps"] == ["2"]
+    assert len(index["history_by_step"]["2"]) == 2
+    assert index["items"][1]["attempt_no"] == 2
+    assert index["items"][1]["phase"] == "failed_resume"
+
+
+def test_run_detail_exposes_resume_history_and_links():
+    detail = build_run_detail_v2(resumed_run())
+
+    assert detail["execution_profile"] == "dev"
+    assert detail["resume"]["resumable"] is False
+    assert detail["resume"]["resume_count"] == 1
+    assert detail["resume"]["latest_boundary"]["from_step_id"] == 2
+    assert detail["resume"]["latest_summary"]["status"] == "completed"
+    assert detail["links"]["resume_v2"] == "/runs/resumed-run/resume/v2"
+    assert detail["forensic_highlights"]["step_attempts"]["retried_steps"] == ["2"]

--- a/tests/test_step_attempts_v2.py
+++ b/tests/test_step_attempts_v2.py
@@ -1,0 +1,138 @@
+import sqlite3
+from pathlib import Path
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.memory import MemoryStore
+from velocity_claw.memory.step_attempts_v2 import attempt_summary, effective_steps
+
+
+def settings_for(tmp_path: Path, monkeypatch) -> Settings:
+    monkeypatch.setenv("VELOCITY_CLAW_ENV", "test")
+    monkeypatch.setenv("VELOCITY_CLAW_MEMORY_DB_PATH", str(tmp_path / "memory.db"))
+    return Settings()
+
+
+def step(step_id, status, *, attempt_no=1, phase="initial", error=None):
+    return {
+        "id": step_id,
+        "title": f"Step {step_id}",
+        "tool": "analysis",
+        "args": {"prompt": "inspect"},
+        "status": status,
+        "result": {"attempt": attempt_no} if status == "success" else None,
+        "error": error,
+        "started_at": f"2026-06-26T10:00:0{attempt_no}",
+        "completed_at": f"2026-06-26T10:00:1{attempt_no}",
+        "attempt_no": attempt_no,
+        "phase": phase,
+    }
+
+
+def test_existing_steps_table_is_migrated_without_losing_history(tmp_path: Path, monkeypatch):
+    settings = settings_for(tmp_path, monkeypatch)
+    with sqlite3.connect(settings.memory_db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE runs (
+                run_id TEXT PRIMARY KEY,
+                task TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                completed_at DATETIME
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE steps (
+                id INTEGER PRIMARY KEY,
+                run_id TEXT NOT NULL,
+                step_id INTEGER NOT NULL,
+                title TEXT NOT NULL,
+                tool TEXT,
+                args TEXT,
+                status TEXT NOT NULL,
+                result TEXT,
+                error TEXT,
+                started_at DATETIME,
+                completed_at DATETIME
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO runs (run_id, task, status) VALUES (?, ?, ?)",
+            ("legacy-run", "Legacy run", "failed"),
+        )
+        conn.execute(
+            """
+            INSERT INTO steps (
+                run_id, step_id, title, tool, args, status, result, error
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("legacy-run", 1, "Legacy step", "analysis", "{}", "failed", None, "boom"),
+        )
+
+    memory = MemoryStore(settings)
+    loaded = memory.load_steps("legacy-run")
+
+    with sqlite3.connect(settings.memory_db_path) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(steps)").fetchall()}
+
+    assert {"attempt_no", "phase"}.issubset(columns)
+    assert loaded[0]["status"] == "failed"
+    assert loaded[0]["attempt_no"] == 1
+    assert loaded[0]["phase"] == "initial"
+
+
+def test_multiple_attempts_are_preserved_and_effective_state_uses_latest(tmp_path: Path, monkeypatch):
+    memory = MemoryStore(settings_for(tmp_path, monkeypatch))
+    run_id = memory.create_run("Resume failed step")
+    memory.save_step(run_id, step(1, "success"))
+    memory.save_step(run_id, step(2, "failed", error="first failure"))
+    memory.save_step(run_id, step(2, "success", attempt_no=2, phase="failed_resume"))
+    memory.save_step(run_id, step(3, "success", attempt_no=1, phase="failed_resume"))
+    memory.update_run_status(run_id, "completed")
+
+    run = memory.load_run(run_id)
+    records = run["steps"]
+    latest = effective_steps(records)
+
+    assert len(records) == 4
+    assert [item["id"] for item in latest] == [1, 2, 3]
+    assert next(item for item in latest if item["id"] == 2)["status"] == "success"
+    assert run["forensics"]["failed_step"] is None
+    assert run["forensics"]["step_attempts"]["retried_steps"] == ["2"]
+    assert run["report"]["step_overview"]["failed"] == 0
+    assert run["report"]["step_attempt_overview"]["total_attempt_records"] == 4
+
+
+def test_update_step_status_changes_only_latest_attempt(tmp_path: Path, monkeypatch):
+    memory = MemoryStore(settings_for(tmp_path, monkeypatch))
+    run_id = memory.create_run("Approval attempt")
+    memory.save_step(run_id, step(2, "failed", error="old failure"))
+    memory.save_step(run_id, step(2, "pending_approval", attempt_no=2, phase="failed_resume"))
+
+    memory.update_step_status(run_id, 2, "approved", result={"decision": "approved"})
+    records = memory.load_steps(run_id)
+
+    assert records[0]["status"] == "failed"
+    assert records[0]["error"] == "old failure"
+    assert records[1]["status"] == "approved"
+    assert records[1]["attempt_no"] == 2
+    assert records[1]["phase"] == "failed_resume"
+
+
+def test_attempt_summary_counts_phases_and_retries():
+    records = [
+        step(1, "success"),
+        step(2, "failed"),
+        step(2, "success", attempt_no=2, phase="failed_resume"),
+    ]
+
+    summary = attempt_summary(records)
+
+    assert summary["total_attempt_records"] == 3
+    assert summary["unique_steps"] == 2
+    assert summary["retried_steps"] == ["2"]
+    assert summary["attempts_by_step"] == {"1": 1, "2": 2}
+    assert summary["records_by_phase"] == {"initial": 2, "failed_resume": 1}

--- a/velocity_claw/api/app.py
+++ b/velocity_claw/api/app.py
@@ -17,6 +17,7 @@ from velocity_claw.api.dashboard_runs_v2 import render_dashboard_runs_v2
 from velocity_claw.api.dashboard_v2 import render_dashboard_v2
 from velocity_claw.api.diagnostics_v2 import build_diagnostics_v2
 from velocity_claw.api.errors import install_api_error_handlers
+from velocity_claw.api.failed_run_resume_v2 import install_failed_run_resume_v2
 from velocity_claw.api.ops_console import build_operations_console
 from velocity_claw.api.run_detail_v2 import build_artifact_index, build_run_detail_v2
 from velocity_claw.api.server import ApprovalDecisionRequest, create_app as create_base_app
@@ -316,6 +317,7 @@ def create_app() -> FastAPI:
     install_queue_persistence_v2(app)
     install_approval_v2(app)
     install_run_detail_v2(app)
+    install_failed_run_resume_v2(app)
     install_diagnostics_v2(app)
     install_dashboard_v2(app)
     install_api_key_auth(app)
@@ -325,6 +327,7 @@ def create_app() -> FastAPI:
     app.state.queue_orchestration_v2_installed = True
     app.state.approval_v2_installed = True
     app.state.run_detail_v2_installed = True
+    app.state.failed_run_resume_v2_installed = True
     app.state.diagnostics_v2_installed = True
     app.state.dashboard_v2_installed = True
     app.state.api_key_auth_installed = True

--- a/velocity_claw/api/approval_attempts_v2.py
+++ b/velocity_claw/api/approval_attempts_v2.py
@@ -7,11 +7,39 @@ def install_latest_step_lookup(approval_module: Any) -> None:
     if getattr(approval_module, "_latest_step_lookup_v2_installed", False):
         return
 
+    original_approve_and_continue = approval_module.approve_and_continue
+
     def _find_step(run: dict[str, Any], step_id: int) -> dict[str, Any] | None:
         for step in reversed(run.get("steps", [])):
             if step.get("id") == step_id:
                 return step
         return None
 
+    async def _approve_and_continue(
+        agent: Any,
+        run_id: str,
+        step_id: int,
+        *,
+        actor: str,
+        reason: str | None,
+    ) -> dict[str, Any]:
+        run = agent.memory.load_run(run_id)
+        latest = _find_step(run or {}, step_id)
+        if latest and latest.get("phase") == "failed_resume":
+            return await agent.approve_step(
+                run_id,
+                step_id,
+                actor=actor,
+                reason=reason,
+            )
+        return await original_approve_and_continue(
+            agent,
+            run_id,
+            step_id,
+            actor=actor,
+            reason=reason,
+        )
+
     approval_module._find_step = _find_step
+    approval_module.approve_and_continue = _approve_and_continue
     approval_module._latest_step_lookup_v2_installed = True

--- a/velocity_claw/api/approval_attempts_v2.py
+++ b/velocity_claw/api/approval_attempts_v2.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def install_latest_step_lookup(approval_module: Any) -> None:
+    if getattr(approval_module, "_latest_step_lookup_v2_installed", False):
+        return
+
+    def _find_step(run: dict[str, Any], step_id: int) -> dict[str, Any] | None:
+        for step in reversed(run.get("steps", [])):
+            if step.get("id") == step_id:
+                return step
+        return None
+
+    approval_module._find_step = _find_step
+    approval_module._latest_step_lookup_v2_installed = True

--- a/velocity_claw/api/failed_run_resume_v2.py
+++ b/velocity_claw/api/failed_run_resume_v2.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
+from velocity_claw.api import approval_v2 as approval_v2_module
+from velocity_claw.api.approval_attempts_v2 import install_latest_step_lookup
 from velocity_claw.core.failed_run_resume import (
     FailedRunResumeError,
     install_failed_run_resume_instance,
@@ -26,6 +28,7 @@ def _raise_http(exc: FailedRunResumeError) -> None:
 
 
 def install_failed_run_resume_v2(app: FastAPI) -> None:
+    install_latest_step_lookup(approval_v2_module)
     install_failed_run_resume_instance(app.state.agent)
 
     @app.get("/runs/{run_id}/resume/v2")

--- a/velocity_claw/api/failed_run_resume_v2.py
+++ b/velocity_claw/api/failed_run_resume_v2.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from velocity_claw.core.failed_run_resume import (
+    FailedRunResumeError,
+    install_failed_run_resume_instance,
+)
+
+
+class ResumeFailedRunRequest(BaseModel):
+    actor: str = "operator"
+    reason: str | None = None
+
+
+def _raise_http(exc: FailedRunResumeError) -> None:
+    raise HTTPException(
+        status_code=exc.status_code,
+        detail={
+            "status": "failed",
+            "error": exc.code,
+            "detail": exc.detail,
+        },
+    ) from exc
+
+
+def install_failed_run_resume_v2(app: FastAPI) -> None:
+    install_failed_run_resume_instance(app.state.agent)
+
+    @app.get("/runs/{run_id}/resume/v2")
+    def failed_run_resume_preview_v2(run_id: str):
+        try:
+            preview = app.state.agent.get_failed_run_resume_state(run_id)
+        except FailedRunResumeError as exc:
+            _raise_http(exc)
+        return {"status": "ok", "resume": preview}
+
+    @app.post("/runs/{run_id}/resume/v2")
+    async def failed_run_resume_v2(run_id: str, payload: ResumeFailedRunRequest):
+        try:
+            result = await app.state.agent.resume_failed_run(
+                run_id,
+                actor=payload.actor,
+                reason=payload.reason,
+            )
+        except FailedRunResumeError as exc:
+            _raise_http(exc)
+        return {"status": "ok", "resume": result}

--- a/velocity_claw/api/run_detail_v2.py
+++ b/velocity_claw/api/run_detail_v2.py
@@ -1,12 +1,28 @@
 from __future__ import annotations
 
+import json
 from collections import Counter, defaultdict
 from typing import Any
+
+from velocity_claw.core.agent import VelocityClawAgent
+from velocity_claw.core.failed_run_resume_install import install_failed_run_resume_class
+from velocity_claw.memory.step_attempts_v2 import attempt_summary, effective_steps
+
+
+install_failed_run_resume_class(VelocityClawAgent)
 
 
 def _preview(content: Any, limit: int = 240) -> str:
     text = "" if content is None else str(content)
     return text[:limit]
+
+
+def _artifact_json(artifact: dict[str, Any]) -> dict[str, Any]:
+    try:
+        payload = json.loads(artifact.get("content") or "{}")
+    except (TypeError, ValueError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
 
 
 def build_artifact_index(run: dict[str, Any]) -> dict[str, Any]:
@@ -41,19 +57,46 @@ def build_artifact_index(run: dict[str, Any]) -> dict[str, Any]:
 
 
 def build_step_index(run: dict[str, Any]) -> dict[str, Any]:
-    steps = run.get("steps", [])
-    status_counts = Counter(step.get("status") or "unknown" for step in steps)
-    failed_steps = [step for step in steps if step.get("status") == "failed"]
-    pending_approval_steps = [step for step in steps if step.get("status") == "pending_approval"]
+    records = run.get("steps", [])
+    effective = effective_steps(records)
+    status_counts = Counter(step.get("status") or "unknown" for step in effective)
+    failed_steps = [step for step in effective if step.get("status") == "failed"]
+    pending_approval_steps = [
+        step for step in effective if step.get("status") == "pending_approval"
+    ]
+    history_by_step: dict[str, list[dict[str, Any]]] = defaultdict(list)
+
+    attempt_records = []
+    for step in records:
+        item = {
+            "record_id": step.get("record_id"),
+            "id": step.get("id"),
+            "title": step.get("title"),
+            "tool": step.get("tool"),
+            "status": step.get("status"),
+            "attempt_no": step.get("attempt_no", 1),
+            "phase": step.get("phase", "initial"),
+            "started_at": step.get("started_at"),
+            "completed_at": step.get("completed_at"),
+            "has_error": bool(step.get("error")),
+            "error": step.get("error"),
+        }
+        attempt_records.append(item)
+        history_by_step[str(step.get("id"))].append(item)
+
     return {
-        "total": len(steps),
+        "total": len(effective),
+        "total_attempt_records": len(records),
         "status_counts": dict(status_counts),
+        "attempt_summary": attempt_summary(records),
         "failed_steps": [
             {
                 "id": step.get("id"),
                 "title": step.get("title"),
                 "tool": step.get("tool"),
                 "error": step.get("error"),
+                "attempt_no": step.get("attempt_no", 1),
+                "phase": step.get("phase", "initial"),
             }
             for step in failed_steps
         ],
@@ -62,40 +105,77 @@ def build_step_index(run: dict[str, Any]) -> dict[str, Any]:
                 "id": step.get("id"),
                 "title": step.get("title"),
                 "tool": step.get("tool"),
+                "attempt_no": step.get("attempt_no", 1),
+                "phase": step.get("phase", "initial"),
                 "approval_detail_url": f"/approvals/v2/{run.get('run_id')}/{step.get('id')}",
             }
             for step in pending_approval_steps
         ],
         "items": [
             {
+                "record_id": step.get("record_id"),
                 "id": step.get("id"),
                 "title": step.get("title"),
                 "tool": step.get("tool"),
                 "status": step.get("status"),
+                "attempt_no": step.get("attempt_no", 1),
+                "phase": step.get("phase", "initial"),
                 "started_at": step.get("started_at"),
                 "completed_at": step.get("completed_at"),
                 "has_error": bool(step.get("error")),
             }
-            for step in steps
+            for step in effective
         ],
+        "attempt_records": attempt_records,
+        "history_by_step": dict(history_by_step),
+    }
+
+
+def build_resume_index(run: dict[str, Any]) -> dict[str, Any]:
+    artifacts = run.get("artifacts", [])
+    boundaries = [
+        _artifact_json(item)
+        for item in artifacts
+        if item.get("artifact_type") == "resume_boundary"
+    ]
+    summaries = [
+        _artifact_json(item)
+        for item in artifacts
+        if item.get("artifact_type") == "resume_summary"
+    ]
+    effective = effective_steps(run.get("steps", []))
+    failed = next((step for step in effective if step.get("status") == "failed"), None)
+    has_plan = any(item.get("name") == "run_plan" for item in artifacts)
+    return {
+        "resumable": bool(run.get("status") == "failed" and failed and has_plan),
+        "resume_count": len(boundaries),
+        "latest_boundary": boundaries[-1] if boundaries else None,
+        "latest_summary": summaries[-1] if summaries else None,
+        "boundaries": boundaries,
+        "summaries": summaries,
+        "failed_step_id": failed.get("id") if failed else None,
     }
 
 
 def build_run_detail_v2(run: dict[str, Any]) -> dict[str, Any]:
     step_index = build_step_index(run)
     artifact_index = build_artifact_index(run)
+    resume_index = build_resume_index(run)
     report = run.get("report") or {}
     forensics = run.get("forensics") or {}
     approval_history = run.get("approval_history") or []
+    run_id = run.get("run_id")
     return {
-        "run_id": run.get("run_id"),
+        "run_id": run_id,
         "task": run.get("task"),
         "status": run.get("status"),
+        "execution_profile": run.get("execution_profile", "unknown"),
         "created_at": run.get("created_at"),
         "completed_at": run.get("completed_at"),
         "summary": report.get("executive_summary"),
         "step_index": step_index,
         "artifact_index": artifact_index,
+        "resume": resume_index,
         "approval_history": approval_history,
         "approval_events": len(approval_history),
         "forensic_highlights": {
@@ -103,13 +183,15 @@ def build_run_detail_v2(run: dict[str, Any]) -> dict[str, Any]:
             "pending_approval_step": forensics.get("pending_approval_step"),
             "last_step": forensics.get("last_step"),
             "artifact_counts_by_type": forensics.get("artifact_counts_by_type", {}),
+            "step_attempts": forensics.get("step_attempts", {}),
         },
         "links": {
-            "raw": f"/runs/{run.get('run_id')}",
-            "html": f"/runs/{run.get('run_id')}/view",
-            "report": f"/runs/{run.get('run_id')}/report",
-            "forensics": f"/runs/{run.get('run_id')}/forensics",
-            "artifacts_v2": f"/runs/{run.get('run_id')}/artifacts/v2",
-            "detail_v2": f"/runs/{run.get('run_id')}/detail/v2",
+            "raw": f"/runs/{run_id}",
+            "html": f"/runs/{run_id}/view",
+            "report": f"/runs/{run_id}/report",
+            "forensics": f"/runs/{run_id}/forensics",
+            "artifacts_v2": f"/runs/{run_id}/artifacts/v2",
+            "detail_v2": f"/runs/{run_id}/detail/v2",
+            "resume_v2": f"/runs/{run_id}/resume/v2",
         },
     }

--- a/velocity_claw/core/failed_run_resume.py
+++ b/velocity_claw/core/failed_run_resume.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime
+from types import MethodType
+from typing import Any
+
+from velocity_claw.memory.step_attempts_v2 import effective_steps
+
+
+class FailedRunResumeError(RuntimeError):
+    def __init__(self, code: str, detail: str, *, status_code: int = 409):
+        super().__init__(detail)
+        self.code = code
+        self.detail = detail
+        self.status_code = status_code
+
+
+class FailedRunResumer:
+    def __init__(self, agent: Any):
+        self.agent = agent
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    def _lock_for(self, run_id: str) -> asyncio.Lock:
+        lock = self._locks.get(run_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[run_id] = lock
+        return lock
+
+    def _artifact_json(self, run: dict[str, Any], name: str, default: Any = None) -> Any:
+        artifact = next(
+            (item for item in reversed(run.get("artifacts") or []) if item.get("name") == name),
+            None,
+        )
+        if not artifact:
+            return default
+        try:
+            return json.loads(artifact.get("content") or "null")
+        except (TypeError, ValueError):
+            return default
+
+    def _plan(self, run: dict[str, Any]) -> dict[str, Any]:
+        plan = self._artifact_json(run, "run_plan")
+        if not isinstance(plan, dict) or not isinstance(plan.get("steps"), list):
+            raise FailedRunResumeError(
+                "run_plan_missing",
+                "Run does not contain a valid persisted plan.",
+            )
+        return plan
+
+    def _failed_step_index(
+        self,
+        plan_steps: list[dict[str, Any]],
+        step_records: list[dict[str, Any]],
+    ) -> int:
+        latest_by_id = {
+            step.get("id"): step
+            for step in effective_steps(step_records)
+            if step.get("id") is not None
+        }
+        for index, planned in enumerate(plan_steps):
+            record = latest_by_id.get(planned.get("id"))
+            if record and record.get("status") == "failed":
+                return index
+        raise FailedRunResumeError(
+            "failed_step_not_found",
+            "Run is marked failed but has no effective failed step to resume.",
+        )
+
+    def _resume_number(self, run: dict[str, Any]) -> int:
+        count = sum(
+            1
+            for artifact in run.get("artifacts") or []
+            if artifact.get("artifact_type") == "resume_boundary"
+        )
+        return count + 1
+
+    def _attempt_for_step(self, records: list[dict[str, Any]], step_id: Any) -> int:
+        attempts = [
+            int(item.get("attempt_no") or 1)
+            for item in records
+            if item.get("id") == step_id
+        ]
+        return max(attempts, default=0) + 1
+
+    def preview(self, run_id: str) -> dict[str, Any]:
+        run = self.agent.memory.load_run(run_id)
+        if not run:
+            raise FailedRunResumeError("run_not_found", "Run not found.", status_code=404)
+        if run.get("status") != "failed":
+            raise FailedRunResumeError(
+                "run_not_failed",
+                f"Only failed runs can be resumed; current status is {run.get('status')}.",
+            )
+
+        plan = self._plan(run)
+        plan_steps = plan.get("steps") or []
+        failed_index = self._failed_step_index(plan_steps, run.get("steps") or [])
+        failed_step = plan_steps[failed_index]
+        lock = self._locks.get(run_id)
+        profile = self.agent._profile_for_run(run)
+        return {
+            "run_id": run_id,
+            "status": run.get("status"),
+            "resumable": True,
+            "resume_in_progress": bool(lock and lock.locked()),
+            "execution_profile": profile,
+            "from_step_id": failed_step.get("id"),
+            "from_step_index": failed_index,
+            "remaining_step_ids": [item.get("id") for item in plan_steps[failed_index:]],
+            "skipped_completed_step_ids": [item.get("id") for item in plan_steps[:failed_index]],
+            "next_resume_number": self._resume_number(run),
+            "next_attempt_no": self._attempt_for_step(
+                run.get("steps") or [],
+                failed_step.get("id"),
+            ),
+            "links": {
+                "run_detail_v2": f"/runs/{run_id}/detail/v2",
+                "artifacts_v2": f"/runs/{run_id}/artifacts/v2",
+                "resume_v2": f"/runs/{run_id}/resume/v2",
+            },
+        }
+
+    def _execution_context(self, run: dict[str, Any]) -> dict[str, Any]:
+        context = self._artifact_json(run, "planning_context", default={})
+        return context if isinstance(context, dict) else {}
+
+    def _save_boundary(
+        self,
+        run: dict[str, Any],
+        preview: dict[str, Any],
+        *,
+        actor: str,
+        reason: str | None,
+    ) -> dict[str, Any]:
+        boundary = {
+            "run_id": run["run_id"],
+            "resume_number": preview["next_resume_number"],
+            "from_step_id": preview["from_step_id"],
+            "remaining_step_ids": preview["remaining_step_ids"],
+            "skipped_completed_step_ids": preview["skipped_completed_step_ids"],
+            "execution_profile": preview["execution_profile"],
+            "actor": actor,
+            "reason": reason,
+            "started_at": datetime.now().isoformat(),
+        }
+        self.agent.memory.save_artifact(
+            run["run_id"],
+            f"failed_resume_boundary_{boundary['resume_number']}",
+            json.dumps(boundary, ensure_ascii=False),
+            step_id=preview["from_step_id"],
+            artifact_type="resume_boundary",
+        )
+        self.agent.memory.save_project_note(
+            "failed_resume",
+            f"Run {run['run_id']} resumed from step {preview['from_step_id']} (resume {boundary['resume_number']})",
+        )
+        return boundary
+
+    def _save_summary(
+        self,
+        run_id: str,
+        boundary: dict[str, Any],
+        *,
+        status: str,
+        executed: list[dict[str, Any]],
+        boundary_step_id: Any = None,
+    ) -> dict[str, Any]:
+        summary = {
+            "run_id": run_id,
+            "resume_number": boundary["resume_number"],
+            "from_step_id": boundary["from_step_id"],
+            "status": status,
+            "executed_step_ids": [item.get("id") for item in executed],
+            "boundary_step_id": boundary_step_id,
+            "completed_at": datetime.now().isoformat(),
+        }
+        self.agent.memory.save_artifact(
+            run_id,
+            f"failed_resume_summary_{boundary['resume_number']}",
+            json.dumps(summary, ensure_ascii=False),
+            step_id=boundary_step_id or boundary["from_step_id"],
+            artifact_type="resume_summary",
+        )
+        return summary
+
+    def _pause_for_resume_approval(
+        self,
+        *,
+        run: dict[str, Any],
+        step: dict[str, Any],
+        profile_name: str,
+        attempt_no: int,
+        resume_number: int,
+        executed: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        started_at = datetime.now().isoformat()
+        approval = self.agent.approvals.build_record(step, profile_name=profile_name)
+        step_result = {
+            "id": step.get("id"),
+            "title": step.get("title"),
+            "tool": step.get("tool"),
+            "args": step.get("args", {}),
+            "status": "pending_approval",
+            "result": approval,
+            "error": None,
+            "started_at": started_at,
+            "completed_at": datetime.now().isoformat(),
+            "attempt_no": attempt_no,
+            "phase": "failed_resume",
+        }
+        self.agent.memory.save_step(
+            run["run_id"],
+            step_result,
+            attempt_no=attempt_no,
+            phase="failed_resume",
+        )
+        payload = {
+            "step_id": step.get("id"),
+            "boundary_type": "failed_resume_approval",
+            "resume_number": resume_number,
+            "attempt_no": attempt_no,
+            "phase": "failed_resume",
+        }
+        self.agent.memory.save_artifact(
+            run["run_id"],
+            f"approval_step_{step.get('id')}_resume_{resume_number}",
+            json.dumps(approval, ensure_ascii=False),
+            step_id=step.get("id"),
+            artifact_type="approval",
+        )
+        self.agent.memory.save_artifact(
+            run["run_id"],
+            f"approval_boundary_step_{step.get('id')}_resume_{resume_number}",
+            json.dumps(payload, ensure_ascii=False),
+            step_id=step.get("id"),
+            artifact_type="approval_boundary",
+        )
+        self.agent.memory.save_approval_decision(
+            run["run_id"],
+            step.get("id"),
+            "requested",
+            actor=None,
+            reason=approval.get("reason"),
+            payload={**approval, **payload},
+        )
+        self.agent.memory.update_run_status(run["run_id"], "awaiting_approval")
+        return {
+            "status": "awaiting_approval",
+            "run_id": run["run_id"],
+            "boundary_step_id": step.get("id"),
+            "executed": executed,
+            "approval": approval,
+            "resume_number": resume_number,
+        }
+
+    async def _execute_from(
+        self,
+        *,
+        run: dict[str, Any],
+        plan_steps: list[dict[str, Any]],
+        start_index: int,
+        profile_name: str,
+        boundary: dict[str, Any],
+        approved_step_id: Any = None,
+    ) -> dict[str, Any]:
+        records = list(run.get("steps") or [])
+        context = self._execution_context(run)
+        executed: list[dict[str, Any]] = []
+
+        for step in plan_steps[start_index:]:
+            step_id = step.get("id")
+            attempt_no = self._attempt_for_step(records, step_id)
+            approved = approved_step_id is not None and step_id == approved_step_id
+            outcome = await self.agent.step_guard.execute(
+                step,
+                context,
+                profile_name,
+                approved=approved,
+                started_at=datetime.now().isoformat(),
+            )
+            if outcome["state"] == "approval_required":
+                paused = self._pause_for_resume_approval(
+                    run=run,
+                    step=step,
+                    profile_name=profile_name,
+                    attempt_no=attempt_no,
+                    resume_number=boundary["resume_number"],
+                    executed=executed,
+                )
+                paused["resume_summary"] = self._save_summary(
+                    run["run_id"],
+                    boundary,
+                    status="awaiting_approval",
+                    executed=executed,
+                    boundary_step_id=step_id,
+                )
+                return paused
+
+            step_result = outcome["step_result"]
+            step_result["attempt_no"] = attempt_no
+            step_result["phase"] = "failed_resume"
+            self.agent.memory.save_step(
+                run["run_id"],
+                step_result,
+                attempt_no=attempt_no,
+                phase="failed_resume",
+            )
+            self.agent._persist_artifacts(run["run_id"], step_result)
+            executed.append(step_result)
+            records.append(step_result)
+
+            if step_result.get("status") == "failed":
+                self.agent.memory.update_run_status(run["run_id"], "failed")
+                summary = self._save_summary(
+                    run["run_id"],
+                    boundary,
+                    status="failed",
+                    executed=executed,
+                )
+                self.agent.memory.save_project_note(
+                    "failed_resume_failure",
+                    f"Run {run['run_id']} failed during resume {boundary['resume_number']} at step {step_id}",
+                )
+                return {
+                    "status": "failed",
+                    "run_id": run["run_id"],
+                    "resume_number": boundary["resume_number"],
+                    "executed": executed,
+                    "resume_summary": summary,
+                }
+
+        self.agent.memory.update_run_status(run["run_id"], "completed")
+        summary = self._save_summary(
+            run["run_id"],
+            boundary,
+            status="completed",
+            executed=executed,
+        )
+        self.agent.memory.save_project_note(
+            "failed_resume_complete",
+            f"Run {run['run_id']} completed during resume {boundary['resume_number']}",
+        )
+        return {
+            "status": "completed",
+            "run_id": run["run_id"],
+            "resume_number": boundary["resume_number"],
+            "executed": executed,
+            "resume_summary": summary,
+        }
+
+    async def resume(
+        self,
+        run_id: str,
+        *,
+        actor: str = "operator",
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        lock = self._lock_for(run_id)
+        if lock.locked():
+            raise FailedRunResumeError(
+                "resume_in_progress",
+                "A failed-run resume is already in progress for this run.",
+            )
+
+        async with lock:
+            run = self.agent.memory.load_run(run_id)
+            preview = self.preview(run_id)
+            plan = self._plan(run)
+            boundary = self._save_boundary(run, preview, actor=actor, reason=reason)
+            self.agent.memory.update_run_status(run_id, "resuming_failed_run")
+            return await self._execute_from(
+                run=run,
+                plan_steps=plan["steps"],
+                start_index=preview["from_step_index"],
+                profile_name=preview["execution_profile"],
+                boundary=boundary,
+            )
+
+    async def continue_after_approval(
+        self,
+        run_id: str,
+        step_id: int,
+    ) -> dict[str, Any]:
+        lock = self._lock_for(run_id)
+        if lock.locked():
+            raise FailedRunResumeError(
+                "resume_in_progress",
+                "A failed-run resume is already in progress for this run.",
+            )
+
+        async with lock:
+            run = self.agent.memory.load_run(run_id)
+            if not run:
+                raise FailedRunResumeError("run_not_found", "Run not found.", status_code=404)
+            plan = self._plan(run)
+            start_index = next(
+                (index for index, item in enumerate(plan["steps"]) if item.get("id") == step_id),
+                None,
+            )
+            if start_index is None:
+                raise FailedRunResumeError(
+                    "step_boundary_missing",
+                    "Approved step is not present in the persisted run plan.",
+                )
+            boundary_artifacts = [
+                item
+                for item in run.get("artifacts") or []
+                if item.get("artifact_type") == "resume_boundary"
+            ]
+            if not boundary_artifacts:
+                raise FailedRunResumeError(
+                    "resume_boundary_missing",
+                    "Failed-run resume boundary is missing.",
+                )
+            try:
+                boundary = json.loads(boundary_artifacts[-1].get("content") or "{}")
+            except (TypeError, ValueError):
+                boundary = {}
+            if not boundary.get("resume_number"):
+                raise FailedRunResumeError(
+                    "resume_boundary_invalid",
+                    "Failed-run resume boundary is invalid.",
+                )
+            self.agent.memory.update_run_status(run_id, "resuming_failed_run")
+            return await self._execute_from(
+                run=run,
+                plan_steps=plan["steps"],
+                start_index=start_index,
+                profile_name=self.agent._profile_for_run(run),
+                boundary=boundary,
+                approved_step_id=step_id,
+            )
+
+
+def install_failed_run_resume_instance(agent: Any) -> FailedRunResumer:
+    existing = getattr(agent, "failed_run_resumer", None)
+    if existing is not None:
+        return existing
+
+    resumer = FailedRunResumer(agent)
+    original_resume_after_approval = agent.resume_after_approval
+
+    def get_failed_run_resume_state(self, run_id: str):
+        return self.failed_run_resumer.preview(run_id)
+
+    async def resume_failed_run(self, run_id: str, actor: str = "operator", reason: str | None = None):
+        return await self.failed_run_resumer.resume(run_id, actor=actor, reason=reason)
+
+    async def resume_after_approval(self, run_id: str, step_id: int):
+        run = self.memory.load_run(run_id)
+        latest = next(
+            (
+                item
+                for item in reversed((run or {}).get("steps") or [])
+                if item.get("id") == step_id
+            ),
+            None,
+        )
+        if latest and latest.get("phase") == "failed_resume":
+            return await self.failed_run_resumer.continue_after_approval(run_id, step_id)
+        return await original_resume_after_approval(run_id, step_id)
+
+    agent.failed_run_resumer = resumer
+    agent.get_failed_run_resume_state = MethodType(get_failed_run_resume_state, agent)
+    agent.resume_failed_run = MethodType(resume_failed_run, agent)
+    agent.resume_after_approval = MethodType(resume_after_approval, agent)
+    return resumer

--- a/velocity_claw/core/failed_run_resume.py
+++ b/velocity_claw/core/failed_run_resume.py
@@ -29,17 +29,21 @@ class FailedRunResumer:
             self._locks[run_id] = lock
         return lock
 
-    def _artifact_json(self, run: dict[str, Any], name: str, default: Any = None) -> Any:
-        artifact = next(
-            (item for item in reversed(run.get("artifacts") or []) if item.get("name") == name),
-            None,
-        )
+    @staticmethod
+    def _decode_artifact(artifact: dict[str, Any] | None, default: Any = None) -> Any:
         if not artifact:
             return default
         try:
             return json.loads(artifact.get("content") or "null")
         except (TypeError, ValueError):
             return default
+
+    def _artifact_json(self, run: dict[str, Any], name: str, default: Any = None) -> Any:
+        artifact = next(
+            (item for item in reversed(run.get("artifacts") or []) if item.get("name") == name),
+            None,
+        )
+        return self._decode_artifact(artifact, default)
 
     def _plan(self, run: dict[str, Any]) -> dict[str, Any]:
         plan = self._artifact_json(run, "run_plan")
@@ -53,36 +57,46 @@ class FailedRunResumer:
     def _failed_step_index(
         self,
         plan_steps: list[dict[str, Any]],
-        step_records: list[dict[str, Any]],
+        records: list[dict[str, Any]],
     ) -> int:
         latest_by_id = {
             step.get("id"): step
-            for step in effective_steps(step_records)
+            for step in effective_steps(records)
             if step.get("id") is not None
         }
         for index, planned in enumerate(plan_steps):
-            record = latest_by_id.get(planned.get("id"))
-            if record and record.get("status") == "failed":
+            current = latest_by_id.get(planned.get("id"))
+            if current and current.get("status") == "failed":
                 return index
         raise FailedRunResumeError(
             "failed_step_not_found",
             "Run is marked failed but has no effective failed step to resume.",
         )
 
-    def _resume_number(self, run: dict[str, Any]) -> int:
-        count = sum(
+    @staticmethod
+    def _resume_number(run: dict[str, Any]) -> int:
+        return 1 + sum(
             1
             for artifact in run.get("artifacts") or []
             if artifact.get("artifact_type") == "resume_boundary"
         )
-        return count + 1
 
-    def _attempt_for_step(self, records: list[dict[str, Any]], step_id: Any) -> int:
-        attempts = [
-            int(item.get("attempt_no") or 1)
-            for item in records
-            if item.get("id") == step_id
-        ]
+    @staticmethod
+    def _attempt_for_step(
+        records: list[dict[str, Any]],
+        step_id: Any,
+        *,
+        reuse_approval_attempt: bool = False,
+    ) -> int:
+        matching = [item for item in records if item.get("id") == step_id]
+        if reuse_approval_attempt and matching:
+            latest = matching[-1]
+            if (
+                latest.get("phase") == "failed_resume"
+                and latest.get("status") in {"pending_approval", "approved"}
+            ):
+                return max(1, int(latest.get("attempt_no") or 1))
+        attempts = [int(item.get("attempt_no") or 1) for item in matching]
         return max(attempts, default=0) + 1
 
     def preview(self, run_id: str) -> dict[str, Any]:
@@ -95,18 +109,16 @@ class FailedRunResumer:
                 f"Only failed runs can be resumed; current status is {run.get('status')}.",
             )
 
-        plan = self._plan(run)
-        plan_steps = plan.get("steps") or []
+        plan_steps = self._plan(run)["steps"]
         failed_index = self._failed_step_index(plan_steps, run.get("steps") or [])
         failed_step = plan_steps[failed_index]
         lock = self._locks.get(run_id)
-        profile = self.agent._profile_for_run(run)
         return {
             "run_id": run_id,
             "status": run.get("status"),
             "resumable": True,
             "resume_in_progress": bool(lock and lock.locked()),
-            "execution_profile": profile,
+            "execution_profile": self.agent._profile_for_run(run),
             "from_step_id": failed_step.get("id"),
             "from_step_index": failed_index,
             "remaining_step_ids": [item.get("id") for item in plan_steps[failed_index:]],
@@ -186,7 +198,7 @@ class FailedRunResumer:
         )
         return summary
 
-    def _pause_for_resume_approval(
+    def _pause_for_approval(
         self,
         *,
         run: dict[str, Any],
@@ -196,7 +208,6 @@ class FailedRunResumer:
         resume_number: int,
         executed: list[dict[str, Any]],
     ) -> dict[str, Any]:
-        started_at = datetime.now().isoformat()
         approval = self.agent.approvals.build_record(step, profile_name=profile_name)
         step_result = {
             "id": step.get("id"),
@@ -206,7 +217,7 @@ class FailedRunResumer:
             "status": "pending_approval",
             "result": approval,
             "error": None,
-            "started_at": started_at,
+            "started_at": datetime.now().isoformat(),
             "completed_at": datetime.now().isoformat(),
             "attempt_no": attempt_no,
             "phase": "failed_resume",
@@ -217,7 +228,7 @@ class FailedRunResumer:
             attempt_no=attempt_no,
             phase="failed_resume",
         )
-        payload = {
+        boundary_payload = {
             "step_id": step.get("id"),
             "boundary_type": "failed_resume_approval",
             "resume_number": resume_number,
@@ -234,7 +245,7 @@ class FailedRunResumer:
         self.agent.memory.save_artifact(
             run["run_id"],
             f"approval_boundary_step_{step.get('id')}_resume_{resume_number}",
-            json.dumps(payload, ensure_ascii=False),
+            json.dumps(boundary_payload, ensure_ascii=False),
             step_id=step.get("id"),
             artifact_type="approval_boundary",
         )
@@ -244,7 +255,7 @@ class FailedRunResumer:
             "requested",
             actor=None,
             reason=approval.get("reason"),
-            payload={**approval, **payload},
+            payload={**approval, **boundary_payload},
         )
         self.agent.memory.update_run_status(run["run_id"], "awaiting_approval")
         return {
@@ -272,8 +283,12 @@ class FailedRunResumer:
 
         for step in plan_steps[start_index:]:
             step_id = step.get("id")
-            attempt_no = self._attempt_for_step(records, step_id)
             approved = approved_step_id is not None and step_id == approved_step_id
+            attempt_no = self._attempt_for_step(
+                records,
+                step_id,
+                reuse_approval_attempt=approved,
+            )
             outcome = await self.agent.step_guard.execute(
                 step,
                 context,
@@ -282,7 +297,7 @@ class FailedRunResumer:
                 started_at=datetime.now().isoformat(),
             )
             if outcome["state"] == "approval_required":
-                paused = self._pause_for_resume_approval(
+                paused = self._pause_for_approval(
                     run=run,
                     step=step,
                     profile_name=profile_name,
@@ -379,11 +394,7 @@ class FailedRunResumer:
                 boundary=boundary,
             )
 
-    async def continue_after_approval(
-        self,
-        run_id: str,
-        step_id: int,
-    ) -> dict[str, Any]:
+    async def continue_after_approval(self, run_id: str, step_id: int) -> dict[str, Any]:
         lock = self._lock_for(run_id)
         if lock.locked():
             raise FailedRunResumeError(
@@ -395,6 +406,16 @@ class FailedRunResumer:
             run = self.agent.memory.load_run(run_id)
             if not run:
                 raise FailedRunResumeError("run_not_found", "Run not found.", status_code=404)
+            latest = next(
+                (item for item in reversed(run.get("steps") or []) if item.get("id") == step_id),
+                None,
+            )
+            if not latest or latest.get("status") != "approved":
+                raise FailedRunResumeError(
+                    "step_not_approved",
+                    "Failed-resume continuation requires the latest step attempt to be approved.",
+                )
+
             plan = self._plan(run)
             start_index = next(
                 (index for index, item in enumerate(plan["steps"]) if item.get("id") == step_id),
@@ -405,25 +426,22 @@ class FailedRunResumer:
                     "step_boundary_missing",
                     "Approved step is not present in the persisted run plan.",
                 )
-            boundary_artifacts = [
-                item
-                for item in run.get("artifacts") or []
-                if item.get("artifact_type") == "resume_boundary"
-            ]
-            if not boundary_artifacts:
-                raise FailedRunResumeError(
-                    "resume_boundary_missing",
-                    "Failed-run resume boundary is missing.",
-                )
-            try:
-                boundary = json.loads(boundary_artifacts[-1].get("content") or "{}")
-            except (TypeError, ValueError):
-                boundary = {}
-            if not boundary.get("resume_number"):
+
+            boundary_artifact = next(
+                (
+                    item
+                    for item in reversed(run.get("artifacts") or [])
+                    if item.get("artifact_type") == "resume_boundary"
+                ),
+                None,
+            )
+            boundary = self._decode_artifact(boundary_artifact, {})
+            if not isinstance(boundary, dict) or not boundary.get("resume_number"):
                 raise FailedRunResumeError(
                     "resume_boundary_invalid",
-                    "Failed-run resume boundary is invalid.",
+                    "Failed-run resume boundary is missing or invalid.",
                 )
+
             self.agent.memory.update_run_status(run_id, "resuming_failed_run")
             return await self._execute_from(
                 run=run,
@@ -446,7 +464,12 @@ def install_failed_run_resume_instance(agent: Any) -> FailedRunResumer:
     def get_failed_run_resume_state(self, run_id: str):
         return self.failed_run_resumer.preview(run_id)
 
-    async def resume_failed_run(self, run_id: str, actor: str = "operator", reason: str | None = None):
+    async def resume_failed_run(
+        self,
+        run_id: str,
+        actor: str = "operator",
+        reason: str | None = None,
+    ):
         return await self.failed_run_resumer.resume(run_id, actor=actor, reason=reason)
 
     async def resume_after_approval(self, run_id: str, step_id: int):

--- a/velocity_claw/core/failed_run_resume_install.py
+++ b/velocity_claw/core/failed_run_resume_install.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Any
+
+from velocity_claw.core.failed_run_resume import install_failed_run_resume_instance
+
+
+def install_failed_run_resume_class(agent_cls: type) -> None:
+    if getattr(agent_cls, "_failed_run_resume_v2_installed", False):
+        return
+
+    original_init = agent_cls.__init__
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        original_init(self, *args, **kwargs)
+        install_failed_run_resume_instance(self)
+
+    agent_cls.__init__ = __init__
+    agent_cls._failed_run_resume_v2_installed = True

--- a/velocity_claw/memory/__init__.py
+++ b/velocity_claw/memory/__init__.py
@@ -1,8 +1,10 @@
 """Velocity Claw memory package."""
 
 from velocity_claw.memory.run_profile_schema import install_run_profile_schema
+from velocity_claw.memory.step_attempts_v2 import install_step_attempts_v2
 from velocity_claw.memory.store import MemoryStore
 
 install_run_profile_schema(MemoryStore)
+install_step_attempts_v2(MemoryStore)
 
 __all__ = ["MemoryStore"]

--- a/velocity_claw/memory/step_attempts_v2.py
+++ b/velocity_claw/memory/step_attempts_v2.py
@@ -20,14 +20,29 @@ def effective_steps(steps: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 def attempt_summary(steps: list[dict[str, Any]]) -> dict[str, Any]:
-    counts = Counter(str(step.get("id")) for step in steps if step.get("id") is not None)
+    attempt_numbers: dict[str, set[int]] = {}
+    for step in steps:
+        if step.get("id") is None:
+            continue
+        key = str(step.get("id"))
+        try:
+            attempt_no = max(1, int(step.get("attempt_no") or 1))
+        except (TypeError, ValueError):
+            attempt_no = 1
+        attempt_numbers.setdefault(key, set()).add(attempt_no)
+    attempts_by_step = {
+        step_id: len(numbers)
+        for step_id, numbers in attempt_numbers.items()
+    }
     phases = Counter(str(step.get("phase") or "initial") for step in steps)
     latest = effective_steps(steps)
     return {
         "total_attempt_records": len(steps),
         "unique_steps": len(latest),
-        "retried_steps": sorted(step_id for step_id, count in counts.items() if count > 1),
-        "attempts_by_step": dict(counts),
+        "retried_steps": sorted(
+            step_id for step_id, count in attempts_by_step.items() if count > 1
+        ),
+        "attempts_by_step": attempts_by_step,
         "records_by_phase": dict(phases),
     }
 

--- a/velocity_claw/memory/step_attempts_v2.py
+++ b/velocity_claw/memory/step_attempts_v2.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections import Counter
+from typing import Any
+
+
+def effective_steps(steps: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    latest: dict[Any, dict[str, Any]] = {}
+    order: list[Any] = []
+    for index, step in enumerate(steps):
+        step_id = step.get("id")
+        key = step_id if step_id is not None else f"record:{step.get('record_id', index)}"
+        if key not in latest:
+            order.append(key)
+        latest[key] = step
+    return [latest[key] for key in order]
+
+
+def attempt_summary(steps: list[dict[str, Any]]) -> dict[str, Any]:
+    counts = Counter(str(step.get("id")) for step in steps if step.get("id") is not None)
+    phases = Counter(str(step.get("phase") or "initial") for step in steps)
+    latest = effective_steps(steps)
+    return {
+        "total_attempt_records": len(steps),
+        "unique_steps": len(latest),
+        "retried_steps": sorted(step_id for step_id, count in counts.items() if count > 1),
+        "attempts_by_step": dict(counts),
+        "records_by_phase": dict(phases),
+    }
+
+
+def install_step_attempts_v2(memory_cls: type) -> None:
+    if getattr(memory_cls, "_step_attempts_v2_installed", False):
+        return
+
+    original_ensure_tables = memory_cls._ensure_tables
+    original_build_forensics = memory_cls.build_run_forensics
+    original_build_report = memory_cls.build_run_report
+
+    def _ensure_tables(self) -> None:
+        original_ensure_tables(self)
+        if not getattr(self, "enabled", False):
+            return
+        with sqlite3.connect(self.db_path) as conn:
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(steps)").fetchall()}
+            if "attempt_no" not in columns:
+                conn.execute("ALTER TABLE steps ADD COLUMN attempt_no INTEGER NOT NULL DEFAULT 1")
+            if "phase" not in columns:
+                conn.execute("ALTER TABLE steps ADD COLUMN phase TEXT NOT NULL DEFAULT 'initial'")
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_steps_run_step_attempt "
+                "ON steps(run_id, step_id, attempt_no, id)"
+            )
+
+    def save_step(self, run_id: str, step: dict, attempt_no: int | None = None, phase: str | None = None) -> None:
+        if not getattr(self, "enabled", False):
+            return
+        resolved_attempt = attempt_no if attempt_no is not None else step.get("attempt_no", 1)
+        try:
+            resolved_attempt = max(1, int(resolved_attempt))
+        except (TypeError, ValueError):
+            resolved_attempt = 1
+        resolved_phase = str(phase or step.get("phase") or "initial").strip() or "initial"
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO steps (
+                    run_id, step_id, title, tool, args, status, result, error,
+                    started_at, completed_at, attempt_no, phase
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run_id,
+                    step.get("id"),
+                    step.get("title"),
+                    step.get("tool"),
+                    json.dumps(step.get("args", {}), ensure_ascii=False),
+                    step.get("status"),
+                    json.dumps(step.get("result"), ensure_ascii=False),
+                    step.get("error"),
+                    step.get("started_at"),
+                    step.get("completed_at"),
+                    resolved_attempt,
+                    resolved_phase,
+                ),
+            )
+
+    def load_steps(self, run_id: str):
+        if not getattr(self, "enabled", False):
+            return []
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute(
+                """
+                SELECT id, step_id, title, tool, args, status, result, error,
+                       started_at, completed_at, attempt_no, phase
+                FROM steps
+                WHERE run_id = ?
+                ORDER BY id
+                """,
+                (run_id,),
+            ).fetchall()
+        return [
+            {
+                "record_id": row[0],
+                "id": row[1],
+                "title": row[2],
+                "tool": row[3],
+                "args": json.loads(row[4]) if row[4] else {},
+                "status": row[5],
+                "result": json.loads(row[6]) if row[6] is not None else None,
+                "error": row[7],
+                "started_at": row[8],
+                "completed_at": row[9],
+                "attempt_no": row[10] or 1,
+                "phase": row[11] or "initial",
+            }
+            for row in rows
+        ]
+
+    def update_step_status(self, run_id: str, step_id: int, status: str, result: Any = None, error: str | None = None) -> None:
+        if not getattr(self, "enabled", False):
+            return
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                UPDATE steps
+                SET status = ?, result = ?, error = ?, completed_at = ?
+                WHERE id = (
+                    SELECT id FROM steps
+                    WHERE run_id = ? AND step_id = ?
+                    ORDER BY id DESC LIMIT 1
+                )
+                """,
+                (
+                    status,
+                    json.dumps(result, ensure_ascii=False) if result is not None else None,
+                    error,
+                    __import__("datetime").datetime.now().isoformat(),
+                    run_id,
+                    step_id,
+                ),
+            )
+
+    def build_run_forensics(self, run: dict) -> dict:
+        steps = run.get("steps", [])
+        effective = effective_steps(steps)
+        payload = original_build_forensics(self, {**run, "steps": effective, "forensics": None})
+        payload["step_attempts"] = attempt_summary(steps)
+        payload["latest_effective_steps"] = [
+            {
+                "id": step.get("id"),
+                "status": step.get("status"),
+                "attempt_no": step.get("attempt_no", 1),
+                "phase": step.get("phase", "initial"),
+            }
+            for step in effective
+        ]
+        return payload
+
+    def build_run_report(self, run: dict) -> dict:
+        steps = run.get("steps", [])
+        effective = effective_steps(steps)
+        payload = original_build_report(self, {**run, "steps": effective, "forensics": None, "report": None})
+        payload["step_attempt_overview"] = attempt_summary(steps)
+        return payload
+
+    memory_cls._ensure_tables = _ensure_tables
+    memory_cls.save_step = save_step
+    memory_cls.load_steps = load_steps
+    memory_cls.update_step_status = update_step_status
+    memory_cls.build_run_forensics = build_run_forensics
+    memory_cls.build_run_report = build_run_report
+    memory_cls._step_attempts_v2_installed = True

--- a/velocity_claw/memory/step_attempts_v2.py
+++ b/velocity_claw/memory/step_attempts_v2.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from collections import Counter
+from datetime import datetime
 from typing import Any
 
 
@@ -138,7 +139,7 @@ def install_step_attempts_v2(memory_cls: type) -> None:
                     status,
                     json.dumps(result, ensure_ascii=False) if result is not None else None,
                     error,
-                    __import__("datetime").datetime.now().isoformat(),
+                    datetime.now().isoformat(),
                     run_id,
                     step_id,
                 ),


### PR DESCRIPTION
## Summary

Implements issue #11: resume a failed run from its effective failed step while preserving the original trace.

Changes:
- add persistent step-attempt metadata with non-destructive SQLite migration
- preserve all historical attempts while reports/forensics use the latest attempt per step
- add failed-run resume preview and execution engine
- keep the original `run_id`, plan, planning context, artifacts, and stored execution profile
- skip earlier completed steps and retry only the failed step plus remaining plan
- pass resumed work through the normal profile, runtime, approval, and security guard
- prevent concurrent duplicate resume in the same process
- persist resume boundary and summary artifacts
- reopen approval boundaries for resumed gated steps
- make Approval v2 resolve the latest attempt for a repeated `step_id`
- expose attempt and resume history in Run detail v2
- add `GET/POST /runs/{run_id}/resume/v2`
- add migration, engine, API, approval, and Run detail tests
- document resume versus retry workflows

Validation targets:
- complete pytest suite
- package validation
- dependency audit
- wheel/source build

Closes #11 when merged.