### PR TITLE
test: cover exported package metadata

### DIFF
--- a/tests/test_package_version.py
+++ b/tests/test_package_version.py
@@ -1,11 +1,17 @@
 from pathlib import Path
 
 import velocity_claw
-from velocity_claw.__version__ import __version__ as canonical_version
+from velocity_claw.__version__ import (
+    __product_name__ as canonical_product_name,
+    __release_stage__ as canonical_release_stage,
+    __version__ as canonical_version,
+)
 
 
-def test_package_exports_canonical_version() -> None:
+def test_package_exports_canonical_metadata() -> None:
     assert velocity_claw.__version__ == canonical_version
+    assert velocity_claw.__release_stage__ == canonical_release_stage
+    assert velocity_claw.__product_name__ == canonical_product_name
 
 
 def test_version_file_matches_package_version() -> None:


### PR DESCRIPTION
Расширяет регрессионную проверку метаданных пакета:

- проверяет публичный `__version__`;
- проверяет публичные `__release_stage__` и `__product_name__`;
- сохраняет сверку файла `VERSION` с канонической версией.

Также этот PR прогонит CI для теста, который ранее по ошибке был добавлен напрямую в `master`.