### PR TITLE
Complete safe test runner support with npm and failure semantics

### DIFF
--- a/docs/TEST_RUNNER.md
+++ b/docs/TEST_RUNNER.md
@@ -1,0 +1,89 @@
+# Test runner
+
+Velocity Claw exposes test execution through the `test.run` tool.
+
+## Supported runners
+
+- `pytest`
+- `python -m pytest`
+- `npm test`
+
+Commands are always executed with `shell=False`. The runner name is selected from the fixed list above; arbitrary executable strings are rejected.
+
+## Workspace restrictions
+
+- the process working directory defaults to `WORKSPACE_ROOT`;
+- an optional `cwd` must resolve to an existing directory inside the workspace;
+- pytest targets and node IDs are validated against workspace boundaries;
+- npm/Jest test targets must also resolve inside the workspace;
+- subprocesses cannot request a timeout greater than `COMMAND_TIMEOUT`.
+
+## Targeted pytest execution
+
+`test.run` accepts:
+
+- `target`
+- `nodeid`
+- `keyword`
+- `marker`
+- `extra_args`
+
+Only a small allowlist of extra pytest arguments is forwarded. Examples include `-q`, `-x`, `--lf`, `--maxfail=1`, and short traceback modes.
+
+## npm and Jest execution
+
+`npm test` may receive a workspace test target and allowlisted arguments after `--`.
+
+Allowlisted examples include:
+
+- `--runInBand`
+- `--watch=false`
+- `--passWithNoTests`
+- `--coverage`
+- `--testNamePattern=...`
+- `--testPathPattern=...`
+- `--maxWorkers=...`
+
+Unknown npm arguments are discarded instead of being forwarded.
+
+## Structured result
+
+Every test result contains:
+
+- runner and command array;
+- target and selectors;
+- resolved working directory;
+- effective timeout;
+- exit code and normalized status;
+- stdout and stderr;
+- duration;
+- passed/failed/error/skipped summary;
+- parsed failure objects.
+
+Normalized statuses are:
+
+- `passed`
+- `failed`
+- `timeout`
+- `runner_unavailable`
+- `simulated`
+
+A `failed`, `timeout`, or `runner_unavailable` test result marks the enclosing agent step as failed. The plan therefore stops instead of continuing after an unsuccessful verification step.
+
+## Failure objects
+
+Pytest and common Jest output are normalized into objects containing:
+
+- failed test name;
+- node ID or test title;
+- file;
+- line when available;
+- assertion/message;
+- traceback summary;
+- failure kind.
+
+The full stdout/stderr and parsed failure list remain in the step result. Velocity Claw persists test logs and parsed failures as run artifacts for retry, failed-run resume, reporting, and auto-fix diagnostics.
+
+## Dry run
+
+In dry-run mode no subprocess is started. The result returns the exact command array, working directory, effective timeout, and `status=simulated` while keeping path and argument validation active.

