### PR TITLE
Add unified diff previews to dry-run file actions

### DIFF
--- a/docs/DIFF_PREVIEW.md
+++ b/docs/DIFF_PREVIEW.md
@@ -18,6 +18,8 @@ Direct filesystem actions return a structured result containing:
 - unified diff;
 - byte counts before and after the modification.
 
+Dry-run mode returns the same before/after unified diff with `status: simulated` and does not create or modify the target file. This allows approval and inspection workflows to review the exact proposed text change before execution.
+
 A no-op write returns `changed: false` and an empty diff.
 
 When a step result contains a non-empty `diff`, the agent stores it as a run artifact with:

--- a/tests/test_dry_run_file_diff_preview.py
+++ b/tests/test_dry_run_file_diff_preview.py
@@ -1,0 +1,80 @@
+from types import SimpleNamespace
+
+import pytest
+
+from velocity_claw.executor.executor import Executor
+from velocity_claw.tools.fs import FileSystemTool
+
+
+def build_executor_surface(tmp_path, max_file_size=1024 * 1024):
+    settings = SimpleNamespace(
+        workspace_root=str(tmp_path),
+        max_file_size=max_file_size,
+    )
+    return SimpleNamespace(
+        settings=settings,
+        fs=FileSystemTool(settings),
+    )
+
+
+def simulate(surface, tool, args):
+    return Executor._simulate_file_action(surface, tool, args)
+
+
+def test_dry_run_write_returns_diff_without_creating_file(tmp_path):
+    surface = build_executor_surface(tmp_path)
+
+    result = simulate(surface, "fs.write", {"path": "new.txt", "content": "hello\n"})
+
+    assert result["status"] == "simulated"
+    assert result["dry_run"] is True
+    assert result["changed"] is True
+    assert result["exists"] is False
+    assert "+hello" in result["diff"]
+    assert not (tmp_path / "new.txt").exists()
+
+
+def test_dry_run_append_and_replace_do_not_modify_existing_file(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("one\n", encoding="utf-8")
+    surface = build_executor_surface(tmp_path)
+
+    appended = simulate(surface, "fs.append", {"path": "sample.txt", "content": "two\n"})
+    replaced = simulate(
+        surface,
+        "fs.replace",
+        {"path": "sample.txt", "old_string": "one", "new_string": "first"},
+    )
+
+    assert "+two" in appended["diff"]
+    assert "-one" in replaced["diff"]
+    assert "+first" in replaced["diff"]
+    assert target.read_text(encoding="utf-8") == "one\n"
+
+
+def test_dry_run_no_op_write_has_empty_diff(tmp_path):
+    target = tmp_path / "same.txt"
+    target.write_text("same\n", encoding="utf-8")
+    surface = build_executor_surface(tmp_path)
+
+    result = simulate(surface, "fs.write", {"path": "same.txt", "content": "same\n"})
+
+    assert result["changed"] is False
+    assert result["diff"] == ""
+    assert result["bytes_before"] == result["bytes_after"]
+
+
+def test_dry_run_replace_preserves_validation(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("one\n", encoding="utf-8")
+    surface = build_executor_surface(tmp_path, max_file_size=5)
+
+    with pytest.raises(ValueError, match="Old string not found"):
+        simulate(
+            surface,
+            "fs.replace",
+            {"path": "sample.txt", "old_string": "missing", "new_string": "x"},
+        )
+
+    with pytest.raises(ValueError, match="Content too large"):
+        simulate(surface, "fs.append", {"path": "sample.txt", "content": "extra"})

--- a/velocity_claw/executor/__init__.py
+++ b/velocity_claw/executor/__init__.py
@@ -1,1 +1,54 @@
-"""Velocity Claw executor package."""
+"""Velocity Claw executor package.
+
+The package installs small compatibility extensions around the public Executor
+class while keeping the main implementation module stable.
+"""
+
+from velocity_claw.executor.executor import Executor
+
+
+def _install_dry_run_file_diff_preview(executor_cls: type) -> None:
+    if getattr(executor_cls, "_dry_run_file_diff_preview_installed", False):
+        return
+
+    def _simulate_file_action(self, tool: str, args: dict) -> dict:
+        resolved = self.fs._validate_path(args["path"])
+        before = self.fs._read_existing(resolved)
+
+        if tool == "fs.write":
+            after = str(args.get("content", ""))
+        elif tool == "fs.append":
+            after = before + str(args.get("content", ""))
+        elif tool == "fs.replace":
+            old_string = str(args.get("old_string", ""))
+            if old_string not in before:
+                raise ValueError(f"Old string not found in {args['path']}")
+            after = before.replace(old_string, str(args.get("new_string", "")), 1)
+        else:
+            raise ValueError(f"Unsupported dry-run file action: {tool}")
+
+        encoded_size = len(after.encode("utf-8"))
+        if encoded_size > self.settings.max_file_size:
+            raise ValueError(f"Content too large: {encoded_size}")
+
+        display_path = self.fs._display_path(resolved)
+        return {
+            "status": "simulated",
+            "dry_run": True,
+            "validated": True,
+            "action": tool,
+            "path": display_path,
+            "exists": resolved.exists(),
+            "changed": before != after,
+            "diff": self.fs._make_diff(display_path, before, after),
+            "bytes_before": len(before.encode("utf-8")),
+            "bytes_after": encoded_size,
+        }
+
+    executor_cls._simulate_file_action = _simulate_file_action
+    executor_cls._dry_run_file_diff_preview_installed = True
+
+
+_install_dry_run_file_diff_preview(Executor)
+
+__all__ = ["Executor"]


### PR DESCRIPTION
## Summary

Follow-up to merged PR #129.

Changes:
- generate the exact unified diff for dry-run `fs.write`, `fs.append`, and `fs.replace`
- return the same path, changed flag, and before/after byte counts as real file modifications
- keep dry-run side-effect free: target files are never created or modified
- preserve workspace, replacement-target, binary-file, and maximum-size validation
- report no-op previews with `changed: false` and an empty diff
- install the compatibility extension at the executor package boundary without changing the stable main executor module
- add focused write, append, replace, no-op, and validation tests
- document approval/inspection use of dry-run diffs

Validation targets:
- complete pytest suite
- package validation
- dependency audit
- wheel/source build