### PR TITLE
fix: normalize symbol reference contexts

### DIFF
--- a/tests/test_symbol_reference_context_contract.py
+++ b/tests/test_symbol_reference_context_contract.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from velocity_claw.config.settings import Settings
+from velocity_claw.tools.code_nav import CodeNavigationTool
+
+
+def test_find_references_uses_reference_definition_and_import_contexts(tmp_path: Path) -> None:
+    (tmp_path / "sample.py").write_text(
+        "from module import target\n\n"
+        "def target():\n"
+        "    return 1\n\n"
+        "value = target()\n",
+        encoding="utf-8",
+    )
+    nav = CodeNavigationTool(Settings(workspace_root=str(tmp_path)))
+
+    contexts = {item["context"] for item in nav.find_references("target")}
+
+    assert contexts == {"import", "definition", "reference"}

--- a/velocity_claw/tools/__init__.py
+++ b/velocity_claw/tools/__init__.py
@@ -1,3 +1,5 @@
+import ast
+
 from velocity_claw.tools.fs import FileSystemTool
 from velocity_claw.tools.shell import ShellTool
 from velocity_claw.tools.git import GitTool
@@ -5,6 +7,42 @@ from velocity_claw.tools.http import HTTPTool
 from velocity_claw.tools.patch import PatchEngine
 from velocity_claw.tools.code_nav import CodeNavigationTool
 from velocity_claw.tools.test_runner import TestRunnerTool
+
+
+def _install_reference_context_contract(tool_cls: type) -> None:
+    if getattr(tool_cls, "_reference_context_contract_installed", False):
+        return
+
+    original = tool_cls._reference_entry
+
+    def _reference_entry(self, node, name, path, source_lines):
+        entry = original(self, node, name, path, source_lines)
+        if entry is not None:
+            if isinstance(node, ast.alias):
+                entry["context"] = "import"
+            else:
+                entry["context"] = "reference"
+            return entry
+
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)) and node.name == name:
+            line = node.lineno
+            source_line = source_lines[line - 1].strip() if 0 < line <= len(source_lines) else ""
+            return {
+                "path": path,
+                "name": name,
+                "line": line,
+                "column": node.col_offset,
+                "context": "definition",
+                "source_line": source_line,
+            }
+
+        return None
+
+    tool_cls._reference_entry = _reference_entry
+    tool_cls._reference_context_contract_installed = True
+
+
+_install_reference_context_contract(CodeNavigationTool)
 
 __all__ = [
     "FileSystemTool",


### PR DESCRIPTION
Шаг 2.4 — только контракт `find_references()`.

Исправлено:
- обычные использования символа возвращают `context="reference"`;
- импорт возвращает `context="import"`;
- определения функций, async-функций и классов возвращают `context="definition"`;
- удалены внутренние AST-значения `load`, `store`, `attribute`, `import_alias` из публичного результата.

Добавлен регрессионный тест на все три допустимых значения.