### PR TITLE
Enforce non-bypassable validated dry-run execution

### DIFF
--- a/docs/DRY_RUN.md
+++ b/docs/DRY_RUN.md
@@ -1,0 +1,83 @@
+# Dry-run execution mode
+
+Velocity Claw dry-run mode validates a plan without applying mutating actions.
+
+## Enablement
+
+Set:
+
+```text
+VELOCITY_CLAW_DRY_RUN=true
+```
+
+or pass `dry_run=true` in a tool step.
+
+The global setting is authoritative. When `DRY_RUN=true`, a step cannot disable it with `dry_run=false`.
+
+## Simulated actions
+
+The following actions are validated but not applied:
+
+- `fs.write`
+- `fs.append`
+- `fs.replace`
+- `patch.apply`
+- `test.run`
+- `shell.run`
+- `git.run`
+- `http.post`
+
+Read-only operations such as filesystem reads, code navigation, analysis, patch preview, git inspection, and HTTP GET may still run when their profile and runtime policies allow them.
+
+## Validation remains active
+
+Dry-run is not a policy bypass. Before returning `status=simulated`, Velocity Claw still applies:
+
+- execution-profile allow/approval/deny rules;
+- `SHELL_ENABLED` and `GIT_ENABLED` runtime gates;
+- workspace path validation;
+- file-size validation;
+- replacement-target validation;
+- patch safety and ambiguity checks;
+- shell and git command allowlists;
+- working-directory validation;
+- URL and host allowlist validation;
+- test runner, argument, timeout, and workspace validation.
+
+A denied or invalid action returns a failed step instead of a simulated success.
+
+## Simulation result
+
+Simulated actions return structured metadata including:
+
+- `status: simulated`
+- `dry_run: true`
+- `validated: true`
+- action/tool name
+- path, command, URL, or test command as applicable
+- expected size or diff information when available
+
+The enclosing agent step remains successful and is marked `simulated=true`. This lets later inspection steps continue while preserving the distinction between actual and simulated execution.
+
+## Reports and forensics
+
+Stored run reports include `dry_run_overview` with:
+
+- whether the run contains simulations;
+- number of simulated actions;
+- simulated step IDs, tools, paths, and commands;
+- validation state and attempt metadata.
+
+Run forensics include the same actions under `dry_run`. The executive summary explicitly states how many actions were simulated and that the listed mutations were not applied.
+
+## Safety examples
+
+A dry-run filesystem write outside `WORKSPACE_ROOT` is rejected.
+
+A dry-run replacement whose old text is absent is rejected.
+
+A dry-run shell or git command remains blocked when its runtime capability is disabled.
+
+A dry-run HTTP POST validates the destination but sends no request.
+
+A dry-run patch returns its unified diff while leaving the file unchanged.

