### PR TITLE
chore: annotate Telegram help handler

### DIFF
--- a/tests/test_telegram_bot_annotations.py
+++ b/tests/test_telegram_bot_annotations.py
@@ -37,3 +37,9 @@ def test_start_handler_declares_optional_reply_return() -> None:
     hints = get_type_hints(VelocityClawTelegramBot.start)
 
     assert hints["return"] == object | None
+
+
+def test_help_handler_declares_optional_reply_return() -> None:
+    hints = get_type_hints(VelocityClawTelegramBot.help)
+
+    assert hints["return"] == object | None

--- a/velocity_claw/telegram_bot/bot.py
+++ b/velocity_claw/telegram_bot/bot.py
@@ -57,7 +57,7 @@ class VelocityClawTelegramBot:
             return await self._reply(update, "Access denied.")
         await self._reply(update, "Velocity Claw active. Отправь /help для списка команд.")
 
-    async def help(self, update, _context):
+    async def help(self, update, _context) -> object | None:
         if not await self._check_access(update):
             return await self._reply(update, "Access denied.")
         await self._reply(update, "/start\n/help\n/status\n/model\n/reset\n/task <описание>\n/plan\n/logs\n/stop")


### PR DESCRIPTION
Шаг 3.11 — добавлена отсутствующая аннотация возвращаемого значения для `help`: `object | None`. Расширен существующий тест сигнатур. Поведение обработчика не менялось.