### PR TITLE
chore: annotate Telegram plan handler

### DIFF
--- a/tests/test_telegram_bot_annotations.py
+++ b/tests/test_telegram_bot_annotations.py
@@ -61,3 +61,9 @@ def test_reset_handler_declares_optional_reply_return() -> None:
     hints = get_type_hints(VelocityClawTelegramBot.reset)
 
     assert hints["return"] == object | None
+
+
+def test_plan_handler_declares_optional_reply_return() -> None:
+    hints = get_type_hints(VelocityClawTelegramBot.plan)
+
+    assert hints["return"] == object | None

--- a/velocity_claw/telegram_bot/bot.py
+++ b/velocity_claw/telegram_bot/bot.py
@@ -77,7 +77,7 @@ class VelocityClawTelegramBot:
             return await self._reply(update, "Access denied.")
         await self._reply(update, str(self.agent.reset_context()))
 
-    async def plan(self, update, context):
+    async def plan(self, update, context) -> object | None:
         if not await self._check_access(update):
             return await self._reply(update, "Access denied.")
         task = " ".join(context.args) if getattr(context, "args", None) else None


### PR DESCRIPTION
Шаг 3.15 — добавлена отсутствующая аннотация возвращаемого значения для `plan`: `object | None`. Расширен существующий тест сигнатур. Поведение обработчика не менялось.