### PR TITLE
refactor: finish filesystem and executor audit cleanup

### DIFF
--- a/velocity_claw/executor/__init__.py
+++ b/velocity_claw/executor/__init__.py
@@ -12,8 +12,8 @@ def _install_dry_run_file_diff_preview(executor_cls: type) -> None:
         return
 
     def _simulate_file_action(self, tool: str, args: dict) -> dict:
-        resolved = self.fs._validate_path(args["path"])
-        before = self.fs._read_existing(resolved)
+        resolved = self.fs.validate_path(args["path"])
+        before = self.fs.read_existing(resolved)
 
         if tool == "fs.write":
             after = str(args.get("content", ""))
@@ -31,7 +31,7 @@ def _install_dry_run_file_diff_preview(executor_cls: type) -> None:
         if encoded_size > self.settings.max_file_size:
             raise ValueError(f"Content too large: {encoded_size}")
 
-        display_path = self.fs._display_path(resolved)
+        display_path = self.fs.display_path(resolved)
         return {
             "status": "simulated",
             "dry_run": True,
@@ -40,7 +40,7 @@ def _install_dry_run_file_diff_preview(executor_cls: type) -> None:
             "path": display_path,
             "exists": resolved.exists(),
             "changed": before != after,
-            "diff": self.fs._make_diff(display_path, before, after),
+            "diff": self.fs.make_diff(display_path, before, after),
             "bytes_before": len(before.encode("utf-8")),
             "bytes_after": encoded_size,
         }

--- a/velocity_claw/executor/executor.py
+++ b/velocity_claw/executor/executor.py
@@ -59,12 +59,7 @@ class Executor:
         tool = step.get("tool")
         args = step.get("args", {})
         self.logger.info("Executing step %s: %s", step_id, title)
-        base_result = {
-            "id": step_id,
-            "title": title,
-            "tool": tool,
-            "args": args,
-        }
+        base_result = {"id": step_id, "title": title, "tool": tool, "args": args}
         try:
             profile = self._get_profile(tool)
             result = await self._execute_tool(tool, args, profile)
@@ -87,9 +82,9 @@ class Executor:
                 "error": None,
                 "simulated": simulated,
             }
-        except Exception as e:
-            self.logger.error("Step %s failed: %s", step_id, e)
-            return {**base_result, "status": "failed", "result": None, "error": str(e), "simulated": False}
+        except Exception as exc:
+            self.logger.exception("Step %s failed: %s", step_id, exc)
+            return {**base_result, "status": "failed", "result": None, "error": str(exc), "simulated": False}
 
     def _dry_run_enabled(self, args: Dict) -> bool:
         return bool(self.settings.dry_run or args.get("dry_run") is True)
@@ -107,7 +102,7 @@ class Executor:
         return encoded_size
 
     def _simulate_file_action(self, tool: str, args: Dict) -> dict:
-        resolved = self.fs._validate_path(args["path"])
+        resolved = self.fs.validate_path(args["path"])
         before_size = resolved.stat().st_size if resolved.exists() else 0
 
         if tool == "fs.write":
@@ -166,39 +161,20 @@ class Executor:
         if tool == "patch.apply":
             result = self.patch.apply(args["patch"], dry_run=dry_run)
             if dry_run:
-                return {
-                    "status": "simulated",
-                    "dry_run": True,
-                    "validated": True,
-                    "action": tool,
-                    **result,
-                }
+                return {"status": "simulated", "dry_run": True, "validated": True, "action": tool, **result}
             return result
         if tool == "code.find_symbol":
             return self.code_nav.find_symbol(args["name"], args.get("kind"))
         if tool == "code.read_symbol":
             return self.code_nav.read_symbol(args["path"], args["name"], args["kind"])
         if tool == "code.read_lines":
-            return self.code_nav.read_lines(
-                args["path"],
-                args["start_line"],
-                args["end_line"],
-                args.get("context_lines", 0),
-            )
+            return self.code_nav.read_lines(args["path"], args["start_line"], args["end_line"], args.get("context_lines", 0))
         if tool == "code.list_imports":
             return self.code_nav.list_imports(args["path"])
         if tool == "code.find_references":
-            return self.code_nav.find_references(
-                args["name"],
-                path=args.get("path"),
-                limit=args.get("limit", 200),
-            )
+            return self.code_nav.find_references(args["name"], path=args.get("path"), limit=args.get("limit", 200))
         if tool == "code.find_routes":