--- a/tests/test_test_runner_npm_v2.py
+++ b/tests/test_test_runner_npm_v2.py
@@ -1,0 +1,193 @@
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.executor.executor import Executor
+from velocity_claw.tools.test_runner import TestRunnerTool
+
+
+def make_runner(tmp_path: Path) -> TestRunnerTool:
+    return TestRunnerTool(
+        Settings(
+            env="test",
+            workspace_root=str(tmp_path),
+            command_timeout=30,
+        )
+    )
+
+
+def test_npm_command_uses_shell_free_allowlisted_arguments(tmp_path: Path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "widget.test.js").write_text("test('ok', () => {});", encoding="utf-8")
+    runner = make_runner(tmp_path)
+
+    command = runner._build_command(
+        "npm test",
+        "src/widget.test.js",
+        ["--runInBand", "--maxWorkers=2", "--dangerous", "value"],
+    )
+
+    assert command == [
+        "npm",
+        "test",
+        "--",
+        "src/widget.test.js",
+        "--runInBand",
+        "--maxWorkers=2",
+    ]
+
+
+def test_npm_target_and_cwd_stay_inside_workspace(tmp_path: Path):
+    package = tmp_path / "frontend"
+    package.mkdir()
+    (package / "package.json").write_text("{}", encoding="utf-8")
+    runner = make_runner(tmp_path)
+
+    result = runner.run("npm test", cwd="frontend", dry_run=True)
+
+    assert result["status"] == "simulated"
+    assert result["cwd"] == str(package.resolve())
+    assert result["command"] == ["npm", "test"]
+
+    with pytest.raises(ValueError, match="outside workspace"):
+        runner.run("npm test", cwd="../outside", dry_run=True)
+
+
+def test_npm_jest_output_is_structured(tmp_path: Path):
+    runner = make_runner(tmp_path)
+    output = """
+FAIL src/widget.test.js
+  ● widget › renders value
+
+    Expected: 2
+    Received: 1
+
+      at Object.<anonymous> (src/widget.test.js:12:5)
+
+Tests:       1 failed, 2 passed, 1 skipped, 4 total
+"""
+    completed = SimpleNamespace(returncode=1, stdout=output, stderr="")
+
+    with patch("velocity_claw.tools.test_runner.subprocess.run", return_value=completed) as run_mock:
+        result = runner.run("npm test", timeout=10)
+
+    assert result["status"] == "failed"
+    assert result["summary"]["collected"] == 4
+    assert result["summary"]["failed"] == 1
+    assert result["summary"]["passed"] == 2
+    assert result["summary"]["skipped"] == 1
+    assert result["parsed_failures"] == [
+        {
+            "failed_test_name": "widget › renders value",
+            "nodeid": "widget › renders value",
+            "file": "src/widget.test.js",
+            "line": 12,
+            "assertion": "Expected: 2 Received: 1",
+            "traceback_summary": "Expected: 2 Received: 1",
+            "kind": "failed",
+        }
+    ]
+    assert run_mock.call_args.kwargs["shell"] is False
+    assert run_mock.call_args.kwargs["cwd"] == tmp_path.resolve()
+    assert run_mock.call_args.kwargs["timeout"] == 10
+
+
+def test_missing_npm_binary_returns_structured_runner_error(tmp_path: Path):
+    runner = make_runner(tmp_path)
+
+    with patch(
+        "velocity_claw.tools.test_runner.subprocess.run",
+        side_effect=FileNotFoundError("npm not found"),
+    ):
+        result = runner.run("npm test", timeout=5)
+
+    assert result["status"] == "runner_unavailable"
+    assert result["code"] == -127
+    assert result["summary"]["errors"] == 1
+    assert "npm not found" in result["stderr"]
+
+
+def test_timeout_is_bounded_by_runtime_setting(tmp_path: Path):
+    runner = make_runner(tmp_path)
+
+    with pytest.raises(ValueError, match="between 1 and 30"):
+        runner.run("pytest", timeout=31, dry_run=True)
+    with pytest.raises(ValueError, match="between 1 and 30"):
+        runner.run("pytest", timeout=0, dry_run=True)
+
+
+def test_pytest_targeted_selectors_are_preserved(tmp_path: Path):
+    test_file = tmp_path / "test_sample.py"
+    test_file.write_text("def test_value():\n    assert True\n", encoding="utf-8")
+    runner = make_runner(tmp_path)
+
+    command = runner._build_command(
+        "python -m pytest",
+        None,
+        ["-q"],
+        keyword="value",
+        marker="unit",
+        nodeid="test_sample.py::test_value",
+    )
+
+    assert command == [
+        "python",
+        "-m",
+        "pytest",
+        "test_sample.py::test_value",
+        "-k",
+        "value",
+        "-m",
+        "unit",
+        "-q",
+    ]
+
+
+def test_executor_marks_failed_test_result_as_failed_step(tmp_path: Path):
+    settings = Settings(env="test", workspace_root=str(tmp_path), command_timeout=30)
+    executor = Executor(router=object(), settings=settings)
+    captured = {}
+
+    class FakeRunner:
+        def run(self, runner, **kwargs):
+            captured["runner"] = runner
+            captured.update(kwargs)
+            return {
+                "runner": runner,
+                "status": "failed",
+                "code": 1,
+                "stdout": "",
+                "stderr": "",
+                "summary": {"failed": 1},
+                "parsed_failures": [{"nodeid": "test_sample.py::test_value"}],
+            }
+
+    executor.test_runner = FakeRunner()
+    step = {
+        "id": 1,
+        "title": "Run targeted test",
+        "tool": "test.run",
+        "args": {
+            "runner": "pytest",
+            "nodeid": "test_sample.py::test_value",
+            "keyword": "value",
+            "marker": "unit",
+            "cwd": ".",
+            "timeout": 15,
+        },
+    }
+
+    result = asyncio.run(executor.execute_step(step, {}))
+
+    assert result["status"] == "failed"
+    assert result["error"] == "test_run_failed"
+    assert result["result"]["parsed_failures"][0]["nodeid"] == "test_sample.py::test_value"
+    assert captured["nodeid"] == "test_sample.py::test_value"
+    assert captured["keyword"] == "value"
+    assert captured["marker"] == "unit"
+    assert captured["cwd"] == "."
+    assert captured["timeout"] == 15

