### PR TITLE
chore: parameterize provider payload annotations

### DIFF
--- a/tests/test_model_provider_annotations.py
+++ b/tests/test_model_provider_annotations.py
@@ -1,0 +1,11 @@
+from typing import get_type_hints
+
+from velocity_claw.models.providers import ModelProvider
+
+
+def test_model_provider_payload_annotations_are_parameterized() -> None:
+    build_hints = get_type_hints(ModelProvider.build_payload)
+    parse_hints = get_type_hints(ModelProvider.parse_response)
+
+    assert build_hints["return"] == dict[str, object]
+    assert parse_hints["payload"] == dict[str, object]

--- a/velocity_claw/models/providers.py
+++ b/velocity_claw/models/providers.py
@@ -1,9 +1,6 @@
-from typing import Dict
-
-
 class ModelProvider:
-    def build_payload(self, prompt: str, task_type: str) -> Dict:
+    def build_payload(self, prompt: str, task_type: str) -> dict[str, object]:
         raise NotImplementedError()
 
-    def parse_response(self, payload: Dict) -> str:
+    def parse_response(self, payload: dict[str, object]) -> str:
         raise NotImplementedError()


### PR DESCRIPTION
Шаг 3.4 — один статический дефект: удалён legacy `typing.Dict` без параметров из базового интерфейса провайдера. Аннотации заменены на `dict[str, object]`, добавлен тест на сигнатуры. Поведение runtime не менялось.