-            return self.code_nav.find_routes(
-                path=args.get("path"),
-                route=args.get("route"),
-                method=args.get("method"),
-            )
+            return self.code_nav.find_routes(path=args.get("path"), route=args.get("route"), method=args.get("method"))
         if tool == "test.run":
             return self.test_runner.run(
                 args["runner"],
@@ -218,12 +194,7 @@ class Executor:
             if dry_run:
                 argv = self.shell.validate_command(args["command"])
                 cwd = self.shell.validate_cwd(args.get("cwd"))
-                return self._simulated_action(
-                    tool,
-                    command=args["command"],
-                    argv=argv,
-                    cwd=str(cwd),
-                )
+                return self._simulated_action(tool, command=args["command"], argv=argv, cwd=str(cwd))
             return self.shell.run_command(args["command"], args.get("cwd"), timeout=self.settings.command_timeout)
         if tool == "git.inspect":
             return self.git.inspect_repo(args.get("cwd"), timeout=args.get("timeout", self.settings.command_timeout))
@@ -234,12 +205,7 @@ class Executor:
             if dry_run:
                 argv = self.git.validate_git_command(args["command"])
                 cwd = self.git.validate_repo_root(args.get("cwd"))
-                return self._simulated_action(
-                    tool,
-                    command=args["command"],
-                    argv=argv,
-                    cwd=str(cwd),
-                )
+                return self._simulated_action(tool, command=args["command"], argv=argv, cwd=str(cwd))
             return self.git.run_git_command(args["command"], args.get("cwd"), timeout=self.settings.command_timeout)
         if tool == "http.get":
             self.security.validate_url(args["url"], profile)
@@ -247,11 +213,7 @@ class Executor:
         if tool == "http.post":
             self.security.validate_url(args["url"], profile)
             if dry_run:
-                return self._simulated_action(
-                    tool,
-                    url=args["url"],
-                    payload_present=bool(args.get("data")),
-                )
+                return self._simulated_action(tool, url=args["url"], payload_present=bool(args.get("data")))
             return await self.http.post(args["url"], args.get("data", {}), headers=args.get("headers"))
         if tool == "analysis":
             response = await self.router.route("analysis", args["prompt"])

--- a/velocity_claw/tools/fs.py
+++ b/velocity_claw/tools/fs.py
@@ -4,6 +4,7 @@ import os
 import re
 from pathlib import Path
 from typing import List, Optional
+
 from velocity_claw.config.settings import Settings
 
 
@@ -12,42 +13,53 @@ class FileSystemTool:
         self.settings = settings
         self.workspace_root = Path(settings.workspace_root).resolve()
 
-    def _validate_path(self, path: str) -> Path:
-        """Validate and resolve path within workspace."""
+    def validate_path(self, path: str) -> Path:
+        """Validate and resolve a path within the configured workspace."""
         raw = Path(path)
         candidate = raw if raw.is_absolute() else (self.workspace_root / raw)
         try:
             resolved = candidate.resolve()
-        except (OSError, ValueError) as e:
-            raise ValueError(f"Invalid path: {e}")
+        except (OSError, ValueError) as exc:
+            raise ValueError(f"Invalid path: {exc}") from exc
 
         if not resolved.is_relative_to(self.workspace_root):
             raise ValueError(f"Path outside workspace: {resolved}")
-
         return resolved
+
+    def _validate_path(self, path: str) -> Path:
+        return self.validate_path(path)
 
     def _check_file_size(self, path: Path) -> None:
         if path.exists() and path.stat().st_size > self.settings.max_file_size:
             raise ValueError(f"File too large: {path.stat().st_size} > {self.settings.max_file_size}")
 
-    def _read_existing(self, resolved: Path) -> str:
+    def read_existing(self, resolved: Path) -> str:
+        """Read an existing UTF-8 file, returning an empty string when absent."""
         if not resolved.exists():
             return ""
         self._check_file_size(resolved)
         try:
             with open(resolved, "r", encoding="utf-8") as handle:
                 return handle.read()
-        except UnicodeDecodeError:
-            raise ValueError(f"Binary file detected: {resolved}")
+        except UnicodeDecodeError as exc:
+            raise ValueError(f"Binary file detected: {resolved}") from exc
 
-    def _display_path(self, resolved: Path) -> str:
+    def _read_existing(self, resolved: Path) -> str:
+        return self.read_existing(resolved)
+
+    def display_path(self, resolved: Path) -> str:
+        """Return a workspace-relative display path when possible."""
         try:
             return str(resolved.relative_to(self.workspace_root))
         except ValueError:
             return str(resolved)
 
+    def _display_path(self, resolved: Path) -> str:
+        return self.display_path(resolved)
+
     @staticmethod
-    def _make_diff(path: str, before: str, after: str) -> str:
+    def make_diff(path: str, before: str, after: str) -> str:
+        """Build a unified diff for a proposed file change."""
         return "".join(
             difflib.unified_diff(
                 before.splitlines(keepends=True),
@@ -57,13 +69,17 @@ class FileSystemTool:
             )
         )
 
+    @staticmethod
+    def _make_diff(path: str, before: str, after: str) -> str:
+        return FileSystemTool.make_diff(path, before, after)
+
     def _write_with_diff(self, path: str, before: str, after: str, action: str) -> dict:
-        resolved = self._validate_path(path)
+        resolved = self.validate_path(path)
         encoded_size = len(after.encode("utf-8"))
         if encoded_size > self.settings.max_file_size:
             raise ValueError(f"Content too large: {encoded_size}")
-        display_path = self._display_path(resolved)
-        diff = self._make_diff(display_path, before, after)
+        display_path = self.display_path(resolved)
+        diff = self.make_diff(display_path, before, after)
         changed = before != after
         if changed:
             resolved.parent.mkdir(parents=True, exist_ok=True)
@@ -80,7 +96,7 @@ class FileSystemTool:
         }
 
     def read(self, path: str) -> str:
-        resolved = self._validate_path(path)
+        resolved = self.validate_path(path)
         self._check_file_size(resolved)
         try:
             with open(resolved, "r", encoding="utf-8") as handle:
@@ -88,32 +104,32 @@ class FileSystemTool:
                 if len(content.encode("utf-8")) > self.settings.max_file_size:
                     raise ValueError(f"Content too large: {len(content)}")
                 return content
-        except UnicodeDecodeError:
-            raise ValueError(f"Binary file detected: {resolved}")
+        except UnicodeDecodeError as exc:
+            raise ValueError(f"Binary file detected: {resolved}") from exc
 
     def write(self, path: str, content: str) -> dict:
-        resolved = self._validate_path(path)
-        before = self._read_existing(resolved)
+        resolved = self.validate_path(path)
+        before = self.read_existing(resolved)
         return self._write_with_diff(path, before, content, "fs.write")
 
     def append(self, path: str, content: str) -> dict:
-        resolved = self._validate_path(path)
-        before = self._read_existing(resolved)
+        resolved = self.validate_path(path)
+        before = self.read_existing(resolved)
         return self._write_with_diff(path, before, before + content, "fs.append")
 
     def replace(self, path: str, old_string: str, new_string: str) -> dict:
-        resolved = self._validate_path(path)
-        before = self._read_existing(resolved)
+        resolved = self.validate_path(path)
+        before = self.read_existing(resolved)
         if old_string not in before:
             raise ValueError(f"Old string not found in {path}")
         after = before.replace(old_string, new_string, 1)
         return self._write_with_diff(path, before, after, "fs.replace")
 
     def exists(self, path: str) -> bool:
-        return self._validate_path(path).exists()
+        return self.validate_path(path).exists()
 
     def search(self, root: str, pattern: str, extensions: Optional[List[str]] = None) -> List[str]:
-        root_resolved = self._validate_path(root)
+        root_resolved = self.validate_path(root)
         matches = []
         for base, _, files in os.walk(root_resolved):
             for name in files:
@@ -131,7 +147,7 @@ class FileSystemTool:
         return matches
 
     def list_dir(self, path: str) -> List[str]:
-        resolved = self._validate_path(path)
+        resolved = self.validate_path(path)
         if not resolved.is_dir():
             raise ValueError(f"Not a directory: {resolved}")
         return [str(p.relative_to(self.workspace_root)) for p in resolved.iterdir()]
@@ -139,8 +155,8 @@ class FileSystemTool:
     def to_json(self, path: str):
         try:
             return json.loads(self.read(path))
-        except json.JSONDecodeError as e:
-            raise ValueError(f"Invalid JSON: {e}")
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON: {exc}") from exc
 
     def write_json(self, path: str, data):
         json_str = json.dumps(data, indent=2, ensure_ascii=False)


### PR DESCRIPTION
Закрывает оставшиеся замечания аудита вокруг executor/filesystem:

- добавляет публичные методы `validate_path`, `read_existing`, `display_path`, `make_diff`;
- сохраняет приватные aliases для обратной совместимости;
- переводит executor dry-run preview на публичные методы;
- меняет `logger.error` на `logger.exception`, чтобы сохранять traceback;
- добавляет exception chaining для ошибок файловой системы и JSON.

Перед слиянием должны пройти CI, build-artifacts, dependency-audit и CodeQL.