--- a/velocity_claw/executor/executor.py
+++ b/velocity_claw/executor/executor.py
@@ -66,6 +66,15 @@ class Executor:
         try:
             profile = self._get_profile(tool)
             result = await self._execute_tool(tool, args, profile)
+            if tool == "test.run" and isinstance(result, dict):
+                runner_status = result.get("status")
+                if runner_status not in {"passed", "simulated"}:
+                    return {
+                        **base_result,
+                        "status": "failed",
+                        "result": result,
+                        "error": f"test_run_{runner_status or 'failed'}",
+                    }
             return {**base_result, "status": "success", "result": result, "error": None}
         except Exception as e:
             self.logger.error("Step %s failed: %s", step_id, e)
@@ -104,6 +113,10 @@ class Executor:
                 timeout=args.get("timeout", self.settings.command_timeout),
                 extra_args=args.get("extra_args"),
                 dry_run=dry_run,
+                keyword=args.get("keyword"),
+                marker=args.get("marker"),
+                nodeid=args.get("nodeid"),
+                cwd=args.get("cwd"),
             )
         if tool == "shell.run":
             self.security.validate_command(args["command"], profile)

--- a/velocity_claw/tools/test_runner.py
+++ b/velocity_claw/tools/test_runner.py
@@ -12,8 +12,33 @@ from velocity_claw.tools.fs import FileSystemTool
 
 class TestRunnerTool:
     __test__ = False
-    _ALLOWED_EXACT_ARGS = {"-q", "-x", "-vv", "--lf", "--ff", "--disable-warnings"}
-    _ALLOWED_PREFIX_ARGS = ("--maxfail=",)
+
+    _PYTEST_ALLOWED_EXACT_ARGS = {
+        "-q",
+        "-x",
+        "-vv",
+        "--lf",
+        "--ff",
+        "--disable-warnings",
+        "--tb=short",
+        "--tb=line",
+        "--strict-markers",
+    }
+    _PYTEST_ALLOWED_PREFIX_ARGS = ("--maxfail=",)
+
+    _NPM_ALLOWED_EXACT_ARGS = {
+        "--runInBand",
+        "--watch=false",
+        "--passWithNoTests",
+        "--coverage",
+        "--silent",
+        "--verbose",
+    }
+    _NPM_ALLOWED_PREFIX_ARGS = (
+        "--testNamePattern=",
+        "--testPathPattern=",
+        "--maxWorkers=",
+    )
 
     def __init__(self, settings: Settings):
         self.settings = settings
@@ -30,73 +55,116 @@ class TestRunnerTool:
         keyword: Optional[str] = None,
         marker: Optional[str] = None,
         nodeid: Optional[str] = None,
+        cwd: Optional[str] = None,
     ) -> dict:
         extra_args = extra_args or []
