### PR TITLE
fix: reject explicit negative log settings

### DIFF
--- a/tests/test_logging_zero_rotation.py
+++ b/tests/test_logging_zero_rotation.py
@@ -1,6 +1,8 @@
 import logging
 from pathlib import Path
 
+import pytest
+
 from velocity_claw.logs import logger as logger_module
 
 
@@ -69,3 +71,9 @@ def test_negative_rotation_setting_uses_default(monkeypatch) -> None:
     monkeypatch.setenv("LOG_FILE_BACKUP_COUNT", "-1")
 
     assert logger_module._resolve_int_env("LOG_FILE_BACKUP_COUNT", 5) == 5
+
+
+@pytest.mark.parametrize("setting", [{"max_bytes": -1}, {"backup_count": -1}])
+def test_explicit_negative_rotation_setting_is_rejected(setting) -> None:
+    with pytest.raises(ValueError):
+        logger_module.configure_logging(**setting)

--- a/velocity_claw/logs/logger.py
+++ b/velocity_claw/logs/logger.py
@@ -50,6 +50,11 @@ def configure_logging(
     backup_count: int | None = None,
 ) -> logging.Logger:
     """Configure root logging once and return the root logger."""
+    if max_bytes is not None and max_bytes < 0:
+        raise ValueError("max_bytes must be non-negative")
+    if backup_count is not None and backup_count < 0:
+        raise ValueError("backup_count must be non-negative")
+
     root = logging.getLogger()
     level = _resolve_level(level_name)
     root.setLevel(level)


### PR DESCRIPTION
Шаг 3.27 — явные отрицательные `max_bytes` и `backup_count` теперь отклоняются до настройки обработчиков, чтобы не создавать частично настроенное логирование. Добавлен параметризованный тест.