### PR TITLE
fix: trim file logging toggle

### DIFF
--- a/tests/test_logging_zero_rotation.py
+++ b/tests/test_logging_zero_rotation.py
@@ -46,3 +46,14 @@ def test_empty_explicit_level_does_not_use_environment(monkeypatch) -> None:
     monkeypatch.setenv("LOG_LEVEL", "DEBUG")
 
     assert logger_module._resolve_level("") == logging.INFO
+
+
+def test_file_logging_toggle_ignores_surrounding_whitespace(monkeypatch) -> None:
+    logger_module.reset_logging_for_tests()
+    monkeypatch.setenv("LOG_TO_FILE", " false ")
+
+    try:
+        root = logger_module.configure_logging()
+        assert not any(isinstance(handler, logger_module.RotatingFileHandler) for handler in root.handlers)
+    finally:
+        logger_module.reset_logging_for_tests()

--- a/velocity_claw/logs/logger.py
+++ b/velocity_claw/logs/logger.py
@@ -64,7 +64,7 @@ def configure_logging(
     stream_handler.setFormatter(formatter)
     root.addHandler(stream_handler)
 
-    file_logging_enabled = enable_file if enable_file is not None else os.getenv("LOG_TO_FILE", "true").lower() not in {"0", "false", "no", "off"}
+    file_logging_enabled = enable_file if enable_file is not None else os.getenv("LOG_TO_FILE", "true").strip().lower() not in {"0", "false", "no", "off"}
     if file_logging_enabled:
         resolved_log_dir = Path(log_dir if log_dir is not None else os.getenv("LOG_DIR", DEFAULT_LOG_DIR))
         resolved_log_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Шаг 3.24 — значение `LOG_TO_FILE` теперь очищается от пробелов перед разбором. Строки вроде ` false ` корректно отключают файловое логирование. Добавлен функциональный тест.