-        cmd = self._build_command(runner, target, extra_args, keyword=keyword, marker=marker, nodeid=nodeid)
+        timeout_seconds = self._normalize_timeout(timeout)
+        working_directory = self._resolve_cwd(cwd)
+        cmd = self._build_command(
+            runner,
+            target,
+            extra_args,
+            keyword=keyword,
+            marker=marker,
+            nodeid=nodeid,
+        )
+        base = {
+            "runner": runner,
+            "target": target,
+            "nodeid": nodeid,
+            "keyword": keyword,
+            "marker": marker,
+            "cwd": str(working_directory),
+            "timeout_seconds": timeout_seconds,
+            "command": cmd,
+        }
         if dry_run:
             return {
-                "runner": runner,
-                "target": target,
-                "nodeid": nodeid,
-                "keyword": keyword,
-                "marker": marker,
+                **base,
                 "code": 0,
                 "status": "simulated",
                 "stdout": "",
                 "stderr": "",
                 "duration_ms": 0,
                 "summary": self._empty_summary(),
-                "command": cmd,
                 "parsed_failures": [],
             }
+
         start = time.monotonic()
         try:
             completed = subprocess.run(
                 cmd,
-                cwd=self.workspace_root,
+                cwd=working_directory,
                 capture_output=True,
                 text=True,
-                timeout=timeout,
+                timeout=timeout_seconds,
                 shell=False,
             )
             duration_ms = int((time.monotonic() - start) * 1000)
-            stdout = completed.stdout
-            stderr = completed.stderr
+            stdout = completed.stdout or ""
+            stderr = completed.stderr or ""
             combined = stdout + "\n" + stderr
-            summary = self._extract_summary(combined)
-            status = self._determine_status(completed.returncode, summary)
+            summary = self._extract_summary(combined, runner)
             return {
-                "runner": runner,
-                "target": target,
-                "nodeid": nodeid,
-                "keyword": keyword,
-                "marker": marker,
+                **base,
                 "code": completed.returncode,
-                "status": status,
+                "status": self._determine_status(completed.returncode, summary),
                 "stdout": stdout,
                 "stderr": stderr,
                 "duration_ms": duration_ms,
                 "summary": summary,
-                "command": cmd,
-                "parsed_failures": self.parse_failures(combined),
+                "parsed_failures": self.parse_failures(combined, runner=runner),
             }
-        except subprocess.TimeoutExpired as e:
+        except subprocess.TimeoutExpired as exc:
             duration_ms = int((time.monotonic() - start) * 1000)
             return {
-                "runner": runner,
-                "target": target,
-                "nodeid": nodeid,
-                "keyword": keyword,
-                "marker": marker,
+                **base,
                 "code": -1,
                 "status": "timeout",
-                "stdout": e.stdout or "",
-                "stderr": e.stderr or "",
+                "stdout": self._decode_process_output(exc.stdout),
+                "stderr": self._decode_process_output(exc.stderr),
                 "duration_ms": duration_ms,
                 "summary": {**self._empty_summary(), "errors": 1},
-                "command": cmd,
                 "parsed_failures": [],
             }
+        except FileNotFoundError as exc:
+            duration_ms = int((time.monotonic() - start) * 1000)
+            return {
+                **base,
+                "code": -127,
+                "status": "runner_unavailable",
+                "stdout": "",
+                "stderr": str(exc),
+                "duration_ms": duration_ms,
+                "summary": {**self._empty_summary(), "errors": 1},
+                "parsed_failures": [],
+            }
+
+    @staticmethod
+    def _decode_process_output(value) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, bytes):
+            return value.decode("utf-8", errors="replace")
+        return str(value)
+
+    def _normalize_timeout(self, timeout: int) -> int:
+        try:
+            value = int(timeout)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Test timeout must be an integer") from exc
+        maximum = max(1, int(self.settings.command_timeout))
+        if value < 1 or value > maximum:
+            raise ValueError(f"Test timeout must be between 1 and {maximum} seconds")
+        return value
+
+    def _resolve_cwd(self, cwd: Optional[str]) -> Path:
+        resolved = self.workspace_root if not cwd else self.fs._validate_path(cwd)
+        if not resolved.exists():
+            raise ValueError(f"Test working directory does not exist: {resolved}")
+        if not resolved.is_dir():
+            raise ValueError(f"Test working directory is not a directory: {resolved}")
+        return resolved
 
     def _build_command(
         self,
@@ -108,37 +176,61 @@ class TestRunnerTool:
         marker: Optional[str] = None,
         nodeid: Optional[str] = None,
     ) -> list[str]:
