### PR TITLE
test: align dependency audit action version

### DIFF
--- a/tests/test_dependency_audit_workflow_v2.py
+++ b/tests/test_dependency_audit_workflow_v2.py
@@ -25,5 +25,5 @@ def test_dependency_audit_workflow_validates_package_metadata_and_runs_audit():
 def test_dependency_audit_workflow_uploads_report_artifact():
     content = WORKFLOW.read_text(encoding="utf-8")
     assert "dist/dependency-audit.json" in content
-    assert "actions/upload-artifact@v4" in content
+    assert "actions/upload-artifact@v7" in content
     assert "dependency-audit-report" in content


### PR DESCRIPTION
Шаг 2.6, следующая отдельная ошибка — только тест dependency-audit workflow.

Проблема: workflow уже использует `actions/upload-artifact@v7`, а тест ожидал `@v4`.

Исправлено одно устаревшее ожидание. Контракт отчёта `dist/dependency-audit.json` и artifact `dependency-audit-report` не менялся.