### PR TITLE
chore: annotate Telegram start handler

### DIFF
--- a/tests/test_telegram_bot_annotations.py
+++ b/tests/test_telegram_bot_annotations.py
@@ -31,3 +31,9 @@ def test_reply_helper_declares_return_type() -> None:
     hints = get_type_hints(VelocityClawTelegramBot._reply)
 
     assert hints["return"] is object
+
+
+def test_start_handler_declares_optional_reply_return() -> None:
+    hints = get_type_hints(VelocityClawTelegramBot.start)
+
+    assert hints["return"] == object | None

--- a/velocity_claw/telegram_bot/bot.py
+++ b/velocity_claw/telegram_bot/bot.py
@@ -52,7 +52,7 @@ class VelocityClawTelegramBot:
             return True
         return str(update.effective_chat.id) == str(self.settings.telegram_chat_id)
 
-    async def start(self, update, _context):
+    async def start(self, update, _context) -> object | None:
         if not await self._check_access(update):
             return await self._reply(update, "Access denied.")
         await self._reply(update, "Velocity Claw active. Отправь /help для списка команд.")


### PR DESCRIPTION
Шаг 3.10 — добавлена отсутствующая аннотация возвращаемого значения для `start`: `object | None`. Расширен существующий тест сигнатур. Поведение обработчика не менялось.