### PR TITLE
fix: preserve zero log rotation size

### DIFF
--- a/tests/test_logging_zero_rotation.py
+++ b/tests/test_logging_zero_rotation.py
@@ -1,0 +1,21 @@
+import logging
+
+from velocity_claw.logs import logger as logger_module
+
+
+def test_zero_max_bytes_disables_rotation(monkeypatch, tmp_path) -> None:
+    recorded_max_bytes: list[int] = []
+
+    class RecordingHandler(logging.Handler):
+        def __init__(self, _filename, *, maxBytes: int, backupCount: int, encoding: str) -> None:
+            super().__init__()
+            recorded_max_bytes.append(maxBytes)
+
+    logger_module.reset_logging_for_tests()
+    monkeypatch.setattr(logger_module, "RotatingFileHandler", RecordingHandler)
+
+    try:
+        logger_module.configure_logging(enable_file=True, log_dir=tmp_path, max_bytes=0)
+        assert recorded_max_bytes == [0, 0]
+    finally:
+        logger_module.reset_logging_for_tests()

--- a/velocity_claw/logs/logger.py
+++ b/velocity_claw/logs/logger.py
@@ -68,7 +68,7 @@ def configure_logging(
     if file_logging_enabled:
         resolved_log_dir = Path(log_dir or os.getenv("LOG_DIR", DEFAULT_LOG_DIR))
         resolved_log_dir.mkdir(parents=True, exist_ok=True)
-        resolved_max_bytes = max_bytes or _resolve_int_env("LOG_FILE_MAX_BYTES", 10 * 1024 * 1024)
+        resolved_max_bytes = max_bytes if max_bytes is not None else _resolve_int_env("LOG_FILE_MAX_BYTES", 10 * 1024 * 1024)
         resolved_backup_count = backup_count if backup_count is not None else _resolve_int_env("LOG_FILE_BACKUP_COUNT", 5)
 
         app_handler = RotatingFileHandler(


### PR DESCRIPTION
Шаг 3.21 — явное `max_bytes=0` больше не заменяется значением по умолчанию. Добавлен функциональный тест, проверяющий передачу нулевого лимита обоим файловым обработчикам.