--- a/tests/test_dry_run_enforcement_v2.py
+++ b/tests/test_dry_run_enforcement_v2.py
@@ -1,0 +1,245 @@
+import asyncio
+from pathlib import Path
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.executor.executor import Executor
+from velocity_claw.memory import MemoryStore
+
+
+class DummyRouter:
+    async def route(self, task_type, prompt):
+        return {"text": "ok"}
+
+
+def make_executor(
+    tmp_path: Path,
+    *,
+    dry_run: bool = True,
+    shell_enabled: bool = False,
+    git_enabled: bool = False,
+    max_file_size: int = 1024,
+):
+    settings = Settings(
+        env="test",
+        workspace_root=str(tmp_path),
+        dry_run=dry_run,
+        shell_enabled=shell_enabled,
+        git_enabled=git_enabled,
+        max_file_size=max_file_size,
+        allowed_hosts=["api.github.com"],
+    )
+    return Executor(DummyRouter(), settings=settings)
+
+
+def run_step(executor, tool, args):
+    return asyncio.run(
+        executor.execute_step(
+            {"id": 1, "title": f"Run {tool}", "tool": tool, "args": args},
+            {},
+        )
+    )
+
+
+def test_global_dry_run_cannot_be_disabled_by_step_argument(tmp_path: Path):
+    executor = make_executor(tmp_path, dry_run=True)
+    target = tmp_path / "created.txt"
+
+    result = run_step(
+        executor,
+        "fs.write",
+        {"path": "created.txt", "content": "hello", "dry_run": False},
+    )
+
+    assert result["status"] == "success"
+    assert result["simulated"] is True
+    assert result["result"]["status"] == "simulated"
+    assert result["result"]["validated"] is True
+    assert result["result"]["action"] == "fs.write"
+    assert result["result"]["bytes_after"] == 5
+    assert not target.exists()
+
+
+def test_step_can_enable_dry_run_when_global_setting_is_false(tmp_path: Path):
+    executor = make_executor(tmp_path, dry_run=False)
+
+    result = run_step(
+        executor,
+        "fs.write",
+        {"path": "step-dry.txt", "content": "safe", "dry_run": True},
+    )
+
+    assert result["simulated"] is True
+    assert not (tmp_path / "step-dry.txt").exists()
+
+
+def test_dry_run_keeps_workspace_and_size_validation_active(tmp_path: Path):
+    executor = make_executor(tmp_path, dry_run=True, max_file_size=4)
+
+    outside = run_step(
+        executor,
+        "fs.write",
+        {"path": "../outside.txt", "content": "x"},
+    )
+    oversized = run_step(
+        executor,
+        "fs.write",
+        {"path": "inside.txt", "content": "12345"},
+    )
+
+    assert outside["status"] == "failed"
+    assert "outside workspace" in outside["error"]
+    assert oversized["status"] == "failed"
+    assert "Content too large" in oversized["error"]
+    assert not (tmp_path / "inside.txt").exists()
+
+
+def test_dry_replace_validates_source_and_does_not_modify_file(tmp_path: Path):
+    target = tmp_path / "config.txt"
+    target.write_text("mode=old\n", encoding="utf-8")
+    executor = make_executor(tmp_path, dry_run=True)
+
+    simulated = run_step(
+        executor,
+        "fs.replace",
+        {"path": "config.txt", "old_string": "old", "new_string": "new"},
+    )
+    missing = run_step(
+        executor,
+        "fs.replace",
+        {"path": "config.txt", "old_string": "missing", "new_string": "new"},
+    )
+
+    assert simulated["simulated"] is True
+    assert simulated["result"]["would_change"] is True
+    assert target.read_text(encoding="utf-8") == "mode=old\n"
+    assert missing["status"] == "failed"
+    assert "Old string not found" in missing["error"]
+
+
+def test_shell_dry_run_validates_command_and_never_executes(tmp_path: Path):
+    executor = make_executor(tmp_path, dry_run=True, shell_enabled=True)
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("shell subprocess must not run")
+
+    executor.shell.run_command = fail_if_called
+    simulated = run_step(
+        executor,
+        "shell.run",
+        {"command": "pwd", "cwd": str(tmp_path)},
+    )
+    blocked = run_step(
+        executor,
+        "shell.run",
+        {"command": "rm -rf .", "cwd": str(tmp_path)},
+    )
+
+    assert simulated["simulated"] is True
+    assert simulated["result"]["argv"] == ["pwd"]
+    assert blocked["status"] == "failed"
+
+
+def test_disabled_shell_and_git_remain_disabled_in_dry_run(tmp_path: Path):
+    executor = make_executor(tmp_path, dry_run=True, shell_enabled=False, git_enabled=False)
+
+    shell_result = run_step(executor, "shell.run", {"command": "pwd"})
+    git_result = run_step(executor, "git.run", {"command": "git status"})
+
+    assert shell_result["status"] == "failed"
+    assert shell_result["error"] == "Shell execution is disabled"
+    assert git_result["status"] == "failed"
+    assert git_result["error"] == "Git operations disabled"
+
+
+def test_git_dry_run_validates_without_running_git(tmp_path: Path):
+    executor = make_executor(tmp_path, dry_run=True, git_enabled=True)
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("git subprocess must not run")
+
+    executor.git.run_git_command = fail_if_called
+    result = run_step(
+        executor,
+        "git.run",
+        {"command": "git status", "cwd": str(tmp_path)},
+    )
+
+    assert result["simulated"] is True
+    assert result["result"]["argv"] == ["git", "status"]
+
+
+def test_http_post_is_simulated_after_url_validation(tmp_path: Path):
+    executor = make_executor(tmp_path, dry_run=True)
+
+    class FailHTTP:
+        async def post(self, *args, **kwargs):
+            raise AssertionError("HTTP request must not be sent")
+
+    executor.http = FailHTTP()
+    result = run_step(
+        executor,
+        "http.post",
+        {"url": "https://api.github.com/repos", "data": {"value": 1}},
+    )
+
+    assert result["simulated"] is True
+    assert result["result"]["action"] == "http.post"
+    assert result["result"]["payload_present"] is True
+
+
+def test_patch_apply_dry_run_returns_diff_without_writing(tmp_path: Path):
+    target = tmp_path / "sample.py"
+    target.write_text("value = 'old'\n", encoding="utf-8")
+    executor = make_executor(tmp_path, dry_run=True)
+
+    result = run_step(
+        executor,
+        "patch.apply",
+        {
+            "patch": {
+                "op": "replace_block",
+                "path": "sample.py",
+                "target": "old",
+                "replacement": "new",
+            }
+        },
+    )
+
+    assert result["simulated"] is True
+    assert result["result"]["preview_only"] is True
+    assert result["result"]["changed"] is True
+    assert "-value = 'old'" in result["result"]["diff"]
+    assert target.read_text(encoding="utf-8") == "value = 'old'\n"
+
+
+def test_run_report_lists_simulated_actions(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("VELOCITY_CLAW_ENV", "test")
+    monkeypatch.setenv("VELOCITY_CLAW_MEMORY_DB_PATH", str(tmp_path / "memory.db"))
+    memory = MemoryStore(Settings())
+    run_id = memory.create_run("Dry-run report")
+    memory.save_step(
+        run_id,
+        {
+            "id": 1,
+            "title": "Simulate write",
+            "tool": "fs.write",
+            "args": {"path": "file.txt"},
+            "status": "success",
+            "result": {
+                "status": "simulated",
+                "action": "fs.write",
+                "path": "file.txt",
+                "validated": True,
+            },
+            "error": None,
+        },
+    )
+    memory.update_run_status(run_id, "completed")
+
+    run = memory.load_run(run_id)
+
+    assert run["report"]["dry_run_overview"]["enabled_for_run"] is True
+    assert run["report"]["dry_run_overview"]["simulated_count"] == 1
+    assert run["report"]["dry_run_overview"]["simulated_steps"][0]["action"] == "fs.write"
+    assert "Dry-run simulated 1 action" in run["report"]["executive_summary"]
+    assert run["forensics"]["dry_run"]["simulated_count"] == 1

--- a/velocity_claw/executor/executor.py
+++ b/velocity_claw/executor/executor.py
@@ -1,4 +1,6 @@
+from pathlib import Path
 from typing import Dict, List
+
 from velocity_claw.models.router import ModelRouter
 from velocity_claw.logs.logger import get_logger
 from velocity_claw.tools.fs import FileSystemTool
@@ -75,31 +77,103 @@ class Executor:
                         "result": result,
                         "error": f"test_run_{runner_status or 'failed'}",
                     }
