### PR TITLE
fix: trim log level values

### DIFF
--- a/tests/test_logging_zero_rotation.py
+++ b/tests/test_logging_zero_rotation.py
@@ -57,3 +57,9 @@ def test_file_logging_toggle_ignores_surrounding_whitespace(monkeypatch) -> None
         assert not any(isinstance(handler, logger_module.RotatingFileHandler) for handler in root.handlers)
     finally:
         logger_module.reset_logging_for_tests()
+
+
+def test_log_level_ignores_surrounding_whitespace(monkeypatch) -> None:
+    monkeypatch.setenv("LOG_LEVEL", " debug ")
+
+    assert logger_module._resolve_level() == logging.DEBUG

--- a/velocity_claw/logs/logger.py
+++ b/velocity_claw/logs/logger.py
@@ -21,7 +21,7 @@ DEFAULT_ERROR_LOG_FILE = "velocity_claw_errors.log"
 
 
 def _resolve_level(level_name: str | None = None) -> int:
-    value = (level_name if level_name is not None else os.getenv("LOG_LEVEL", "INFO")).upper()
+    value = (level_name if level_name is not None else os.getenv("LOG_LEVEL", "INFO")).strip().upper()
     level = logging.getLevelName(value)
     return level if isinstance(level, int) else logging.INFO
 


### PR DESCRIPTION
Шаг 3.25 — `LOG_LEVEL` и явный `level_name` теперь очищаются от пробелов перед нормализацией. Значения вроде ` debug ` корректно распознаются как `DEBUG`. Добавлен тест.