### PR TITLE
chore: annotate Telegram model handler

### DIFF
--- a/tests/test_telegram_bot_annotations.py
+++ b/tests/test_telegram_bot_annotations.py
@@ -49,3 +49,9 @@ def test_status_handler_declares_optional_reply_return() -> None:
     hints = get_type_hints(VelocityClawTelegramBot.status)
 
     assert hints["return"] == object | None
+
+
+def test_model_handler_declares_optional_reply_return() -> None:
+    hints = get_type_hints(VelocityClawTelegramBot.model)
+
+    assert hints["return"] == object | None

--- a/velocity_claw/telegram_bot/bot.py
+++ b/velocity_claw/telegram_bot/bot.py
@@ -67,7 +67,7 @@ class VelocityClawTelegramBot:
             return await self._reply(update, "Access denied.")
         await self._reply(update, str(self.agent.get_status()))
 
-    async def model(self, update, _context):
+    async def model(self, update, _context) -> object | None:
         if not await self._check_access(update):
             return await self._reply(update, "Access denied.")
         await self._reply(update, f"Active model route: {self.agent.router.choose_provider('analysis')}")


### PR DESCRIPTION
Шаг 3.13 — добавлена отсутствующая аннотация возвращаемого значения для `model`: `object | None`. Расширен существующий тест сигнатур. Поведение обработчика не менялось.