### PR TITLE
chore: mark unused signal frame argument

### DIFF
--- a/tests/test_runtime_signal_argument_contract.py
+++ b/tests/test_runtime_signal_argument_contract.py
@@ -1,0 +1,9 @@
+import inspect
+
+from velocity_claw.core.runtime import _handle_signal
+
+
+def test_signal_handler_marks_frame_argument_as_intentionally_unused() -> None:
+    parameters = list(inspect.signature(_handle_signal).parameters)
+
+    assert parameters == ["signum", "_frame"]

--- a/velocity_claw/core/runtime.py
+++ b/velocity_claw/core/runtime.py
@@ -23,7 +23,7 @@ class ShutdownState:
 shutdown_state = ShutdownState()
 
 
-def _handle_signal(signum: int, frame: Optional[FrameType]) -> None:
+def _handle_signal(signum: int, _frame: Optional[FrameType]) -> None:
     signal_name = signal.Signals(signum).name
     shutdown_state.request(signal_name)
     get_logger("velocity_claw.runtime").warning("Shutdown requested by %s", signal_name)


### PR DESCRIPTION
Шаг 3.3 — один статический дефект: неиспользуемый аргумент обработчика сигнала переименован в `_frame`. Добавлен тест на контракт сигнатуры. Поведение runtime не менялось.