-        safe_extra = [arg for arg in extra_args if self._is_allowed_extra_arg(arg)]
-        if target:
-            self.fs._validate_path(target)
-        if nodeid:
-            node_path = nodeid.split("::", 1)[0]
-            self.fs._validate_path(node_path)
-        if runner == "pytest":
-            cmd = ["pytest"]
-        elif runner == "python -m pytest":
-            cmd = ["python", "-m", "pytest"]
-        else:
-            raise ValueError(f"Unsupported runner: {runner}")
-        if target:
-            cmd.append(target)
-        if nodeid:
-            cmd.append(nodeid)
-        if keyword:
-            cmd.extend(["-k", keyword])
-        if marker:
-            cmd.extend(["-m", marker])
-        cmd.extend(safe_extra)
-        return cmd
+        normalized = str(runner or "").strip().lower()
+        safe_extra = [
+            arg for arg in extra_args
+            if self._is_allowed_extra_arg(arg, normalized)
+        ]
 
-    def _is_allowed_extra_arg(self, arg: str) -> bool:
-        if not arg:
+        if normalized in {"pytest", "python -m pytest"}:
+            if target:
+                self.fs._validate_path(target)
+            if nodeid:
+                node_path = nodeid.split("::", 1)[0]
+                self.fs._validate_path(node_path)
+            cmd = ["pytest"] if normalized == "pytest" else ["python", "-m", "pytest"]
+            if target:
+                cmd.append(target)
+            if nodeid:
+                cmd.append(nodeid)
+            if keyword:
+                cmd.extend(["-k", keyword])
+            if marker:
+                cmd.extend(["-m", marker])
+            cmd.extend(safe_extra)
+            return cmd
+
+        if normalized == "npm test":
+            if nodeid or marker:
+                raise ValueError("nodeid and marker selectors are only supported by pytest")
+            if target:
+                self.fs._validate_path(target)
+            npm_args = list(safe_extra)
+            if keyword:
+                npm_args.append(f"--testNamePattern={keyword}")
+            cmd = ["npm", "test"]
+            if target or npm_args:
+                cmd.append("--")
+            if target:
+                cmd.append(target)
+            cmd.extend(npm_args)
+            return cmd
+
+        raise ValueError(f"Unsupported runner: {runner}")
+
+    def _is_allowed_extra_arg(self, arg: str, runner: str = "pytest") -> bool:
+        if not arg or not isinstance(arg, str):
             return False
-        if arg in self._ALLOWED_EXACT_ARGS:
+        if runner == "npm test":
+            if arg in self._NPM_ALLOWED_EXACT_ARGS:
+                return True
+            return any(arg.startswith(prefix) for prefix in self._NPM_ALLOWED_PREFIX_ARGS)
+        if arg in self._PYTEST_ALLOWED_EXACT_ARGS:
             return True
-        return any(arg.startswith(prefix) for prefix in self._ALLOWED_PREFIX_ARGS)
+        return any(arg.startswith(prefix) for prefix in self._PYTEST_ALLOWED_PREFIX_ARGS)
 
-    def _empty_summary(self) -> dict:
+    @staticmethod
+    def _empty_summary() -> dict:
         return {
             "collected": 0,
             "passed": 0,
@@ -149,14 +241,18 @@ class TestRunnerTool:
             "xpassed": 0,
         }
 
-    def _determine_status(self, code: int, summary: dict) -> str:
+    @staticmethod
+    def _determine_status(code: int, summary: dict) -> str:
         if code == 0 and summary["failed"] == 0 and summary["errors"] == 0:
             return "passed"
-        if summary["failed"] > 0 or summary["errors"] > 0:
-            return "failed"
-        return "failed" if code != 0 else "passed"
+        return "failed"
 
