### PR TITLE
fix: preserve zero logging backup count

### DIFF
--- a/tests/test_logging_backup_count.py
+++ b/tests/test_logging_backup_count.py
@@ -1,0 +1,22 @@
+from logging.handlers import RotatingFileHandler
+
+from velocity_claw.logs.logger import configure_logging, reset_logging_for_tests
+
+
+def test_configure_logging_preserves_zero_backup_count(tmp_path) -> None:
+    reset_logging_for_tests()
+    try:
+        root = configure_logging(
+            enable_file=True,
+            log_dir=tmp_path,
+            backup_count=0,
+        )
+
+        rotating_handlers = [
+            handler for handler in root.handlers if isinstance(handler, RotatingFileHandler)
+        ]
+
+        assert rotating_handlers
+        assert all(handler.backupCount == 0 for handler in rotating_handlers)
+    finally:
+        reset_logging_for_tests()

--- a/velocity_claw/logs/logger.py
+++ b/velocity_claw/logs/logger.py
@@ -69,7 +69,7 @@ def configure_logging(
         resolved_log_dir = Path(log_dir or os.getenv("LOG_DIR", DEFAULT_LOG_DIR))
         resolved_log_dir.mkdir(parents=True, exist_ok=True)
         resolved_max_bytes = max_bytes or _resolve_int_env("LOG_FILE_MAX_BYTES", 10 * 1024 * 1024)
-        resolved_backup_count = backup_count or _resolve_int_env("LOG_FILE_BACKUP_COUNT", 5)
+        resolved_backup_count = backup_count if backup_count is not None else _resolve_int_env("LOG_FILE_BACKUP_COUNT", 5)
 
         app_handler = RotatingFileHandler(
             resolved_log_dir / DEFAULT_LOG_FILE,


### PR DESCRIPTION
Шаг 3.21 — явное значение `backup_count=0` больше не подменяется значением по умолчанию. Добавлен тест для обоих файловых обработчиков.