### PR TITLE
fix: export the canonical package version

### DIFF
--- a/velocity_claw/__init__.py
+++ b/velocity_claw/__init__.py
@@ -1,3 +1,5 @@
 """Velocity Claw core package."""
 
-__version__ = "0.1.0"
+from velocity_claw.__version__ import __product_name__, __release_stage__, __version__
+
+__all__ = ["__product_name__", "__release_stage__", "__version__"]


### PR DESCRIPTION
Исправляет рассинхронизацию версии пакета:

- `velocity_claw.__version__` больше не хранит устаревшее значение `0.1.0` в `__init__.py`;
- публичные поля версии, стадии релиза и имени продукта импортируются из единственного канонического модуля `velocity_claw.__version__`;
- исключается повторное расхождение при следующих релизах.

Текущее каноническое значение остаётся `0.2.4`.