-    def _extract_summary(self, output: str) -> dict:
+    def _extract_summary(self, output: str, runner: str = "pytest") -> dict:
+        if str(runner).strip().lower() == "npm test":
+            return self._extract_npm_summary(output)
+        return self._extract_pytest_summary(output)
+
+    def _extract_pytest_summary(self, output: str) -> dict:
         summary = self._empty_summary()
         collected = re.search(r"collected\s+(\d+)\s+items?", output)
         if collected:
@@ -170,71 +266,137 @@ class TestRunnerTool:
             "xpassed": r"(\d+) xpassed",
         }
         for key, pattern in patterns.items():
-            m = re.search(pattern, output)
-            if m:
-                summary[key] = int(m.group(1))
+            match = re.search(pattern, output)
+            if match:
+                summary[key] = int(match.group(1))
         if summary["collected"] == 0:
-            counted = summary["passed"] + summary["failed"] + summary["errors"] + summary["skipped"] + summary["xfailed"] + summary["xpassed"]
-            summary["collected"] = counted
+            summary["collected"] = sum(
+                summary[key]
+                for key in ("passed", "failed", "errors", "skipped", "xfailed", "xpassed")
+            )
         return summary
 
-    def parse_failures(self, output: str) -> list[dict]:
+    def _extract_npm_summary(self, output: str) -> dict:
+        summary = self._empty_summary()
+        tests_line = next(
+            (line for line in output.splitlines() if line.strip().startswith("Tests:")),
+            "",
+        )
+        mappings = {
+            "passed": r"(\d+)\s+passed",
+            "failed": r"(\d+)\s+failed",
+            "skipped": r"(\d+)\s+(?:skipped|pending|todo)",
+            "collected": r"(\d+)\s+total",
+        }
+        for key, pattern in mappings.items():
+            match = re.search(pattern, tests_line, flags=re.IGNORECASE)
+            if match:
+                summary[key] = int(match.group(1))
+        if summary["collected"] == 0:
+            summary["collected"] = summary["passed"] + summary["failed"] + summary["skipped"]
+        return summary
+
+    def parse_failures(self, output: str, runner: str = "pytest") -> list[dict]:
+        if str(runner).strip().lower() == "npm test":
+            return self._parse_jest_failures(output)
+        return self._parse_pytest_failures(output)
+
+    def _parse_pytest_failures(self, output: str) -> list[dict]:
         failures: list[dict] = []
         current: dict | None = None
         in_short_summary = False
 
         for raw_line in output.splitlines():
-            line = raw_line.rstrip()
-            stripped = line.strip()
-
+            stripped = raw_line.rstrip().strip()
             if stripped.startswith("short test summary info"):
                 in_short_summary = True
                 continue
-
             if stripped.startswith("FAILED "):
-                current = self._parse_summary_line(stripped, kind="failed")
+                current = self._parse_pytest_summary_line(stripped, kind="failed")
                 failures.append(current)
                 in_short_summary = True
                 continue
-
             if stripped.startswith("ERROR "):
-                current = self._parse_summary_line(stripped, kind="error")
+                current = self._parse_pytest_summary_line(stripped, kind="error")
                 failures.append(current)
                 in_short_summary = True
                 continue
-
             if in_short_summary and current and stripped.startswith("E   "):
                 message = stripped[4:].strip()
                 current["assertion"] = message
                 current["traceback_summary"] = message
                 continue
-
             file_match = re.match(r"(.+\.py):(\d+):\s+in\s+", stripped)
             if current and file_match:
                 current["file"] = file_match.group(1)
                 current["line"] = int(file_match.group(2))
                 continue
-
             if current and stripped.startswith("E       "):
                 message = stripped.replace("E       ", "", 1).strip()
                 current["assertion"] = message
                 current["traceback_summary"] = message
-                continue
-
         return failures
 
-    def _parse_summary_line(self, line: str, *, kind: str) -> dict:
+    @staticmethod
+    def _parse_pytest_summary_line(line: str, *, kind: str) -> dict:
         tail = line[len("FAILED "):] if kind == "failed" else line[len("ERROR "):]
         parts = tail.split(" - ", 1)
         node = parts[0].strip()
         message = parts[1].strip() if len(parts) > 1 else tail
