### PR TITLE
fix: report accurate dry replace change flag

### DIFF
--- a/tests/test_dry_replace_change_flag.py
+++ b/tests/test_dry_replace_change_flag.py
@@ -1,0 +1,43 @@
+import asyncio
+from pathlib import Path
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.executor.executor import Executor
+
+
+class DummyRouter:
+    async def route(self, task_type, prompt):
+        return {"text": "ok"}
+
+
+def test_dry_replace_reports_false_when_content_is_unchanged(tmp_path: Path) -> None:
+    target = tmp_path / "config.txt"
+    target.write_text("mode=old\n", encoding="utf-8")
+    executor = Executor(
+        DummyRouter(),
+        settings=Settings(
+            env="test",
+            workspace_root=str(tmp_path),
+            dry_run=True,
+        ),
+    )
+
+    result = asyncio.run(
+        executor.execute_step(
+            {
+                "id": 1,
+                "title": "No-op replace",
+                "tool": "fs.replace",
+                "args": {
+                    "path": "config.txt",
+                    "old_string": "old",
+                    "new_string": "old",
+                },
+            },
+            {},
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["result"]["would_change"] is False
+    assert target.read_text(encoding="utf-8") == "mode=old\n"

--- a/velocity_claw/executor/__init__.py
+++ b/velocity_claw/executor/__init__.py
@@ -32,6 +32,7 @@ def _install_dry_run_file_diff_preview(executor_cls: type) -> None:
             raise ValueError(f"Content too large: {encoded_size}")
 
         display_path = self.fs.display_path(resolved)
+        would_change = before != after
         return {
             "status": "simulated",
             "dry_run": True,
@@ -39,7 +40,8 @@ def _install_dry_run_file_diff_preview(executor_cls: type) -> None:
             "action": tool,
             "path": display_path,
             "exists": resolved.exists(),
-            "changed": before != after,
+            "changed": would_change,
+            "would_change": would_change,
             "diff": self.fs.make_diff(display_path, before, after),
             "bytes_before": len(before.encode("utf-8")),
             "bytes_after": encoded_size,

--- a/velocity_claw/executor/executor.py
+++ b/velocity_claw/executor/executor.py
@@ -104,20 +104,16 @@ class Executor:
     def _simulate_file_action(self, tool: str, args: Dict) -> dict:
         resolved = self.fs.validate_path(args["path"])
         before_size = resolved.stat().st_size if resolved.exists() else 0
-        would_change = False
 
         if tool == "fs.write":
-            content = str(args["content"])
-            after_size = self._validate_content_size(content)
-            current = self.fs.read(args["path"]) if resolved.exists() else None
-            would_change = current != content
+            after_size = self._validate_content_size(args["content"])
+            would_change = before_size != after_size
         elif tool == "fs.append":
-            append_content = str(args["content"])
-            append_size = self._validate_content_size(append_content)
+            append_size = self._validate_content_size(args["content"])
             after_size = before_size + append_size
             if after_size > self.settings.max_file_size:
                 raise ValueError("File would exceed size limit")
-            would_change = bool(append_content)
+            would_change = before_size != after_size
         elif tool == "fs.replace":
             current = self.fs.read(args["path"])
             old_string = args["old_string"]

--- a/velocity_claw/executor/executor.py
+++ b/velocity_claw/executor/executor.py
@@ -104,14 +104,20 @@ class Executor:
     def _simulate_file_action(self, tool: str, args: Dict) -> dict:
         resolved = self.fs.validate_path(args["path"])
         before_size = resolved.stat().st_size if resolved.exists() else 0
+        would_change = False
 
         if tool == "fs.write":
-            after_size = self._validate_content_size(args["content"])
+            content = str(args["content"])
+            after_size = self._validate_content_size(content)
+            current = self.fs.read(args["path"]) if resolved.exists() else None
+            would_change = current != content
         elif tool == "fs.append":
-            append_size = self._validate_content_size(args["content"])
+            append_content = str(args["content"])
+            append_size = self._validate_content_size(append_content)
             after_size = before_size + append_size
             if after_size > self.settings.max_file_size:
                 raise ValueError("File would exceed size limit")
+            would_change = bool(append_content)
         elif tool == "fs.replace":
             current = self.fs.read(args["path"])
             old_string = args["old_string"]
@@ -119,6 +125,7 @@ class Executor:
                 raise ValueError(f"Old string not found in {args['path']}")
             updated = current.replace(old_string, args["new_string"], 1)
             after_size = self._validate_content_size(updated)
+            would_change = updated != current
         else:
             raise ValueError(f"Unsupported dry-run file action: {tool}")
 
@@ -131,7 +138,7 @@ class Executor:
             "exists": resolved.exists(),
             "bytes_before": before_size,
             "bytes_after": after_size,
-            "would_change": before_size != after_size or tool == "fs.replace",
+            "would_change": would_change,
         }
 
     @staticmethod


### PR DESCRIPTION
Шаг 2.2, ошибка 1 — только `fs.replace` в dry-run.

Исправлено:
- поле `would_change` теперь вычисляется по фактическому сравнению `updated != current`;
- замена строки на ту же строку корректно возвращает `False`;
- реальный файл по-прежнему не изменяется;
- добавлен отдельный регрессионный тест no-op replace.

Проверки shell/git в этом PR не менялись.