### PR TITLE
test: verify packaged CLI entrypoint

### DIFF
--- a/tests/test_package_cli_entrypoint.py
+++ b/tests/test_package_cli_entrypoint.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_python_m_velocity_claw_displays_help() -> None:
+    completed = subprocess.run(
+        [sys.executable, "-m", "velocity_claw", "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "Velocity Claw AI Agent" in completed.stdout
+
+
+def test_scripts_package_is_importable() -> None:
+    import scripts
+
+    assert scripts.__doc__


### PR DESCRIPTION
Шаг 1.2 — только проверка пакетного CLI.

Текущее состояние уже соответствует требованию:
- `velocity_claw/cli.py` существует;
- `velocity_claw/__main__.py` импортирует `main` из пакета;
- `scripts/__init__.py` существует;
- корневой `cli.py` оставлен только как backward-compatible wrapper.

Добавлены регрессионные тесты:
- `python -m velocity_claw --help` завершается с кодом 0;
- пакет `scripts` импортируется.