### PR TITLE
fix: publish releases from an explicit commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,12 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Optional release tag; must match VERSION, for example v0.2.4"
-        required: false
-        default: ""
+        description: "Release tag; must match VERSION, for example v0.2.4"
+        required: true
+        type: string
+      target_sha:
+        description: "Exact commit SHA to publish"
+        required: true
         type: string
 
 permissions:
@@ -35,6 +38,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.target_sha || github.sha }}
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -64,7 +68,7 @@ jobs:
           set -euo pipefail
           pip-audit -r requirements.txt
 
-      - name: Resolve release tag
+      - name: Resolve release tag and target
         id: release
         env:
           MANUAL_TAG: ${{ inputs.tag }}
@@ -72,8 +76,9 @@ jobs:
           set -euo pipefail
           VERSION_VALUE="$(tr -d '[:space:]' < VERSION)"
           EXPECTED_TAG="v${VERSION_VALUE}"
+          TARGET_SHA="$(git rev-parse HEAD)"
 
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && -n "${MANUAL_TAG}" ]]; then
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
             REQUESTED_TAG="${MANUAL_TAG}"
           else
             REQUESTED_TAG="${EXPECTED_TAG}"
@@ -86,11 +91,13 @@ jobs:
 
           echo "version=${VERSION_VALUE}" >> "${GITHUB_OUTPUT}"
           echo "tag=${EXPECTED_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "target_sha=${TARGET_SHA}" >> "${GITHUB_OUTPUT}"
 
       - name: Inspect existing tag and release
         id: state
         env:
           TAG_VALUE: ${{ steps.release.outputs.tag }}
+          TARGET_SHA: ${{ steps.release.outputs.target_sha }}
         run: |
           set -euo pipefail
           git fetch --tags --force
@@ -106,11 +113,9 @@ jobs:
             RELEASE_EXISTS="false"
           fi
 
-          if [[ -n "${TAG_SHA}" && "${TAG_SHA}" != "${GITHUB_SHA}" ]]; then
-            if [[ "${RELEASE_EXISTS}" == "false" || "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-              echo "Tag ${TAG_VALUE} points to ${TAG_SHA}, but this run uses ${GITHUB_SHA}. Select the tag ref for a manual repair run." >&2
-              exit 1
-            fi
+          if [[ -n "${TAG_SHA}" && "${TAG_SHA}" != "${TARGET_SHA}" ]]; then
+            echo "Tag ${TAG_VALUE} points to ${TAG_SHA}, expected ${TARGET_SHA}" >&2
+            exit 1
           fi
 
           echo "tag_sha=${TAG_SHA}" >> "${GITHUB_OUTPUT}"
@@ -131,6 +136,7 @@ jobs:
         env:
           VERSION_VALUE: ${{ steps.release.outputs.version }}
           TAG_VALUE: ${{ steps.release.outputs.tag }}
+          TARGET_SHA: ${{ steps.release.outputs.target_sha }}
         run: |
           set -euo pipefail
           {
@@ -143,6 +149,7 @@ jobs:
             echo "- Dependency audit passed"
             echo "- Wheel and source distribution built"
             echo "- Release tag ${TAG_VALUE} matched VERSION"
+            echo "- Release target commit: ${TARGET_SHA}"
             echo
             echo "## Release docs"
             echo
@@ -158,6 +165,7 @@ jobs:
           RELEASE_EXISTS: ${{ steps.state.outputs.release_exists }}
           TAG_VALUE: ${{ steps.release.outputs.tag }}
           VERSION_VALUE: ${{ steps.release.outputs.version }}
+          TARGET_SHA: ${{ steps.release.outputs.target_sha }}
         run: |
           set -euo pipefail
 
@@ -179,7 +187,7 @@ jobs:
               dist/*.whl \
               dist/*.tar.gz \
               dist/release-summary.md \
-              --target "${GITHUB_SHA}" \
+              --target "${TARGET_SHA}" \
               --title "Velocity Claw ${VERSION_VALUE}" \
               --notes-file dist/release-notes.md
           fi
@@ -187,9 +195,13 @@ jobs:
       - name: Verify published release
         env:
           TAG_VALUE: ${{ steps.release.outputs.tag }}
+          TARGET_SHA: ${{ steps.release.outputs.target_sha }}
         run: |
           set -euo pipefail
           gh release view "${TAG_VALUE}" --json tagName,name,isDraft,isPrerelease
+          git fetch --tags --force
+          PUBLISHED_SHA="$(git rev-list -n 1 "${TAG_VALUE}")"
+          test "${PUBLISHED_SHA}" = "${TARGET_SHA}"
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Исправляет безопасный repair-flow для исторических релизов:

- ручной запуск требует `tag` и `target_sha`;
- checkout выполняется на указанном коммите;
- VERSION проверяется именно в историческом snapshot;
- существующий тег проверяется против target SHA;
- `gh release create` получает точный `--target`;
- после публикации workflow проверяет фактический SHA тега.

Это позволяет корректно выпустить `v0.2.4` на коммите `04ac2027706dd89138738395d82cdb3273527f29`, не помечая текущий master старой версией.