### PR TITLE
chore: annotate Telegram stop handler

### DIFF
--- a/tests/test_telegram_bot_annotations.py
+++ b/tests/test_telegram_bot_annotations.py
@@ -85,3 +85,9 @@ def test_message_handler_declares_none_return() -> None:
     hints = get_type_hints(VelocityClawTelegramBot.receive_message)
 
     assert hints["return"] is type(None)
+
+
+def test_shutdown_handler_declares_optional_reply_return() -> None:
+    hints = get_type_hints(VelocityClawTelegramBot.stop)
+
+    assert hints["return"] == object | None

--- a/velocity_claw/telegram_bot/bot.py
+++ b/velocity_claw/telegram_bot/bot.py
@@ -91,7 +91,7 @@ class VelocityClawTelegramBot:
             return await self._reply(update, "Access denied.")
         await self._reply(update, "Logs available in velocity_claw/logs/velocity_claw.log")
 
-    async def stop(self, update, _context):
+    async def stop(self, update, _context) -> object | None:
         if not await self._check_access(update):
             return await self._reply(update, "Access denied.")
         await self._reply(update, "Velocity Claw остановлен вручную.")


### PR DESCRIPTION
Шаг 3.19 — добавлена отсутствующая аннотация возвращаемого значения для `stop`: `object | None`. Расширен тест сигнатур. Поведение обработчика не менялось.