-            return {**base_result, "status": "success", "result": result, "error": None}
+            simulated = isinstance(result, dict) and result.get("status") == "simulated"
+            if simulated:
+                self.logger.info("Dry-run simulated step %s with tool %s", step_id, tool)
+            return {
+                **base_result,
+                "status": "success",
+                "result": result,
+                "error": None,
+                "simulated": simulated,
+            }
         except Exception as e:
             self.logger.error("Step %s failed: %s", step_id, e)
-            return {**base_result, "status": "failed", "result": None, "error": str(e)}
+            return {**base_result, "status": "failed", "result": None, "error": str(e), "simulated": False}
+
+    def _dry_run_enabled(self, args: Dict) -> bool:
+        return bool(self.settings.dry_run or args.get("dry_run") is True)
+
+    def _display_path(self, resolved: Path) -> str:
+        try:
+            return str(resolved.relative_to(self.fs.workspace_root)) or "."
+        except ValueError:
+            return str(resolved)
+
+    def _validate_content_size(self, content: str) -> int:
+        encoded_size = len(str(content).encode("utf-8"))
+        if encoded_size > self.settings.max_file_size:
+            raise ValueError(f"Content too large: {encoded_size}")
+        return encoded_size
+
+    def _simulate_file_action(self, tool: str, args: Dict) -> dict:
+        resolved = self.fs._validate_path(args["path"])
+        before_size = resolved.stat().st_size if resolved.exists() else 0
+
+        if tool == "fs.write":
+            after_size = self._validate_content_size(args["content"])
+        elif tool == "fs.append":
+            append_size = self._validate_content_size(args["content"])
+            after_size = before_size + append_size
+            if after_size > self.settings.max_file_size:
+                raise ValueError("File would exceed size limit")
+        elif tool == "fs.replace":
+            current = self.fs.read(args["path"])
+            old_string = args["old_string"]
+            if old_string not in current:
+                raise ValueError(f"Old string not found in {args['path']}")
+            updated = current.replace(old_string, args["new_string"], 1)
+            after_size = self._validate_content_size(updated)
+        else:
+            raise ValueError(f"Unsupported dry-run file action: {tool}")
+
+        return {
+            "status": "simulated",
+            "dry_run": True,
+            "validated": True,
+            "action": tool,
+            "path": self._display_path(resolved),
+            "exists": resolved.exists(),
+            "bytes_before": before_size,
+            "bytes_after": after_size,
+            "would_change": before_size != after_size or tool == "fs.replace",
+        }
+
+    @staticmethod
+    def _simulated_action(tool: str, **details) -> dict:
+        return {
+            "status": "simulated",
+            "dry_run": True,
+            "validated": True,
+            "action": tool,
+            **details,
+        }
 
     async def _execute_tool(self, tool: str, args: Dict, profile: AccessProfile):
