### PR TITLE
fix: preserve explicit empty log directory

### DIFF
--- a/tests/test_logging_zero_rotation.py
+++ b/tests/test_logging_zero_rotation.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 
 from velocity_claw.logs import logger as logger_module
 
@@ -17,5 +18,25 @@ def test_zero_max_bytes_disables_rotation(monkeypatch, tmp_path) -> None:
     try:
         logger_module.configure_logging(enable_file=True, log_dir=tmp_path, max_bytes=0)
         assert recorded_max_bytes == [0, 0]
+    finally:
+        logger_module.reset_logging_for_tests()
+
+
+def test_empty_log_dir_targets_current_directory(monkeypatch, tmp_path) -> None:
+    recorded_paths: list[Path] = []
+
+    class RecordingHandler(logging.Handler):
+        def __init__(self, filename, *, maxBytes: int, backupCount: int, encoding: str) -> None:
+            super().__init__()
+            recorded_paths.append(Path(filename))
+
+    logger_module.reset_logging_for_tests()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("LOG_DIR", "ignored-log-directory")
+    monkeypatch.setattr(logger_module, "RotatingFileHandler", RecordingHandler)
+
+    try:
+        logger_module.configure_logging(enable_file=True, log_dir="")
+        assert recorded_paths == [Path("velocity_claw.log"), Path("velocity_claw_errors.log")]
     finally:
         logger_module.reset_logging_for_tests()

--- a/velocity_claw/logs/logger.py
+++ b/velocity_claw/logs/logger.py
@@ -66,7 +66,7 @@ def configure_logging(
 
     file_logging_enabled = enable_file if enable_file is not None else os.getenv("LOG_TO_FILE", "true").lower() not in {"0", "false", "no", "off"}
     if file_logging_enabled:
-        resolved_log_dir = Path(log_dir or os.getenv("LOG_DIR", DEFAULT_LOG_DIR))
+        resolved_log_dir = Path(log_dir if log_dir is not None else os.getenv("LOG_DIR", DEFAULT_LOG_DIR))
         resolved_log_dir.mkdir(parents=True, exist_ok=True)
         resolved_max_bytes = max_bytes if max_bytes is not None else _resolve_int_env("LOG_FILE_MAX_BYTES", 10 * 1024 * 1024)
         resolved_backup_count = backup_count if backup_count is not None else _resolve_int_env("LOG_FILE_BACKUP_COUNT", 5)


### PR DESCRIPTION
Шаг 3.22 — явный `log_dir=""` теперь означает текущий каталог и не подменяется переменной окружения или каталогом по умолчанию. Добавлен тест для обоих файловых обработчиков.