### PR TITLE
chore: annotate Telegram message handler

### DIFF
--- a/tests/test_telegram_bot_annotations.py
+++ b/tests/test_telegram_bot_annotations.py
@@ -79,3 +79,9 @@ def test_command_handler_declares_optional_reply_return() -> None:
     hints = get_type_hints(VelocityClawTelegramBot.task)
 
     assert hints["return"] == object | None
+
+
+def test_message_handler_declares_none_return() -> None:
+    hints = get_type_hints(VelocityClawTelegramBot.receive_message)
+
+    assert hints["return"] is type(None)

--- a/velocity_claw/telegram_bot/bot.py
+++ b/velocity_claw/telegram_bot/bot.py
@@ -109,7 +109,7 @@ class VelocityClawTelegramBot:
         report = await self.agent.run_task(task)
         await self._reply(update, self._format_report(report))
 
-    async def receive_message(self, update, _context):
+    async def receive_message(self, update, _context) -> None:
         if not await self._check_access(update):
             return
         text = update.message.text or ""


### PR DESCRIPTION
Шаг 3.18 — добавлена отсутствующая аннотация возвращаемого значения для `receive_message`: `None`. Расширен тест сигнатур. Поведение обработчика не менялось.