### PR TITLE
chore: annotate Telegram handler registration

### DIFF
--- a/tests/test_telegram_bot_annotations.py
+++ b/tests/test_telegram_bot_annotations.py
@@ -7,3 +7,9 @@ def test_telegram_bot_initializer_declares_none_return() -> None:
     hints = get_type_hints(VelocityClawTelegramBot.__init__)
 
     assert hints["return"] is type(None)
+
+
+def test_handler_registration_declares_none_return() -> None:
+    hints = get_type_hints(VelocityClawTelegramBot._register_handlers)
+
+    assert hints["return"] is type(None)

--- a/velocity_claw/telegram_bot/bot.py
+++ b/velocity_claw/telegram_bot/bot.py
@@ -17,7 +17,7 @@ class VelocityClawTelegramBot:
         self.app = ApplicationBuilder().token(settings.telegram_token).build()
         self._register_handlers()
 
-    def _register_handlers(self):
+    def _register_handlers(self) -> None:
         from telegram.ext import CommandHandler, MessageHandler, filters
 
         self.app.add_handler(CommandHandler("start", self.start))


### PR DESCRIPTION
Шаг 3.6 — добавлена отсутствующая аннотация `-> None` для `_register_handlers`. Расширен существующий тест сигнатур. Поведение Telegram-интеграции не менялось.