### PR TITLE
chore: parameterize Telegram report mapping

### DIFF
--- a/tests/test_telegram_bot_annotations.py
+++ b/tests/test_telegram_bot_annotations.py
@@ -19,3 +19,9 @@ def test_polling_entrypoint_declares_none_return() -> None:
     hints = get_type_hints(VelocityClawTelegramBot.run)
 
     assert hints["return"] is type(None)
+
+
+def test_report_mapping_annotation_is_parameterized() -> None:
+    hints = get_type_hints(VelocityClawTelegramBot._format_report)
+
+    assert hints["report"] == dict[str, object]

--- a/velocity_claw/telegram_bot/bot.py
+++ b/velocity_claw/telegram_bot/bot.py
@@ -37,7 +37,7 @@ class VelocityClawTelegramBot:
     async def _reply(self, update, text: str):
         return await update.message.reply_text(self._append_signature(text))
 
-    def _format_report(self, report: dict) -> str:
+    def _format_report(self, report: dict[str, object]) -> str:
         lines = [f"Задача: {report.get('task')}", f"Статус: {report.get('status')}"]
         summary = report.get("summary", "")
         if summary:


### PR DESCRIPTION
Шаг 3.8 — заменена непараметризованная аннотация `dict` у `_format_report` на `dict[str, object]`. Расширен существующий тест сигнатур. Поведение форматирования отчёта не менялось.