### PR TITLE
chore: annotate Telegram reset handler

### DIFF
--- a/tests/test_telegram_bot_annotations.py
+++ b/tests/test_telegram_bot_annotations.py
@@ -55,3 +55,9 @@ def test_model_handler_declares_optional_reply_return() -> None:
     hints = get_type_hints(VelocityClawTelegramBot.model)
 
     assert hints["return"] == object | None
+
+
+def test_reset_handler_declares_optional_reply_return() -> None:
+    hints = get_type_hints(VelocityClawTelegramBot.reset)
+
+    assert hints["return"] == object | None

--- a/velocity_claw/telegram_bot/bot.py
+++ b/velocity_claw/telegram_bot/bot.py
@@ -72,7 +72,7 @@ class VelocityClawTelegramBot:
             return await self._reply(update, "Access denied.")
         await self._reply(update, f"Active model route: {self.agent.router.choose_provider('analysis')}")
 
-    async def reset(self, update, _context):
+    async def reset(self, update, _context) -> object | None:
         if not await self._check_access(update):
             return await self._reply(update, "Access denied.")
         await self._reply(update, str(self.agent.reset_context()))


### PR DESCRIPTION
Шаг 3.14 — добавлена отсутствующая аннотация возвращаемого значения для `reset`: `object | None`. Расширен существующий тест сигнатур. Поведение обработчика не менялось.