### PR TITLE
chore: annotate Telegram logs handler

### DIFF
--- a/tests/test_telegram_bot_annotations.py
+++ b/tests/test_telegram_bot_annotations.py
@@ -67,3 +67,9 @@ def test_plan_handler_declares_optional_reply_return() -> None:
     hints = get_type_hints(VelocityClawTelegramBot.plan)
 
     assert hints["return"] == object | None
+
+
+def test_logs_handler_declares_optional_reply_return() -> None:
+    hints = get_type_hints(VelocityClawTelegramBot.logs)
+
+    assert hints["return"] == object | None

--- a/velocity_claw/telegram_bot/bot.py
+++ b/velocity_claw/telegram_bot/bot.py
@@ -86,7 +86,7 @@ class VelocityClawTelegramBot:
         plan = await self.agent.planner.create_plan(task)
         await self._reply(update, f"Plan:\n{plan}")
 
-    async def logs(self, update, _context):
+    async def logs(self, update, _context) -> object | None:
         if not await self._check_access(update):
             return await self._reply(update, "Access denied.")
         await self._reply(update, "Logs available in velocity_claw/logs/velocity_claw.log")


### PR DESCRIPTION
Шаг 3.16 — добавлена отсутствующая аннотация возвращаемого значения для `logs`: `object | None`. Расширен существующий тест сигнатур. Поведение обработчика не менялось.