### PR TITLE
refactor: remove private approval lookup patch

### DIFF
--- a/tests/test_approval_attempts_v2.py
+++ b/tests/test_approval_attempts_v2.py
@@ -52,6 +52,8 @@ def test_find_latest_step_prefers_most_recent_attempt():
 
 
 def test_installation_exposes_public_extension_state_and_is_idempotent():
+    native_lookup = approval_v2._find_step
+
     install_latest_step_lookup(approval_v2)
     installed_wrapper = approval_v2.approve_and_continue
 
@@ -60,6 +62,7 @@ def test_installation_exposes_public_extension_state_and_is_idempotent():
     assert getattr(approval_v2, INSTALLATION_FLAG) is True
     assert getattr(approval_v2, LATEST_STEP_LOOKUP) is find_latest_step
     assert approval_v2.approve_and_continue is installed_wrapper
+    assert approval_v2._find_step is native_lookup
 
 
 def test_approval_guard_uses_latest_attempt_for_retried_step():

--- a/velocity_claw/api/approval_attempts_v2.py
+++ b/velocity_claw/api/approval_attempts_v2.py
@@ -46,8 +46,6 @@ def install_latest_step_lookup(approval_module: Any) -> None:
             reason=reason,
         )
 
-    # approval_v2 currently resolves this helper from its module globals.
-    setattr(approval_module, "_find_step", find_latest_step)
     setattr(approval_module, LATEST_STEP_LOOKUP, find_latest_step)
     approval_module.approve_and_continue = approve_and_continue_with_latest_step
     setattr(approval_module, INSTALLATION_FLAG, True)


### PR DESCRIPTION
Убирает оставшуюся runtime-подмену защищённой функции `approval_v2._find_step` после нативного исправления в PR #152.

Изменения:
- `install_latest_step_lookup` больше не изменяет private lookup;
- сохраняется только публичный `find_latest_step` и wrapper для failed-resume;
- тест фиксирует, что нативный `_find_step` остаётся тем же объектом после установки расширения.