### PR TITLE
chore: annotate Telegram polling entrypoint

### DIFF
--- a/tests/test_telegram_bot_annotations.py
+++ b/tests/test_telegram_bot_annotations.py
@@ -13,3 +13,9 @@ def test_handler_registration_declares_none_return() -> None:
     hints = get_type_hints(VelocityClawTelegramBot._register_handlers)
 
     assert hints["return"] is type(None)
+
+
+def test_polling_entrypoint_declares_none_return() -> None:
+    hints = get_type_hints(VelocityClawTelegramBot.run)
+
+    assert hints["return"] is type(None)

--- a/velocity_claw/telegram_bot/bot.py
+++ b/velocity_claw/telegram_bot/bot.py
@@ -120,5 +120,5 @@ class VelocityClawTelegramBot:
         elif getattr(update.message, "document", None):
             await self._reply(update, "Файл принят. Сейчас не поддерживается прямое выполнение вложений.")
 
-    def run(self):
+    def run(self) -> None:
         self.app.run_polling()


### PR DESCRIPTION
Шаг 3.7 — добавлена отсутствующая аннотация `-> None` для `VelocityClawTelegramBot.run`. Расширен существующий тест сигнатур. Поведение polling не менялось.