### PR TITLE
refactor: expose approval attempt extension contract

### DIFF
--- a/tests/test_approval_attempts_v2.py
+++ b/tests/test_approval_attempts_v2.py
@@ -1,7 +1,12 @@
 import asyncio
 
 from velocity_claw.api import approval_v2
-from velocity_claw.api.approval_attempts_v2 import install_latest_step_lookup
+from velocity_claw.api.approval_attempts_v2 import (
+    INSTALLATION_FLAG,
+    LATEST_STEP_LOOKUP,
+    find_latest_step,
+    install_latest_step_lookup,
+)
 
 
 def run_with_attempts():
@@ -37,6 +42,24 @@ def run_with_attempts():
             {"step_id": 2, "decision": "requested"},
         ],
     }
+
+
+def test_find_latest_step_prefers_most_recent_attempt():
+    latest = find_latest_step(run_with_attempts(), 2)
+
+    assert latest["attempt_no"] == 2
+    assert latest["phase"] == "failed_resume"
+
+
+def test_installation_exposes_public_extension_state_and_is_idempotent():
+    install_latest_step_lookup(approval_v2)
+    installed_wrapper = approval_v2.approve_and_continue
+
+    install_latest_step_lookup(approval_v2)
+
+    assert getattr(approval_v2, INSTALLATION_FLAG) is True
+    assert getattr(approval_v2, LATEST_STEP_LOOKUP) is find_latest_step
+    assert approval_v2.approve_and_continue is installed_wrapper
 
 
 def test_approval_guard_uses_latest_attempt_for_retried_step():

--- a/velocity_claw/api/approval_attempts_v2.py
+++ b/velocity_claw/api/approval_attempts_v2.py
@@ -3,19 +3,25 @@ from __future__ import annotations
 from typing import Any
 
 
+INSTALLATION_FLAG = "latest_step_lookup_v2_installed"
+LATEST_STEP_LOOKUP = "find_latest_step"
+
+
+def find_latest_step(run: dict[str, Any], step_id: int) -> dict[str, Any] | None:
+    """Return the most recent attempt for a logical step id."""
+    for step in reversed(run.get("steps", [])):
+        if step.get("id") == step_id:
+            return step
+    return None
+
+
 def install_latest_step_lookup(approval_module: Any) -> None:
-    if getattr(approval_module, "_latest_step_lookup_v2_installed", False):
+    if getattr(approval_module, INSTALLATION_FLAG, False):
         return
 
     original_approve_and_continue = approval_module.approve_and_continue
 
-    def _find_step(run: dict[str, Any], step_id: int) -> dict[str, Any] | None:
-        for step in reversed(run.get("steps", [])):
-            if step.get("id") == step_id:
-                return step
-        return None
-
-    async def _approve_and_continue(
+    async def approve_and_continue_with_latest_step(
         agent: Any,
         run_id: str,
         step_id: int,
@@ -24,7 +30,7 @@ def install_latest_step_lookup(approval_module: Any) -> None:
         reason: str | None,
     ) -> dict[str, Any]:
         run = agent.memory.load_run(run_id)
-        latest = _find_step(run or {}, step_id)
+        latest = find_latest_step(run or {}, step_id)
         if latest and latest.get("phase") == "failed_resume":
             return await agent.approve_step(
                 run_id,
@@ -40,6 +46,8 @@ def install_latest_step_lookup(approval_module: Any) -> None:
             reason=reason,
         )
 
-    approval_module._find_step = _find_step
-    approval_module.approve_and_continue = _approve_and_continue
-    approval_module._latest_step_lookup_v2_installed = True
+    # approval_v2 currently resolves this helper from its module globals.
+    setattr(approval_module, "_find_step", find_latest_step)
+    setattr(approval_module, LATEST_STEP_LOOKUP, find_latest_step)
+    approval_module.approve_and_continue = approve_and_continue_with_latest_step
+    setattr(approval_module, INSTALLATION_FLAG, True)


### PR DESCRIPTION
Упорядочивает runtime-расширение approval-модуля для повторных попыток:

- логика поиска последней попытки вынесена в публичную функцию `find_latest_step`;
- служебные имена installation state оформлены константами;
- публичный lookup экспортируется в целевой модуль;
- повторная установка остаётся идемпотентной;
- добавлены регрессионные тесты публичного контракта и failed-resume маршрута.

Совместимость с текущим `approval_v2`, который пока разрешает `_find_step` через globals, сохранена.