### PR TITLE
fix: retain unhandled API tracebacks

### DIFF
--- a/tests/test_api_error_traceback.py
+++ b/tests/test_api_error_traceback.py
@@ -1,0 +1,32 @@
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from velocity_claw.api import errors
+
+
+def test_unhandled_exception_handler_logs_supplied_traceback() -> None:
+    request = SimpleNamespace(state=SimpleNamespace(request_id="request-123"))
+
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError as exc:
+        expected_traceback = exc.__traceback__
+        with patch.object(errors.LOGGER, "error") as log_error:
+            response = asyncio.run(errors.unhandled_exception_handler(request, exc))
+
+    log_error.assert_called_once_with(
+        "Unhandled API exception request_id=%s",
+        "request-123",
+        exc_info=(RuntimeError, exc, expected_traceback),
+    )
+    assert response.status_code == 500
+    assert json.loads(response.body) == {
+        "status": "error",
+        "error": {
+            "code": "internal_error",
+            "message": "Internal server error",
+        },
+        "request_id": "request-123",
+    }

--- a/velocity_claw/api/errors.py
+++ b/velocity_claw/api/errors.py
@@ -77,7 +77,11 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 
 async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     request_id = get_request_id(request)
-    LOGGER.exception("Unhandled API exception request_id=%s", request_id)
+    LOGGER.error(
+        "Unhandled API exception request_id=%s",
+        request_id,
+        exc_info=(type(exc), exc, exc.__traceback__),
+    )
     return JSONResponse(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         content=error_payload(


### PR DESCRIPTION
Исправляет журналирование необработанных API-исключений.

Раньше `LOGGER.exception(...)` вызывался уже внутри exception handler, где активного `except`-контекста может не быть, поэтому traceback мог теряться и заменяться на `NoneType: None`.

Теперь logger получает явный `exc_info=(type(exc), exc, exc.__traceback__)`.

Добавлен регрессионный тест, который проверяет:
- точный traceback передаётся в logger;
- наружу по-прежнему возвращается безопасный generic 500 payload без утечки текста исключения.