-        dry_run = bool(args.get("dry_run", self.settings.dry_run))
+        dry_run = self._dry_run_enabled(args)
         if tool == "fs.read":
             return self.fs.read(args["path"])
-        if tool == "fs.write":
+        if tool in {"fs.write", "fs.append", "fs.replace"}:
             if dry_run:
-                return {"status": "simulated", "path": args["path"]}
-            return self.fs.write(args["path"], args["content"])
-        if tool == "fs.append":
-            if dry_run:
-                return {"status": "simulated", "path": args["path"]}
-            return self.fs.append(args["path"], args["content"])
-        if tool == "fs.replace":
-            if dry_run:
-                return {"status": "simulated", "path": args["path"]}
+                return self._simulate_file_action(tool, args)
+            if tool == "fs.write":
+                return self.fs.write(args["path"], args["content"])
+            if tool == "fs.append":
+                return self.fs.append(args["path"], args["content"])
             return self.fs.replace(args["path"], args["old_string"], args["new_string"])
         if tool == "patch.preview":
             return self.patch.preview(args["patch"])
         if tool == "patch.apply":
-            return self.patch.apply(args["patch"], dry_run=dry_run)
+            result = self.patch.apply(args["patch"], dry_run=dry_run)
+            if dry_run:
+                return {
+                    "status": "simulated",
+                    "dry_run": True,
+                    "validated": True,
+                    "action": tool,
+                    **result,
+                }
+            return result
         if tool == "code.find_symbol":
             return self.code_nav.find_symbol(args["name"], args.get("kind"))
         if tool == "code.read_symbol":
@@ -120,21 +194,45 @@ class Executor:
             )
         if tool == "shell.run":
             self.security.validate_command(args["command"], profile)
+            if not self.settings.shell_enabled:
+                raise RuntimeError("Shell execution is disabled")
             if dry_run:
-                return {"status": "simulated", "command": args["command"]}
+                argv = self.shell.validate_command(args["command"])
+                cwd = self.shell.validate_cwd(args.get("cwd"))
+                return self._simulated_action(
+                    tool,
+                    command=args["command"],
+                    argv=argv,
+                    cwd=str(cwd),
+                )
             return self.shell.run_command(args["command"], args.get("cwd"), timeout=self.settings.command_timeout)
         if tool == "git.inspect":
             return self.git.inspect_repo(args.get("cwd"), timeout=args.get("timeout", self.settings.command_timeout))
         if tool == "git.run":
             self.security.validate_git_command(args["command"], profile)
+            if not self.settings.git_enabled:
+                raise RuntimeError("Git operations disabled")
             if dry_run:
-                return {"status": "simulated", "command": args["command"]}
+                argv = self.git.validate_git_command(args["command"])
+                cwd = self.git.validate_repo_root(args.get("cwd"))
+                return self._simulated_action(
+                    tool,
+                    command=args["command"],
+                    argv=argv,
+                    cwd=str(cwd),
+                )
             return self.git.run_git_command(args["command"], args.get("cwd"), timeout=self.settings.command_timeout)
         if tool == "http.get":
             self.security.validate_url(args["url"], profile)
             return await self.http.get(args["url"], headers=args.get("headers"), params=args.get("params"))
         if tool == "http.post":
             self.security.validate_url(args["url"], profile)
+            if dry_run:
+                return self._simulated_action(
+                    tool,
+                    url=args["url"],
+                    payload_present=bool(args.get("data")),
+                )
             return await self.http.post(args["url"], args.get("data", {}), headers=args.get("headers"))
         if tool == "analysis":
             response = await self.router.route("analysis", args["prompt"])
@@ -142,5 +240,8 @@ class Executor:
         raise ValueError(f"Unknown tool: {tool}")
 
     def _extract_summary(self, results: List[Dict]) -> str:
