### PR TITLE
fix: preserve explicit empty log level

### DIFF
--- a/tests/test_logging_zero_rotation.py
+++ b/tests/test_logging_zero_rotation.py
@@ -40,3 +40,9 @@ def test_empty_log_dir_targets_current_directory(monkeypatch, tmp_path) -> None:
         assert recorded_paths == [Path("velocity_claw.log"), Path("velocity_claw_errors.log")]
     finally:
         logger_module.reset_logging_for_tests()
+
+
+def test_empty_explicit_level_does_not_use_environment(monkeypatch) -> None:
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+
+    assert logger_module._resolve_level("") == logging.INFO

--- a/velocity_claw/logs/logger.py
+++ b/velocity_claw/logs/logger.py
@@ -21,7 +21,7 @@ DEFAULT_ERROR_LOG_FILE = "velocity_claw_errors.log"
 
 
 def _resolve_level(level_name: str | None = None) -> int:
-    value = (level_name or os.getenv("LOG_LEVEL", "INFO")).upper()
+    value = (level_name if level_name is not None else os.getenv("LOG_LEVEL", "INFO")).upper()
     level = logging.getLevelName(value)
     return level if isinstance(level, int) else logging.INFO
 


### PR DESCRIPTION
Шаг 3.23 — явный `level_name=""` больше не подменяется значением `LOG_LEVEL`. Некорректное пустое значение корректно откатывается к `INFO`. Добавлен тест с конфликтующей переменной окружения.