### PR TITLE
fix: preserve error-only handler level

### DIFF
--- a/tests/test_logging_zero_rotation.py
+++ b/tests/test_logging_zero_rotation.py
@@ -77,3 +77,21 @@ def test_negative_rotation_setting_uses_default(monkeypatch) -> None:
 def test_explicit_negative_rotation_setting_is_rejected(setting) -> None:
     with pytest.raises(ValueError):
         logger_module.configure_logging(**setting)
+
+
+def test_reconfigure_preserves_error_only_handler_level(tmp_path) -> None:
+    logger_module.reset_logging_for_tests()
+
+    try:
+        root = logger_module.configure_logging(enable_file=True, log_dir=tmp_path, level_name="INFO")
+        logger_module.configure_logging(level_name="DEBUG")
+        error_handlers = [
+            handler
+            for handler in root.handlers
+            if getattr(handler, logger_module._ERROR_HANDLER_ATTR, False)
+        ]
+
+        assert len(error_handlers) == 1
+        assert error_handlers[0].level == logging.ERROR
+    finally:
+        logger_module.reset_logging_for_tests()

--- a/velocity_claw/logs/logger.py
+++ b/velocity_claw/logs/logger.py
@@ -13,6 +13,7 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 _LOGGING_STATE_ATTR = "_velocity_claw_configured"
+_ERROR_HANDLER_ATTR = "_velocity_claw_error_only"
 _LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s:%(lineno)d %(message)s"
 _DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
 DEFAULT_LOG_DIR = "logs"
@@ -61,7 +62,7 @@ def configure_logging(
 
     if getattr(root, _LOGGING_STATE_ATTR, False):
         for handler in root.handlers:
-            handler.setLevel(level)
+            handler.setLevel(logging.ERROR if getattr(handler, _ERROR_HANDLER_ATTR, False) else level)
         return root
 
     formatter = _build_formatter()
@@ -93,6 +94,7 @@ def configure_logging(
             backupCount=resolved_backup_count,
             encoding="utf-8",
         )
+        setattr(error_handler, _ERROR_HANDLER_ATTR, True)
         error_handler.setLevel(logging.ERROR)
         error_handler.setFormatter(formatter)
         root.addHandler(error_handler)


### PR DESCRIPTION
Шаг 3.28 — повторная настройка логирования больше не понижает уровень специализированного error-файла до общего уровня. Error-only обработчик помечается явно и сохраняет `ERROR`. Добавлен регрессионный тест.