-        success = [r for r in results if r["status"] == "success"]
-        return f"Выполнено {len(success)} из {len(results)} шагов." if results else "Нет шагов."
+        success = [result for result in results if result["status"] == "success"]
+        simulated = [result for result in results if result.get("simulated")]
+        if not results:
+            return "Нет шагов."
+        return f"Выполнено {len(success)} из {len(results)} шагов; симулировано {len(simulated)}."

--- a/velocity_claw/memory/__init__.py
+++ b/velocity_claw/memory/__init__.py
@@ -1,10 +1,12 @@
 """Velocity Claw memory package."""
 
+from velocity_claw.memory.dry_run_reporting import install_dry_run_reporting
 from velocity_claw.memory.run_profile_schema import install_run_profile_schema
 from velocity_claw.memory.step_attempts_v2 import install_step_attempts_v2
 from velocity_claw.memory.store import MemoryStore
 
 install_run_profile_schema(MemoryStore)
 install_step_attempts_v2(MemoryStore)
+install_dry_run_reporting(MemoryStore)
 
 __all__ = ["MemoryStore"]

--- a/velocity_claw/memory/dry_run_reporting.py
+++ b/velocity_claw/memory/dry_run_reporting.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any
+
+from velocity_claw.memory.step_attempts_v2 import effective_steps
+
+
+def _simulation_items(run: dict[str, Any]) -> list[dict[str, Any]]:
+    items = []
+    for step in effective_steps(run.get("steps") or []):
+        result = step.get("result")
+        simulated = bool(step.get("simulated")) or (
+            isinstance(result, dict) and result.get("status") == "simulated"
+        )
+        if not simulated:
+            continue
+        items.append(
+            {
+                "id": step.get("id"),
+                "title": step.get("title"),
+                "tool": step.get("tool"),
+                "action": result.get("action") if isinstance(result, dict) else step.get("tool"),
+                "path": result.get("path") if isinstance(result, dict) else None,
+                "command": result.get("command") if isinstance(result, dict) else None,
+                "validated": result.get("validated") if isinstance(result, dict) else None,
+                "attempt_no": step.get("attempt_no", 1),
+                "phase": step.get("phase", "initial"),
+            }
+        )
+    return items
+
+
+def install_dry_run_reporting(memory_cls: type) -> None:
+    if getattr(memory_cls, "_dry_run_reporting_installed", False):
+        return
+
+    original_forensics = memory_cls.build_run_forensics
+    original_report = memory_cls.build_run_report
+
+    def build_run_forensics(self, run: dict[str, Any]) -> dict[str, Any]:
+        payload = original_forensics(self, run)
+        simulations = _simulation_items(run)
+        payload["dry_run"] = {
+            "simulated_count": len(simulations),
+            "simulated_steps": simulations,
+        }
+        return payload
+
+    def build_run_report(self, run: dict[str, Any]) -> dict[str, Any]:
+        payload = original_report(self, run)
+        simulations = _simulation_items(run)
+        payload["dry_run_overview"] = {
+            "enabled_for_run": bool(simulations),
+            "simulated_count": len(simulations),
+            "simulated_steps": simulations,
+        }
+        if simulations and payload.get("executive_summary"):
+            payload["executive_summary"] += (
+                f" Dry-run simulated {len(simulations)} action(s); no listed mutation was applied."
+            )
+        return payload
+
+    memory_cls.build_run_forensics = build_run_forensics
+    memory_cls.build_run_report = build_run_report
+    memory_cls._dry_run_reporting_installed = True


### PR DESCRIPTION
## Summary

Completes issue #5 by making dry-run a validated safety mode rather than an early-return shortcut.

Changes:
- make global `DRY_RUN=true` authoritative so a step cannot disable it
- keep workspace, size, replacement, command, cwd, git, URL, and runtime-capability validation active
- simulate filesystem write/append/replace without changing files
- return patch diffs without applying them
- prevent shell and git subprocess execution while preserving allowlist validation
- keep disabled `SHELL_ENABLED` and `GIT_ENABLED` blocked during dry-run
- simulate HTTP POST after destination validation
- keep test runner command/timeout/workspace validation active
- mark simulated agent steps explicitly
- include simulated action counts and details in stored run reports and forensics
- add focused filesystem, shell, git, HTTP, patch, global-setting, and report tests
- document exact dry-run behavior

Validation targets:
- complete pytest suite
- package validation
- dependency audit
- wheel/source build

Closes #5 when merged.