### PR TITLE
chore: annotate Telegram task handler

### DIFF
--- a/tests/test_telegram_bot_annotations.py
+++ b/tests/test_telegram_bot_annotations.py
@@ -73,3 +73,9 @@ def test_logs_handler_declares_optional_reply_return() -> None:
     hints = get_type_hints(VelocityClawTelegramBot.logs)
 
     assert hints["return"] == object | None
+
+
+def test_command_handler_declares_optional_reply_return() -> None:
+    hints = get_type_hints(VelocityClawTelegramBot.task)
+
+    assert hints["return"] == object | None

--- a/velocity_claw/telegram_bot/bot.py
+++ b/velocity_claw/telegram_bot/bot.py
@@ -97,7 +97,7 @@ class VelocityClawTelegramBot:
         await self._reply(update, "Velocity Claw остановлен вручную.")
         await self.app.stop()
 
-    async def task(self, update, context):
+    async def task(self, update, context) -> object | None:
         if not await self._check_access(update):
             return await self._reply(update, "Access denied.")
         task = " ".join(context.args) if getattr(context, "args", None) else None


### PR DESCRIPTION
Шаг 3.17 — добавлена отсутствующая аннотация возвращаемого значения для `task`: `object | None`. Расширен тест сигнатур. Поведение обработчика не менялось.