### PR TITLE
fix: reject negative log rotation settings

### DIFF
--- a/tests/test_logging_zero_rotation.py
+++ b/tests/test_logging_zero_rotation.py
@@ -63,3 +63,9 @@ def test_log_level_ignores_surrounding_whitespace(monkeypatch) -> None:
     monkeypatch.setenv("LOG_LEVEL", " debug ")
 
     assert logger_module._resolve_level() == logging.DEBUG
+
+
+def test_negative_rotation_setting_uses_default(monkeypatch) -> None:
+    monkeypatch.setenv("LOG_FILE_BACKUP_COUNT", "-1")
+
+    assert logger_module._resolve_int_env("LOG_FILE_BACKUP_COUNT", 5) == 5

--- a/velocity_claw/logs/logger.py
+++ b/velocity_claw/logs/logger.py
@@ -31,9 +31,10 @@ def _resolve_int_env(name: str, default: int) -> int:
     if raw is None:
         return default
     try:
-        return int(raw)
+        value = int(raw)
     except ValueError:
         return default
+    return value if value >= 0 else default
 
 
 def _build_formatter() -> logging.Formatter:


### PR DESCRIPTION
Шаг 3.26 — отрицательные значения параметров ротации логов из окружения больше не передаются в `RotatingFileHandler`; вместо них используется безопасное значение по умолчанию. Добавлен тест для отрицательного `LOG_FILE_BACKUP_COUNT`.