### PR TITLE
refactor: isolate queue persistence boundary

### DIFF
--- a/tests/test_queue_persistence_boundary.py
+++ b/tests/test_queue_persistence_boundary.py
@@ -1,0 +1,20 @@
+from types import SimpleNamespace
+
+import pytest
+
+from velocity_claw.core.queue_persistence import persist_queue_job
+
+
+def test_persist_queue_job_delegates_to_queue_storage() -> None:
+    calls = []
+    job = SimpleNamespace(job_id="job-1")
+    queue = SimpleNamespace(_persist_job=lambda persisted: calls.append(persisted))
+
+    persist_queue_job(queue, job)
+
+    assert calls == [job]
+
+
+def test_persist_queue_job_rejects_missing_storage_boundary() -> None:
+    with pytest.raises(TypeError, match="persistence implementation"):
+        persist_queue_job(SimpleNamespace(), SimpleNamespace(job_id="job-1"))

--- a/velocity_claw/api/app.py
+++ b/velocity_claw/api/app.py
@@ -22,6 +22,7 @@ from velocity_claw.api.ops_console import build_operations_console
 from velocity_claw.api.run_detail_v2 import build_artifact_index, build_run_detail_v2
 from velocity_claw.api.server import ApprovalDecisionRequest, create_app as create_base_app
 from velocity_claw.api.version import build_version_payload
+from velocity_claw.core.queue_persistence import persist_queue_job
 
 
 def install_version_endpoint(app: FastAPI) -> None:
@@ -45,7 +46,7 @@ def _prepare_forced_retry(queue, job) -> None:
             "previous_attempts": previous_attempts,
         }
     )
-    queue._persist_job(job)
+    persist_queue_job(queue, job)
 
 
 def install_queue_persistence_v2(app: FastAPI) -> None:

--- a/velocity_claw/core/queue_persistence.py
+++ b/velocity_claw/core/queue_persistence.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def persist_queue_job(queue: Any, job: Any) -> None:
+    """Persist a queue job through the queue-owned persistence boundary.
+
+    This compatibility boundary keeps API modules from reaching into the
+    queue's protected implementation while the queue storage backend remains
+    internal to ``RunQueue``.
+    """
+    persist = getattr(queue, "_persist_job", None)
+    if persist is None or not callable(persist):
+        raise TypeError("Queue does not provide a persistence implementation")
+    persist(job)


### PR DESCRIPTION
Убирает прямой доступ API-слоя к защищённому методу `RunQueue._persist_job`.

Изменения:
- добавлен отдельный core-boundary `persist_queue_job`;
- `_prepare_forced_retry` больше не обращается к protected member напрямую;
- добавлены проверки делегирования и ошибки при отсутствии persistence implementation.

Это промежуточный шаг к полной инкапсуляции storage backend внутри `RunQueue` без изменения текущей схемы БД и поведения requeue.