### PR TITLE
test: align build artifact action version

### DIFF
--- a/tests/test_build_artifact_workflow_v2.py
+++ b/tests/test_build_artifact_workflow_v2.py
@@ -26,6 +26,6 @@ def test_build_artifact_workflow_validates_before_building():
 
 def test_build_artifact_workflow_uploads_dist_artifacts():
     content = WORKFLOW.read_text(encoding="utf-8")
-    assert "actions/upload-artifact@v4" in content
+    assert "actions/upload-artifact@v7" in content
     assert "python-package-artifacts" in content
     assert "path: dist/*" in content


### PR DESCRIPTION
Шаг 2.6, ошибка 1 — только проверка build-artifacts workflow.

Проблема: workflow уже использует `actions/upload-artifact@v7`, а тест всё ещё ожидал `@v4`.

Исправлено:
- тест синхронизирован с фактической версией action;
- остальной контракт workflow не изменён: `python-package-artifacts`, `dist/*`, metadata validation и pytest остаются обязательными.