### PR TITLE
chore: remove unused logging import

### DIFF
--- a/tests/test_logging_state_contract.py
+++ b/tests/test_logging_state_contract.py
@@ -1,5 +1,3 @@
-import logging
-
 from velocity_claw.logs import logger as logger_module
 
 


### PR DESCRIPTION
Шаг 3.2 — удалён один неиспользуемый импорт из нового теста логирования. Поведение кода и тестовый контракт не менялись.