-        file_name = node.split("::", 1)[0] if ".py" in node else None
         return {
             "failed_test_name": node,
             "nodeid": node,
-            "file": file_name,
+            "file": node.split("::", 1)[0] if ".py" in node else None,
             "line": None,
             "assertion": message,
             "traceback_summary": message,
             "kind": kind,
         }
+
+    def _parse_jest_failures(self, output: str) -> list[dict]:
+        failures: list[dict] = []
+        current_file: str | None = None
+        current: dict | None = None
+        message_lines: list[str] = []
+
+        def flush_message() -> None:
+            nonlocal message_lines
+            if current is not None and message_lines:
+                message = " ".join(message_lines).strip()
+                current["assertion"] = message
+                current["traceback_summary"] = message
+            message_lines = []
+
+        for raw_line in output.splitlines():
+            stripped = raw_line.strip()
+            if stripped.startswith("FAIL "):
+                flush_message()
+                current_file = stripped[5:].split()[0]
+                current = None
+                continue
+            if stripped.startswith("● "):
+                flush_message()
+                test_name = stripped[2:].strip()
+                current = {
+                    "failed_test_name": test_name,
+                    "nodeid": test_name,
+                    "file": current_file,
+                    "line": None,
+                    "assertion": test_name,
+                    "traceback_summary": test_name,
+                    "kind": "failed",
+                }
+                failures.append(current)
+                continue
+            if current is None:
+                continue
+            stack = re.search(r"(?:\(|\s)([^\s()]+\.(?:js|jsx|ts|tsx)):(\d+):(\d+)\)?$", stripped)
+            if stack:
+                current["file"] = stack.group(1)
+                current["line"] = int(stack.group(2))
+                continue
+            if stripped.startswith(("Expected:", "Received:", "Error:", "expect(")):
+                message_lines.append(stripped)
+
+        flush_message()
+        return failures

--- a/velocity_claw/tools/test_runner.py
+++ b/velocity_claw/tools/test_runner.py
@@ -49,7 +49,7 @@ class TestRunnerTool:
         self,
         runner: str,
         target: Optional[str] = None,
-        timeout: int = 120,
+        timeout: Optional[int] = None,
         extra_args: Optional[list[str]] = None,
         dry_run: bool = False,
         keyword: Optional[str] = None,
@@ -148,12 +148,14 @@ class TestRunnerTool:
             return value.decode("utf-8", errors="replace")
         return str(value)
 
-    def _normalize_timeout(self, timeout: int) -> int:
+    def _normalize_timeout(self, timeout: Optional[int]) -> int:
+        maximum = max(1, int(self.settings.command_timeout))
+        if timeout is None:
+            return maximum
         try:
             value = int(timeout)
         except (TypeError, ValueError) as exc:
             raise ValueError("Test timeout must be an integer") from exc
-        maximum = max(1, int(self.settings.command_timeout))
         if value < 1 or value > maximum:
             raise ValueError(f"Test timeout must be between 1 and {maximum} seconds")
         return value


### PR DESCRIPTION
## Summary

Completes issue #3 and closes the remaining gap in the foundational test runner.

Changes:
- add `npm test` to the fixed runner allowlist
- execute all runners with `shell=False`
- support workspace-scoped working directories
- bound requested timeouts by `COMMAND_TIMEOUT`
- add runner-specific argument allowlists for pytest and npm/Jest
- preserve targeted pytest selectors through Executor (`nodeid`, `keyword`, `marker`, `cwd`)
- parse common Jest summaries and failures into the existing structured result format
- return a structured `runner_unavailable` result when an executable is missing
- mark the enclosing agent step as failed for failed, timed-out, or unavailable test runs
- keep stdout, stderr, summaries, and parsed failures available for run artifacts
- add focused safety, parsing, timeout, workspace, and Executor tests
- document the complete test runner contract

Validation targets:
- complete pytest suite
- package validation
- dependency audit
- wheel/source build

Closes #3 when merged.