### PR TITLE
fix: preserve approval installation marker

### DIFF
--- a/tests/test_approval_attempts_v2.py
+++ b/tests/test_approval_attempts_v2.py
@@ -44,6 +44,10 @@ def run_with_attempts():
     }
 
 
+def test_installation_marker_preserves_legacy_module_attribute():
+    assert INSTALLATION_FLAG == "_latest_step_lookup_v2_installed"
+
+
 def test_find_latest_step_prefers_most_recent_attempt():
     latest = find_latest_step(run_with_attempts(), 2)
 

--- a/velocity_claw/api/approval_attempts_v2.py
+++ b/velocity_claw/api/approval_attempts_v2.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 
-INSTALLATION_FLAG = "latest_step_lookup_v2_installed"
+INSTALLATION_FLAG = "_latest_step_lookup_v2_installed"
 LATEST_STEP_LOOKUP = "find_latest_step"
 
 


### PR DESCRIPTION
Сохраняет совместимость runtime-расширения approval после предыдущего рефакторинга.

Изменения:
- публичная константа `INSTALLATION_FLAG` снова указывает на исторический атрибут `_latest_step_lookup_v2_installed`;
- предотвращается повторная установка wrapper при смешанном состоянии старого и нового кода;
- добавлен регрессионный тест, фиксирующий точное имя маркера.